### PR TITLE
fix(react): return options on exported arrow middleware

### DIFF
--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -108,19 +108,19 @@ export function useFloating({
   );
 }
 
-export const arrow = ({
-  element,
-  padding,
-}: {
+export const arrow = (options: {
   element: MutableRefObject<HTMLElement | null> | HTMLElement;
   padding?: number | SideObject;
 }): Middleware => {
+  const {element, padding} = options;
+
   function isRef(value: unknown): value is MutableRefObject<unknown> {
     return Object.prototype.hasOwnProperty.call(value, 'current');
   }
 
   return {
     name: 'arrow',
+    options,
     fn(args) {
       if (isRef(element)) {
         if (element.current != null) {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -151,19 +151,19 @@ export const useFloating = ({
   );
 };
 
-export const arrow = ({
-  element,
-  padding,
-}: {
+export const arrow = (options: {
   element: any;
   padding?: number | SideObject;
 }): Middleware => {
+  const {element, padding} = options;
+
   function isRef(value: unknown) {
     return Object.prototype.hasOwnProperty.call(value, 'current');
   }
 
   return {
     name: 'arrow',
+    options,
     fn(args) {
       if (isRef(element)) {
         if (element.current != null) {


### PR DESCRIPTION
Allows the options to be diffed by the `deepEqual` compare to update on hot reload