### PR TITLE
export `package.json`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,8 +7,11 @@
   "unpkg": "dist/floating-ui.core.min.js",
   "type": "module",
   "exports": {
-    "import": "./dist/floating-ui.core.esm.js",
-    "require": "./dist/floating-ui.core.cjs"
+    ".": {
+      "import": "./dist/floating-ui.core.esm.js",
+      "require": "./dist/floating-ui.core.cjs"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "files": [

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -7,8 +7,11 @@
   "unpkg": "dist/floating-ui.dom.min.js",
   "type": "module",
   "exports": {
-    "import": "./dist/floating-ui.dom.esm.js",
-    "require": "./dist/floating-ui.dom.cjs"
+    ".": {
+      "import": "./dist/floating-ui.dom.esm.js",
+      "require": "./dist/floating-ui.dom.cjs"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "files": [

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -7,8 +7,11 @@
   "unpkg": "dist/floating-ui.react-dom.min.js",
   "type": "module",
   "exports": {
-    "import": "./dist/floating-ui.react-dom.esm.js",
-    "require": "./dist/floating-ui.react-dom.cjs"
+    ".": {
+      "import": "./dist/floating-ui.react-dom.esm.js",
+      "require": "./dist/floating-ui.react-dom.cjs"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
A library such as `rollup-plugin-svelte` relies on a module's exposure of its `package.json` file in order to interrogate it (for a [`svelte` field](https://github.com/sveltejs/rollup-plugin-svelte#pkgsvelte) in their case, permitting it to import an uncompiled version of the distribution). It is common practice to export this file; see '[Package entry points](https://nodejs.org/api/packages.html#packages_package_entry_points)' section of the official docs for an example.

As a consequence, exporting `package.json` would remove the following warning presented to consumers needing to compile Svelte components, for example:

> [rollup-plugin-svelte] The following packages did not export their package.json file so we could not check the "svelte" field. If you had difficulties importing svelte components from a package, then please contact the author and ask them to export the package.json file.

There is further discussion in an equivalent [PR](https://github.com/js-cookie/js-cookie/pull/727) from another library.