### PR TITLE
fix(dom/getViewportRect): Firefox pinch zooming

### DIFF
--- a/packages/dom/src/utils/getViewportRect.ts
+++ b/packages/dom/src/utils/getViewportRect.ts
@@ -22,7 +22,7 @@ export function getViewportRect(element: Element): Rect {
     // Safari returns a number <= 0, usually < -1 when pinch-zoomed
     if (
       Math.abs(win.innerWidth / visualViewport.scale - visualViewport.width) <
-      0.001
+      0.01
     ) {
       x = visualViewport.offsetLeft;
       y = visualViewport.offsetTop;


### PR DESCRIPTION
This value when pinch zoomed on FF can be above 0.001 