### PR TITLE
feat: expand export maps to support no/low build tooling

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,11 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/floating-ui.core.esm.js",
+      "import": {
+        "development": "./dist/floating-ui.core.esm.development.js",
+        "production": "./dist/floating-ui.core.esm.min.js",
+        "default": "./dist/floating-ui.core.esm.js"
+      },
       "require": "./dist/floating-ui.core.cjs"
     },
     "./package.json": "./package.json"

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -25,6 +25,13 @@ const bundles = [
   {
     input,
     output: {
+      file: path.join(__dirname, 'dist/floating-ui.core.esm.development.js'),
+      format: 'esm',
+    },
+  },
+  {
+    input,
+    output: {
       name: 'FloatingUICore',
       file: path.join(__dirname, 'dist/floating-ui.core.js'),
       format: 'umd',
@@ -47,6 +54,12 @@ const bundles = [
   },
 ];
 
+const isDevEnv = (file) => file.includes('.development.');
+const isUMD = (file) => file.includes('.core.js');
+const isMinEnv = (file) => file.includes('.min.');
+const isSpecificEnv = (file) => isMinEnv(file) || isDevEnv(file);
+const isDebugAlways = (file) => isDevEnv(file) || isUMD(file) ? 'true' : 'false';
+
 const buildExport = bundles.map(({input, output}) => ({
   input,
   output,
@@ -58,8 +71,8 @@ const buildExport = bundles.map(({input, output}) => ({
       plugins: ['annotate-pure-calls'],
     }),
     replace({
-      __DEV__: output.file.includes('.min.')
-        ? 'false'
+      __DEV__: isSpecificEnv(output.file)
+        ? isDebugAlways(output.file)
         : 'process.env.NODE_ENV !== "production"',
       preventAssignment: true,
     }),

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -18,7 +18,11 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/floating-ui.dom.esm.js",
+      "import": {
+        "development": "./dist/floating-ui.dom.esm.development.js",
+        "production": "./dist/floating-ui.dom.esm.min.js",
+        "default": "./dist/floating-ui.dom.esm.js"
+      },
       "require": "./dist/floating-ui.dom.cjs"
     },
     "./package.json": "./package.json"

--- a/packages/dom/rollup.config.js
+++ b/packages/dom/rollup.config.js
@@ -24,6 +24,13 @@ const bundles = [
   {
     input,
     output: {
+      file: path.join(__dirname, 'dist/floating-ui.dom.esm.development.js'),
+      format: 'esm',
+    },
+  },
+  {
+    input,
+    output: {
       name: 'FloatingUIDOM',
       file: path.join(__dirname, 'dist/floating-ui.dom.js'),
       format: 'umd',
@@ -52,6 +59,12 @@ const bundles = [
   },
 ];
 
+const isDevEnv = (file) => file.includes('.development.');
+const isUMD = (file) => file.includes('.dom.js');
+const isMinEnv = (file) => file.includes('.min.');
+const isSpecificEnv = (file) => isMinEnv(file) || isDevEnv(file);
+const isDebugAlways = (file) => isDevEnv(file) || isUMD(file) ? 'true' : 'false';
+
 const buildExport = bundles.map(({input, output}) => ({
   input,
   output,
@@ -64,8 +77,8 @@ const buildExport = bundles.map(({input, output}) => ({
       plugins: ['annotate-pure-calls'],
     }),
     replace({
-      __DEV__: output.file.includes('.min.')
-        ? 'false'
+      __DEV__: isSpecificEnv(output.file)
+        ? isDebugAlways(output.file)
         : 'process.env.NODE_ENV !== "production"',
       preventAssignment: true,
     }),


### PR DESCRIPTION
fixes #1497

Split the `import` fork in the export maps to include `node` and `default` subtrees.

Add `browser` and `default` subtree to initial `default`.

Add a "browser" build at `./dist/floating-ui.core.esm.browser.js` and `./dist/floating-ui.dom.esm.browser.js` the is not minified and does not include the debugging forks. It's possible that this _should_ be the inverse and include the debugging forks _always_, but let me know what you think here.

I've tested this locally in a browser with the `development` condition both on and off and it's working pretty nicely, however I'd definitely suggest a pre-/beta release with this as export maps continue to surprise me when actually consumed across a number of different contexts.