### PR TITLE
docs: fetch latest npm versions for CDN links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@floating-ui/monorepo",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@floating-ui/monorepo",
-      "version": "1.0.0",
+      "version": "0.0.0",
       "license": "MIT",
       "workspaces": [
         "./packages/*",
@@ -7848,6 +7848,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "license": "MIT",
@@ -8969,7 +8977,6 @@
     "node_modules/clone-deep": {
       "version": "4.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
@@ -10233,6 +10240,19 @@
       "version": "5.1.0",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/download-stats": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/download-stats/-/download-stats-0.3.4.tgz",
+      "integrity": "sha512-ic2BigbyUWx7/CBbsfGjf71zUNZB4edBGC3oRliSzsoNmvyVx3Ycfp1w3vp2Y78Ee0eIIkjIEO5KzW0zThDGaA==",
+      "dependencies": {
+        "JSONStream": "^1.2.1",
+        "lazy-cache": "^2.0.1",
+        "moment": "^2.15.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/duplexer": {
       "version": "0.1.1",
@@ -11720,7 +11740,6 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.14.5",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -13193,7 +13212,6 @@
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -13366,7 +13384,6 @@
     "node_modules/isobject": {
       "version": "3.0.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16032,6 +16049,29 @@
       "license": "Public Domain",
       "peer": true
     },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "engines": [
+        "node >= 0.2.0"
+      ]
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/jsprim": {
       "version": "1.4.2",
       "dev": true,
@@ -16049,7 +16089,6 @@
     "node_modules/kind-of": {
       "version": "6.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16067,6 +16106,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lazy-cache": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+      "dependencies": {
+        "set-getter": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/leven": {
@@ -17484,6 +17534,14 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "license": "MIT"
@@ -17881,6 +17939,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-api": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-api/-/npm-api-1.0.1.tgz",
+      "integrity": "sha512-4sITrrzEbPcr0aNV28QyOmgn6C9yKiF8k92jn4buYAK8wmA5xo1qL3II5/gT1r7wxbXBflSduZ2K3FbtOrtGkA==",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "download-stats": "^0.3.4",
+        "JSONStream": "^1.3.5",
+        "moment": "^2.24.0",
+        "node-fetch": "^2.6.0",
+        "paged-request": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -18340,6 +18414,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/paged-request": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/paged-request/-/paged-request-2.0.2.tgz",
+      "integrity": "sha512-NWrGqneZImDdcMU/7vMcAOo1bIi5h/pmpJqe7/jdsy85BA/s5MSaU/KlpxwW/IVPmIwBcq2uKPrBWWhEWhtxag==",
+      "dependencies": {
+        "axios": "^0.21.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pako": {
@@ -21484,6 +21569,17 @@
       "license": "ISC",
       "peer": true
     },
+    "node_modules/set-getter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.1.tgz",
+      "integrity": "sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==",
+      "dependencies": {
+        "to-object-path": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/set-value": {
       "version": "2.0.1",
       "license": "MIT",
@@ -21539,7 +21635,6 @@
     "node_modules/shallow-clone": {
       "version": "3.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "kind-of": "^6.0.2"
       },
@@ -22814,6 +22909,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
     "node_modules/through2": {
       "version": "2.0.5",
       "license": "MIT",
@@ -22885,7 +22985,6 @@
     "node_modules/to-object-path": {
       "version": "0.3.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "kind-of": "^3.0.2"
       },
@@ -22895,13 +22994,11 @@
     },
     "node_modules/to-object-path/node_modules/is-buffer": {
       "version": "1.1.6",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/to-object-path/node_modules/kind-of": {
       "version": "3.2.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -24408,7 +24505,7 @@
     },
     "packages/core": {
       "name": "@floating-ui/core",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@atomico/rollup-plugin-sizes": "^1.1.4",
@@ -24428,10 +24525,10 @@
     },
     "packages/dom": {
       "name": "@floating-ui/dom",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^0.2.1"
+        "@floating-ui/core": "^0.2.2"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -24453,10 +24550,10 @@
     },
     "packages/react-dom": {
       "name": "@floating-ui/react-dom",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^0.1.7",
+        "@floating-ui/dom": "^0.1.8",
         "use-isomorphic-layout-effect": "^1.1.1"
       },
       "devDependencies": {
@@ -24488,10 +24585,10 @@
     },
     "packages/react-native": {
       "name": "@floating-ui/react-native",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^0.2.1"
+        "@floating-ui/core": "^0.2.2"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -24529,6 +24626,7 @@
         "@tippyjs/react": "^4.2.6",
         "classnames": "^2.3.1",
         "next": "^12.0.4",
+        "npm-api": "^1.0.1",
         "parse-numeric-range": "^1.3.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -25676,7 +25774,7 @@
       "requires": {
         "@babel/preset-env": "^7.16.4",
         "@babel/preset-typescript": "^7.16.0",
-        "@floating-ui/core": "^0.2.1",
+        "@floating-ui/core": "^0.2.2",
         "@playwright/test": "^1.16.3",
         "@rollup/plugin-replace": "^3.0.0",
         "@types/jest": "^27.0.3",
@@ -25698,7 +25796,7 @@
         "@babel/preset-env": "^7.16.4",
         "@babel/preset-react": "^7.16.0",
         "@babel/preset-typescript": "^7.16.0",
-        "@floating-ui/dom": "^0.1.7",
+        "@floating-ui/dom": "^0.1.8",
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.0.6",
@@ -25724,7 +25822,7 @@
       "requires": {
         "@babel/preset-env": "^7.16.4",
         "@babel/preset-typescript": "^7.16.0",
-        "@floating-ui/core": "^0.2.1",
+        "@floating-ui/core": "^0.2.2",
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.0.6",
@@ -29502,6 +29600,14 @@
       "version": "1.11.0",
       "dev": true
     },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "babel-core": {
       "version": "7.0.0-bridge.0",
       "peer": true,
@@ -30255,7 +30361,6 @@
     },
     "clone-deep": {
       "version": "4.0.1",
-      "peer": true,
       "requires": {
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
@@ -31085,6 +31190,16 @@
     "dotenv-expand": {
       "version": "5.1.0",
       "dev": true
+    },
+    "download-stats": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/download-stats/-/download-stats-0.3.4.tgz",
+      "integrity": "sha512-ic2BigbyUWx7/CBbsfGjf71zUNZB4edBGC3oRliSzsoNmvyVx3Ycfp1w3vp2Y78Ee0eIIkjIEO5KzW0zThDGaA==",
+      "requires": {
+        "JSONStream": "^1.2.1",
+        "lazy-cache": "^2.0.1",
+        "moment": "^2.15.1"
+      }
     },
     "duplexer": {
       "version": "0.1.1",
@@ -32044,8 +32159,7 @@
       "peer": true
     },
     "follow-redirects": {
-      "version": "1.14.5",
-      "dev": true
+      "version": "1.14.5"
     },
     "for-in": {
       "version": "1.0.2",
@@ -32914,7 +33028,6 @@
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "peer": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -33010,8 +33123,7 @@
       "version": "2.0.0"
     },
     "isobject": {
-      "version": "3.0.1",
-      "peer": true
+      "version": "3.0.1"
     },
     "isstream": {
       "version": "0.1.2",
@@ -34771,6 +34883,20 @@
       "version": "0.0.0",
       "peer": true
     },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+    },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "jsprim": {
       "version": "1.4.2",
       "dev": true,
@@ -34782,8 +34908,7 @@
       }
     },
     "kind-of": {
-      "version": "6.0.3",
-      "peer": true
+      "version": "6.0.3"
     },
     "klaw": {
       "version": "1.3.1",
@@ -34794,6 +34919,14 @@
     },
     "kleur": {
       "version": "3.0.3"
+    },
+    "lazy-cache": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+      "requires": {
+        "set-getter": "^0.1.0"
+      }
     },
     "leven": {
       "version": "3.1.0"
@@ -35806,6 +35939,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
     "ms": {
       "version": "2.1.2"
     },
@@ -36045,6 +36183,19 @@
     "normalize-url": {
       "version": "6.1.0",
       "dev": true
+    },
+    "npm-api": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-api/-/npm-api-1.0.1.tgz",
+      "integrity": "sha512-4sITrrzEbPcr0aNV28QyOmgn6C9yKiF8k92jn4buYAK8wmA5xo1qL3II5/gT1r7wxbXBflSduZ2K3FbtOrtGkA==",
+      "requires": {
+        "clone-deep": "^4.0.1",
+        "download-stats": "^0.3.4",
+        "JSONStream": "^1.3.5",
+        "moment": "^2.24.0",
+        "node-fetch": "^2.6.0",
+        "paged-request": "^2.0.1"
+      }
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -36326,6 +36477,14 @@
     },
     "p-try": {
       "version": "2.2.0"
+    },
+    "paged-request": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/paged-request/-/paged-request-2.0.2.tgz",
+      "integrity": "sha512-NWrGqneZImDdcMU/7vMcAOo1bIi5h/pmpJqe7/jdsy85BA/s5MSaU/KlpxwW/IVPmIwBcq2uKPrBWWhEWhtxag==",
+      "requires": {
+        "axios": "^0.21.1"
+      }
     },
     "pako": {
       "version": "1.0.11"
@@ -38356,6 +38515,14 @@
       "version": "2.0.0",
       "peer": true
     },
+    "set-getter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.1.tgz",
+      "integrity": "sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==",
+      "requires": {
+        "to-object-path": "^0.3.0"
+      }
+    },
     "set-value": {
       "version": "2.0.1",
       "peer": true,
@@ -38394,7 +38561,6 @@
     },
     "shallow-clone": {
       "version": "3.0.1",
-      "peer": true,
       "requires": {
         "kind-of": "^6.0.2"
       }
@@ -39231,6 +39397,11 @@
       "version": "6.0.1",
       "dev": true
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
     "through2": {
       "version": "2.0.5",
       "peer": true,
@@ -39288,18 +39459,15 @@
     },
     "to-object-path": {
       "version": "0.3.0",
-      "peer": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
       "dependencies": {
         "is-buffer": {
-          "version": "1.1.6",
-          "peer": true
+          "version": "1.1.6"
         },
         "kind-of": {
           "version": "3.2.2",
-          "peer": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -40049,6 +40217,7 @@
         "autoprefixer": "^10.4.0",
         "classnames": "^2.3.1",
         "next": "^12.0.4",
+        "npm-api": "*",
         "parse-numeric-range": "^1.3.0",
         "postcss": "^8.4.4",
         "react": "^17.0.2",

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,14 +1,24 @@
 const {createRemarkPlugin} = require('@atomiks/mdx-pretty-code');
 const fs = require('fs');
 const visit = require('unist-util-visit');
-const corePkg = require('../packages/core/package.json');
-const domPkg = require('../packages/dom/package.json');
+const NpmApi = require('npm-api');
 
-const replaceVariables = () => (tree) => {
+const replaceVariables = () => async (tree) => {
+  let pkgs = [];
+  try {
+    const npm = new NpmApi();
+    pkgs = await Promise.all([
+      npm.repo('@floating-ui/core').package(),
+      npm.repo('@floating-ui/dom').package(),
+    ]);
+  } catch (e) {
+    pkgs = [{version: 'latest'}, {version: 'latest'}];
+  }
+
   visit(tree, 'code', (node) => {
     node.value = node.value
-      .replace('__CORE_VERSION__', corePkg.version)
-      .replace('__DOM_VERSION__', domPkg.version);
+      .replace('__CORE_VERSION__', pkgs[0].version)
+      .replace('__DOM_VERSION__', pkgs[1].version);
   });
 };
 

--- a/website/package.json
+++ b/website/package.json
@@ -35,6 +35,7 @@
     "@tippyjs/react": "^4.2.6",
     "classnames": "^2.3.1",
     "next": "^12.0.4",
+    "npm-api": "^1.0.1",
     "parse-numeric-range": "^1.3.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
As Rolling Versions doesn't add a commit to update the versions locally, we now need to fetch it from NPM