### PR TITLE
docs: improve CDN usage

### DIFF
--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,5 +1,16 @@
 const {createRemarkPlugin} = require('@atomiks/mdx-pretty-code');
 const fs = require('fs');
+const visit = require('unist-util-visit');
+const corePkg = require('../packages/core/package.json');
+const domPkg = require('../packages/dom/package.json');
+
+const replaceVariables = () => (tree) => {
+  visit(tree, 'code', (node) => {
+    node.value = node.value
+      .replace('__CORE_VERSION__', corePkg.version)
+      .replace('__DOM_VERSION__', domPkg.version);
+  });
+};
 
 const prettyCode = createRemarkPlugin({
   shikiOptions: {
@@ -60,7 +71,7 @@ module.exports = {
           loader: '@mdx-js/loader',
           /** @type {import('@mdx-js/loader').Options} */
           options: {
-            remarkPlugins: [prettyCode],
+            remarkPlugins: [replaceVariables, prettyCode],
           },
         },
       ],

--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -34,19 +34,24 @@ yarn add @floating-ui/dom
 
 ## CDN
 
-Floating UI can be used via the `unpkg` CDN by adding
-`<script>{:html}` tags to your document before your own scripts:
+Floating UI can be loaded via CDN using ESM or UMD format.
+
+### ESM
 
 ```html
-<script src="https://unpkg.com/@floating-ui/core@0"></script>
-<script src="https://unpkg.com/@floating-ui/dom@0"></script>
+<script type="module">
+  import * as FloatingUIDOM from 'https://cdn.skypack.dev/@floating-ui/dom@__DOM_VERSION__';
+</script>
 ```
 
-> Important: you should open each link to retrieve the latest
-> version to lock it to that version.
+### UMD
 
-All exports will then be available on
-`window.FloatingUIDOM{:js}`.
+```html
+<script src="https://unpkg.com/@floating-ui/core@__CORE_VERSION__"></script>
+<script src="https://unpkg.com/@floating-ui/dom@__DOM_VERSION__"></script>
+```
+
+All exports will be available on `window.FloatingUIDOM{:js}`.
 
 ## Tutorial
 

--- a/website/pages/docs/tutorial.mdx
+++ b/website/pages/docs/tutorial.mdx
@@ -502,6 +502,7 @@ Now that the tooltip has everything positioned, we can add
 ```css {2}
 #tooltip {
   display: none;
+  position: absolute;
   background: #222;
   color: white;
   font-weight: bold;

--- a/website/pages/docs/tutorial.mdx
+++ b/website/pages/docs/tutorial.mdx
@@ -15,8 +15,7 @@ If you just want to start learning about the API, skip to the
 ## Setting up
 
 Create a new HTML document with two elements, a `<button>{:html}`
-and a tooltip `<div>{:html}` along with the `unpkg` CDN scripts
-to load Floating UI:
+and a tooltip `<div>{:html}`:
 
 ```html
 <!DOCTYPE html>
@@ -30,9 +29,7 @@ to load Floating UI:
     </button>
     <div id="tooltip" role="tooltip">My tooltip</div>
 
-    <script src="https://unpkg.com/@floating-ui/core"></script>
-    <script src="https://unpkg.com/@floating-ui/dom"></script>
-    <script>
+    <script type="module">
       // Your code will go here.
     </script>
   </body>
@@ -108,16 +105,14 @@ much size as it needs to and is overlaid on top of the UI.
 
 ## Positioning
 
-Inside your `<script>{:html}` tag, add the following code:
+Inside your module `<script>{:html}` tag, add the following code:
 
 ```js
-// First, select the elements on the document
+import {computePosition} from 'https://cdn.skypack.dev/@floating-ui/dom';
+
 const button = document.querySelector('#button');
 const tooltip = document.querySelector('#tooltip');
 
-const {computePosition} = FloatingUIDOM;
-
-// Then position the tooltip
 computePosition(button, tooltip).then(({x, y}) => {
   Object.assign(tooltip.style, {
     left: `${x}px`,
@@ -126,9 +121,8 @@ computePosition(button, tooltip).then(({x, y}) => {
 });
 ```
 
-Above, we call `computePosition(){:js}` (after destructuring it
-from `window.FloatingUIDOM{:js}`) with the button and tooltip
-elements as arguments.
+Above, we call `computePosition(){:js}` with the button and
+tooltip elements as arguments.
 
 It returns a `Promise{:.class}`, so we use the `.then(){:js}`
 method which passes in the calculated `x{:.param}` and
@@ -147,10 +141,10 @@ Floating UI has the `placement{:.objectKey}` option, passed into
 the options object as a third argument:
 
 ```js {7}
+import {computePosition} from 'https://cdn.skypack.dev/@floating-ui/dom';
+
 const button = document.querySelector('#button');
 const tooltip = document.querySelector('#tooltip');
-
-const {computePosition} = FloatingUIDOM;
 
 computePosition(button, tooltip, {
   placement: 'right',
@@ -208,8 +202,14 @@ provide data to the consumer.
 the `'bottom'{:js}` placement automatically without us needing to
 explicitly specify it.
 
-```js /flip/ {1,5}
-const {computePosition, flip} = FloatingUIDOM;
+```js /flip/ {3,11}
+import {
+  computePosition,
+  flip,
+} from 'https://cdn.skypack.dev/@floating-ui/dom';
+
+const button = document.querySelector('#button');
+const tooltip = document.querySelector('#tooltip');
 
 computePosition(button, tooltip, {
   placement: 'top',
@@ -253,8 +253,15 @@ button, it ends up overflowing the edge.
 To solve this problem, we have the `shift{:.function}`
 middleware:
 
-```js /shift/ {1,5}
-const {computePosition, flip, shift} = FloatingUIDOM;
+```js /shift/ {4,12}
+import {
+  computePosition,
+  flip,
+  shift,
+} from 'https://cdn.skypack.dev/@floating-ui/dom';
+
+const button = document.querySelector('#button');
+const tooltip = document.querySelector('#tooltip');
 
 computePosition(button, tooltip, {
   placement: 'top',
@@ -277,8 +284,15 @@ As you can see, the tooltip lies fully flush with the edge of the
 document boundary. To add some whitespace, or padding, the
 `shift{:.function}` middleware accepts an options object:
 
-```js /padding/ {5}
-const {computePosition, flip, shift} = FloatingUIDOM;
+```js /padding/ {12}
+import {
+  computePosition,
+  flip,
+  shift,
+} from 'https://cdn.skypack.dev/@floating-ui/dom';
+
+const button = document.querySelector('#button');
+const tooltip = document.querySelector('#tooltip');
 
 computePosition(button, tooltip, {
   placement: 'top',
@@ -302,8 +316,16 @@ We probably also don't want the tooltip to lie flush with the
 button element. For this, we have the `offset{:.function}`
 middleware:
 
-```js /offset/ {1,5}
-const {computePosition, flip, shift, offset} = FloatingUIDOM;
+```js /offset/ {5,13}
+import {
+  computePosition,
+  flip,
+  shift,
+  offset,
+} from 'https://cdn.skypack.dev/@floating-ui/dom';
+
+const button = document.querySelector('#button');
+const tooltip = document.querySelector('#tooltip');
 
 computePosition(button, tooltip, {
   placement: 'top',
@@ -357,11 +379,18 @@ Then style it:
 Then pass the arrow element into the `arrow{:.function}`
 middleware:
 
-```js /arrow/2 {1,3,12}
-const arrowElement = document.querySelector('#arrow');
+```js {6,11,19}
+import {
+  computePosition,
+  flip,
+  shift,
+  offset,
+  arrow,
+} from 'https://cdn.skypack.dev/@floating-ui/dom';
 
-const {computePosition, flip, shift, offset, arrow} =
-  FloatingUIDOM;
+const button = document.querySelector('#button');
+const tooltip = document.querySelector('#tooltip');
+const arrowElement = document.querySelector('#arrow');
 
 computePosition(button, tooltip, {
   placement: 'top',
@@ -473,7 +502,13 @@ Now that the tooltip has everything positioned, we can add
 ```css {2}
 #tooltip {
   display: none;
-  /* ... rest of the CSS ... */
+  background: #222;
+  color: white;
+  font-weight: bold;
+  padding: 5px;
+  border-radius: 4px;
+  font-size: 90%;
+  pointer-events: none;
 }
 ```
 

--- a/website/pages/docs/tutorial.mdx
+++ b/website/pages/docs/tutorial.mdx
@@ -108,7 +108,7 @@ much size as it needs to and is overlaid on top of the UI.
 Inside your module `<script>{:html}` tag, add the following code:
 
 ```js
-import {computePosition} from 'https://cdn.skypack.dev/@floating-ui/dom';
+import {computePosition} from 'https://cdn.skypack.dev/@floating-ui/dom@__DOM_VERSION__';
 
 const button = document.querySelector('#button');
 const tooltip = document.querySelector('#tooltip');
@@ -141,7 +141,7 @@ Floating UI has the `placement{:.objectKey}` option, passed into
 the options object as a third argument:
 
 ```js {7}
-import {computePosition} from 'https://cdn.skypack.dev/@floating-ui/dom';
+import {computePosition} from 'https://cdn.skypack.dev/@floating-ui/dom@__DOM_VERSION__';
 
 const button = document.querySelector('#button');
 const tooltip = document.querySelector('#tooltip');
@@ -206,7 +206,7 @@ explicitly specify it.
 import {
   computePosition,
   flip,
-} from 'https://cdn.skypack.dev/@floating-ui/dom';
+} from 'https://cdn.skypack.dev/@floating-ui/dom@__DOM_VERSION__';
 
 const button = document.querySelector('#button');
 const tooltip = document.querySelector('#tooltip');
@@ -258,7 +258,7 @@ import {
   computePosition,
   flip,
   shift,
-} from 'https://cdn.skypack.dev/@floating-ui/dom';
+} from 'https://cdn.skypack.dev/@floating-ui/dom@__DOM_VERSION__';
 
 const button = document.querySelector('#button');
 const tooltip = document.querySelector('#tooltip');
@@ -289,7 +289,7 @@ import {
   computePosition,
   flip,
   shift,
-} from 'https://cdn.skypack.dev/@floating-ui/dom';
+} from 'https://cdn.skypack.dev/@floating-ui/dom@__DOM_VERSION__';
 
 const button = document.querySelector('#button');
 const tooltip = document.querySelector('#tooltip');
@@ -322,7 +322,7 @@ import {
   flip,
   shift,
   offset,
-} from 'https://cdn.skypack.dev/@floating-ui/dom';
+} from 'https://cdn.skypack.dev/@floating-ui/dom@__DOM_VERSION__';
 
 const button = document.querySelector('#button');
 const tooltip = document.querySelector('#tooltip');
@@ -386,7 +386,7 @@ import {
   shift,
   offset,
   arrow,
-} from 'https://cdn.skypack.dev/@floating-ui/dom';
+} from 'https://cdn.skypack.dev/@floating-ui/dom@__DOM_VERSION__';
 
 const button = document.querySelector('#button');
 const tooltip = document.querySelector('#tooltip');


### PR DESCRIPTION
- Links both esm and umd ways of CDN consumption
- Locked versions linked by default
- Uses esm format by default in the tutorial