### PR TITLE
fix(react-native): bundle, async cleanup

### DIFF
--- a/packages/react-native/rollup.config.js
+++ b/packages/react-native/rollup.config.js
@@ -18,29 +18,9 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.react-native.esm.min.js'),
-      format: 'esm',
-    },
-  },
-  {
-    input,
-    output: {
       name: 'FloatingUIReactNative',
       file: path.join(__dirname, 'dist/floating-ui.react-native.js'),
-      format: 'umd',
-      globals: {
-        react: 'React',
-        'react-native': 'ReactNative',
-        '@floating-ui/core': 'FloatingUICore',
-      },
-    },
-  },
-  {
-    input,
-    output: {
-      name: 'FloatingUIReactNative',
-      file: path.join(__dirname, 'dist/floating-ui.react-native.min.js'),
-      format: 'umd',
+      format: 'cjs',
       globals: {
         react: 'React',
         'react-native': 'ReactNative',
@@ -53,7 +33,11 @@ const bundles = [
 const buildExport = bundles.map(({input, output}) => ({
   input,
   output,
-  external: ['react', 'react-native'],
+  external: [
+    'react',
+    'react-native',
+    '@floating-ui/core/dist/floating-ui.core',
+  ],
   plugins: [
     commonjs(),
     nodeResolve({extensions: ['.ts', '.js']}),

--- a/packages/react-native/src/floating-ui.core.d.ts
+++ b/packages/react-native/src/floating-ui.core.d.ts
@@ -1,0 +1,3 @@
+declare module '@floating-ui/core/dist/floating-ui.core' {
+  export * from '@floating-ui/core';
+}

--- a/website/pages/docs/react-native.mdx
+++ b/website/pages/docs/react-native.mdx
@@ -46,8 +46,8 @@ function App() {
         ref={floating}
         style={{
           position: 'absolute',
-          top: y ?? '',
-          left: x ?? '',
+          top: y ?? 0,
+          left: x ?? 0,
         }}
       >
         <Text>Floating</Text>


### PR DESCRIPTION
- chore: avoid bundling in `core` package by referring to the CJS build in the imports, remove minified bundles
- fix: stale `computePositions` by cleaning up animation frames
- fix: `isMountedRef` boolean 
- docs: use `?? 0` in the example