### PR TITLE
fix: arrow element TS definition

### DIFF
--- a/packages/react-dom/index.test-d.ts
+++ b/packages/react-dom/index.test-d.ts
@@ -3,7 +3,7 @@ import {useFloating, shift, arrow} from '.';
 
 App;
 function App() {
-  const arrowRef = useRef();
+  const arrowRef = useRef(null);
   useFloating();
   const {reference, floating, update} = useFloating({
     placement: 'right',

--- a/packages/react-dom/index.test-d.tsx
+++ b/packages/react-dom/index.test-d.tsx
@@ -3,12 +3,11 @@ import {useFloating, shift, arrow} from '.';
 
 App;
 function App() {
-  const arrowRef = useRef();
+  const arrowRef = useRef(null);
   useFloating();
   const {reference, floating, update} = useFloating({
     placement: 'right',
     middleware: [shift(), arrow({element: arrowRef})],
-    // @ts-expect-error
     strategy: 'fixed',
   });
   reference(null);
@@ -29,4 +28,5 @@ function App() {
   reference(null);
   floating(null);
   update();
+  return <div ref={arrowRef} />;
 }

--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -103,7 +103,7 @@ export const arrow = ({
   element,
   padding,
 }: {
-  element: MutableRefObject<HTMLElement | undefined> | HTMLElement;
+  element: MutableRefObject<HTMLElement | null> | HTMLElement;
   padding?: number | SideObject;
 }): Middleware => {
   function isRef(value: unknown): value is MutableRefObject<unknown> {

--- a/packages/react-native/index.test-d.tsx
+++ b/packages/react-native/index.test-d.tsx
@@ -1,4 +1,5 @@
 import {useRef} from 'react';
+import {View} from "react-native";
 import {useFloating, shift, arrow} from '.';
 
 App;
@@ -8,6 +9,7 @@ function App() {
   const {reference, floating, update} = useFloating({
     placement: 'right',
     middleware: [shift(), arrow({element: arrowRef})],
+    // @ts-expect-error
     strategy: 'fixed',
   });
   reference(null);
@@ -28,4 +30,5 @@ function App() {
   reference(null);
   floating(null);
   update();
+  return <View ref={arrowRef} />
 }


### PR DESCRIPTION
Arrow element has type HTMLElement | undefined. That cause a TS error with const `arrowRef = useRef(null)`.
If you use useRef without init value (`arrowRef = useRef()`) you got TS error on the target element.

![image](https://user-images.githubusercontent.com/4593089/146206237-7bd4c357-ce61-4503-9e88-d26634104d44.png)

![image](https://user-images.githubusercontent.com/4593089/146206143-6d27d301-19c8-4965-8b05-fc78933d7a24.png)


**Solution**
Change arrow element type to `HTMLElement | null`.

reproduction: https://codesandbox.io/s/floating-ui-react-dom-visual-test-05xpu?file=/src/App.tsx

**Notes**
You can see in the example that there are other errors. It copy-pasted version of the https://github.com/floating-ui/floating-ui/blob/master/packages/react-dom/test/visual/index.js with annotated `arrowRef`. This pull request takes care only of the arrow element, not other errors.