### PR TITLE
feat(shift): expose coords data

### DIFF
--- a/packages/core/src/middleware/shift.ts
+++ b/packages/core/src/middleware/shift.ts
@@ -66,11 +66,19 @@ export const shift = (
       crossAxisCoord = within(min, crossAxisCoord, max);
     }
 
-    return limiter.fn({
+    const limitedCoords = limiter.fn({
       ...middlewareArguments,
       [mainAxis]: mainAxisCoord,
       [crossAxis]: crossAxisCoord,
     });
+
+    return {
+      ...limitedCoords,
+      data: {
+        x: limitedCoords.x - x,
+        y: limitedCoords.y - y,
+      },
+    };
   },
 });
 


### PR DESCRIPTION
Allows consumer to create a dynamic strategy between `fixed` and `absolute` if `shift.{x,y} !== 0`, e.g. for an implementation similar to CSS `position: sticky`