### PR TITLE
add workflow to release popper versions

### DIFF
--- a/.github/workflows/release-floating-ui.yml
+++ b/.github/workflows/release-floating-ui.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Floating UI
 
 on:
   repository_dispatch:

--- a/.github/workflows/release-popper.yml
+++ b/.github/workflows/release-popper.yml
@@ -1,0 +1,20 @@
+name: Release Popper
+
+on: [workflow_dispatch]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - uses: CultureHQ/actions-yarn@master
+        with:
+          args: install
+      - run: npx rollingversions publish --deploy-branch "v2.x"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
With these changes we should be able to manually trigger the new workflow to release Popper versions.