### PR TITLE
Revert #1399

### DIFF
--- a/src/dom-utils/getClippingRect.js
+++ b/src/dom-utils/getClippingRect.js
@@ -63,10 +63,7 @@ function getClippingParents(element: Element): Array<Element> {
     (clippingParent) =>
       isElement(clippingParent) &&
       contains(clippingParent, clipperElement) &&
-      getNodeName(clippingParent) !== 'body' &&
-      (canEscapeClipping
-        ? getComputedStyle(clippingParent).position !== 'static'
-        : true)
+      getNodeName(clippingParent) !== 'body'
   );
 }
 

--- a/tests/functional/clipping-parent.test.js
+++ b/tests/functional/clipping-parent.test.js
@@ -4,7 +4,7 @@
  */
 import { screenshot } from '../utils/puppeteer.js';
 
-it('is positioned at bottom-start', async () => {
+it.skip('is positioned at bottom-start', async () => {
   const page = await browser.newPage();
   await page.goto(`${TEST_URL}/clipping-parent.html`);
 


### PR DESCRIPTION
Fixes #1477 

It appears #1399 is hard to fix without breaking more common DOM layout cases. 

The problem is that the clipping parent contains a clipper element with an absolute position, which causes the clipping parent's size to collapse to nothing, but the popper can still fit within its offsetParent without being clipped. The current solution broke #1477 though... I tried working on a solution but none solved every case. 

I think reverting is the best option for now — that issue had no votes, so I don't think that type of layout is very common in comparison to the one this will now fix. This is also safer as it will always check overflow correctly, and the escape hatch for #1399 is setting a custom boundary.