### PR TITLE
fix(types): strict DOM types

### DIFF
--- a/packages/core/src/middleware/autoPlacement.ts
+++ b/packages/core/src/middleware/autoPlacement.ts
@@ -33,14 +33,16 @@ export function getPlacementList(
   });
 }
 
-export type Options = DetectOverflowOptions & {
+export type Options = {
   alignment: Alignment | null;
   crossAxis: boolean;
   allowedPlacements: Array<Placement>;
   autoAlignment: boolean;
 };
 
-export const autoPlacement = (options: Partial<Options> = {}): Middleware => ({
+export const autoPlacement = (
+  options: Partial<Options & DetectOverflowOptions> = {}
+): Middleware => ({
   name: 'autoPlacement',
   async fn(middlewareArguments: MiddlewareArguments) {
     const {x, y, rects, middlewareData, placement} = middlewareArguments;

--- a/packages/core/src/middleware/flip.ts
+++ b/packages/core/src/middleware/flip.ts
@@ -8,7 +8,7 @@ import {
 import {getAlignmentSides} from '../utils/getAlignmentSides';
 import {getExpandedPlacements} from '../utils/getExpandedPlacements';
 
-export type Options = DetectOverflowOptions & {
+export type Options = {
   mainAxis: boolean;
   crossAxis: boolean;
   fallbackPlacements: Array<Placement>;
@@ -16,7 +16,9 @@ export type Options = DetectOverflowOptions & {
   flipAlignment: boolean;
 };
 
-export const flip = (options: Partial<Options> = {}): Middleware => ({
+export const flip = (
+  options: Partial<Options & DetectOverflowOptions> = {}
+): Middleware => ({
   name: 'flip',
   async fn(middlewareArguments: MiddlewareArguments) {
     const {placement, middlewareData, rects, initialPlacement} =

--- a/packages/core/src/middleware/shift.ts
+++ b/packages/core/src/middleware/shift.ts
@@ -14,13 +14,15 @@ import {
   Options as DetectOverflowOptions,
 } from '../detectOverflow';
 
-type Options = DetectOverflowOptions & {
+export type Options = {
   mainAxis: boolean;
   crossAxis: boolean;
   limiter: (middlewareArguments: MiddlewareArguments) => Coords;
 };
 
-export const shift = (options: Partial<Options> = {}): Middleware => ({
+export const shift = (
+  options: Partial<Options & DetectOverflowOptions> = {}
+): Middleware => ({
   name: 'shift',
   async fn(middlewareArguments: MiddlewareArguments) {
     const {x, y, placement} = middlewareArguments;

--- a/packages/core/src/middleware/size.ts
+++ b/packages/core/src/middleware/size.ts
@@ -11,11 +11,13 @@ import {
 import {getBasePlacement} from '../utils/getBasePlacement';
 import {getAlignment} from '../utils/getAlignment';
 
-export type Options = DetectOverflowOptions & {
+export type Options = {
   apply(args: Dimensions & ElementRects): void;
 };
 
-export const size = (options: Partial<Options> = {}): Middleware => ({
+export const size = (
+  options: Partial<Options & DetectOverflowOptions> = {}
+): Middleware => ({
   name: 'size',
   async fn(middlewareArguments: MiddlewareArguments) {
     const {placement, rects, middlewareData} = middlewareArguments;

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -10,7 +10,7 @@ export const computePosition = (
     | Element
     | {getBoundingClientRect(): ClientRectObject; contextElement?: Element},
   floating: HTMLElement,
-  options: Partial<ComputePositionConfig>
+  options?: Partial<ComputePositionConfig>
 ) => computePositionCore(reference, floating, {platform, ...options});
 
 export {

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -1,12 +1,14 @@
 import {
+  ClientRectObject,
   computePosition as computePositionCore,
   ComputePositionConfig,
-  VirtualElement,
 } from '@floating-ui/core';
 import {platform} from './platform';
 
 export const computePosition = (
-  reference: Element | VirtualElement,
+  reference:
+    | Element
+    | {getBoundingClientRect(): ClientRectObject; contextElement?: Element},
   floating: HTMLElement,
   options: Partial<ComputePositionConfig>
 ) => computePositionCore(reference, floating, {platform, ...options});

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -45,7 +45,7 @@ declare const arrow: (options: {
 declare const detectOverflow: (
   middlewareArguments: MiddlewareArguments,
   options?: Partial<DOMDetectOverflowOptions>
-) => SideObject;
+) => Promise<SideObject>;
 
 export {autoPlacement, shift, arrow, size, flip, detectOverflow};
 export {hide, offset, limitShift} from '@floating-ui/core';

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -22,24 +22,24 @@ export type DOMDetectOverflowOptions = Omit<
 };
 
 declare const autoPlacement: (
-  options?: AutoPlacementOptions & DOMDetectOverflowOptions
+  options?: Partial<AutoPlacementOptions & DOMDetectOverflowOptions>
 ) => Middleware;
 
 declare const shift: (
-  options?: ShiftOptions & DOMDetectOverflowOptions
+  options?: Partial<ShiftOptions & DOMDetectOverflowOptions>
 ) => Middleware;
 
 declare const flip: (
-  options?: FlipOptions & DOMDetectOverflowOptions
+  options?: Partial<FlipOptions & DOMDetectOverflowOptions>
 ) => Middleware;
 
 declare const size: (
-  options?: SizeOptions & DOMDetectOverflowOptions
+  options?: Partial<SizeOptions & DOMDetectOverflowOptions>
 ) => Middleware;
 
 declare const arrow: (options: {
   element: HTMLElement;
-  padding: number | SideObject;
+  padding?: number | SideObject;
 }) => Middleware;
 
 declare const detectOverflow: (

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -1,19 +1,53 @@
+import type {
+  Middleware,
+  MiddlewareArguments,
+  SideObject,
+} from '@floating-ui/core';
+import type {Options as DetectOverflowOptions} from '@floating-ui/core/src/detectOverflow';
+import type {Options as AutoPlacementOptions} from '@floating-ui/core/src/middleware/autoPlacement';
+import type {Options as SizeOptions} from '@floating-ui/core/src/middleware/size';
+import type {Options as FlipOptions} from '@floating-ui/core/src/middleware/flip';
+import type {Options as ShiftOptions} from '@floating-ui/core/src/middleware/shift';
+
 export type NodeScroll = {
   scrollLeft: number;
   scrollTop: number;
 };
 
-export {
-  arrow,
-  autoPlacement,
-  flip,
-  hide,
-  offset,
-  shift,
-  limitShift,
-  size,
-  detectOverflow,
-} from '@floating-ui/core';
+export type DOMDetectOverflowOptions = Omit<
+  DetectOverflowOptions,
+  'boundary'
+> & {
+  boundary: 'clippingParents' | Element | Array<Element>;
+};
 
+declare const autoPlacement: (
+  options?: AutoPlacementOptions & DOMDetectOverflowOptions
+) => Middleware;
+
+declare const shift: (
+  options?: ShiftOptions & DOMDetectOverflowOptions
+) => Middleware;
+
+declare const flip: (
+  options?: FlipOptions & DOMDetectOverflowOptions
+) => Middleware;
+
+declare const size: (
+  options?: SizeOptions & DOMDetectOverflowOptions
+) => Middleware;
+
+declare const arrow: (options: {
+  element: HTMLElement;
+  padding: number | SideObject;
+}) => Middleware;
+
+declare const detectOverflow: (
+  middlewareArguments: MiddlewareArguments,
+  options?: Partial<DOMDetectOverflowOptions>
+) => SideObject;
+
+export {autoPlacement, shift, arrow, size, flip, detectOverflow};
+export {hide, offset, limitShift} from '@floating-ui/core';
 export {computePosition} from './';
 export {getScrollParents} from './utils/getScrollParents';


### PR DESCRIPTION
This wraps some exported types with stricter types than the core, namely `boundary` in `DetectOverflowOptions`, `element` in the `arrow` middleware, and `contextElement` in a `VirtualElement`

- Adding type testing in a new PR