### PR TITLE
chore: min path for low/no-build tooling

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,9 @@
       "import": "./dist/floating-ui.core.esm.js",
       "require": "./dist/floating-ui.core.cjs"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./dist/floating-ui.core.esm.min.js": "./dist/floating-ui.core.esm.min.js",
+    "./min": "./dist/floating-ui.core.esm.min.js"
   },
   "sideEffects": false,
   "files": [

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -21,7 +21,9 @@
       "import": "./dist/floating-ui.dom.esm.js",
       "require": "./dist/floating-ui.dom.cjs"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./dist/floating-ui.dom.esm.min.js": "./dist/floating-ui.dom.esm.min.js",
+    "./min": "./dist/floating-ui.dom.esm.min.js"
   },
   "sideEffects": false,
   "files": [

--- a/packages/dom/rollup.config.js
+++ b/packages/dom/rollup.config.js
@@ -19,6 +19,10 @@ const bundles = [
     output: {
       file: path.join(__dirname, 'dist/floating-ui.dom.esm.min.js'),
       format: 'esm',
+      paths: {
+        '@floating-ui/core':
+          '@floating-ui/core/dist/floating-ui.core.esm.min.js',
+      },
     },
   },
   {


### PR DESCRIPTION
This should allow the user to do this without any build tool (native ESM in the browser), or using Rollup as the bundler without using `replace`:

```js
import {computePosition} from '@floating-ui/dom/min';
```

@Westbrook, does this solve your case/look sound?

I still dislike this because:

- No debugging messages/checks when using the library. 
- No tree-shaking (if you're importing from a CDN or such). The library is built for DCE. More features can/will be added onto core, meaning the file size without DCE keeps increasing. The alternative is supplying individual bundles for each middleware, but then you have to deal with more HTTP requests + the install size of the library increases....

I would only recommend using this for toy apps/tutorials than anything actually running in production.