### PR TITLE
Add Conditional Exports in Popper v2

### DIFF
--- a/.config/rollup.config.js
+++ b/.config/rollup.config.js
@@ -8,14 +8,14 @@ import flowEntry from 'rollup-plugin-flow-entry';
 import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import pkg from '../package.json';
 
-const getFileName = (input) => input.split('/').reverse()[0].split('.')[0];
+const getFileName = (input) => input.split('/')[1].split('.')[0];
 
 const inputs = ['src/popper.js', 'src/popper-lite.js', 'src/popper-base.js', 'src/enums.js'];
 const bundles = [
   { inputs, format: 'umd', dir: 'dist', minify: true, flow: true },
   { inputs, format: 'umd', dir: 'dist' },
   { inputs, format: 'cjs', dir: 'dist', flow: true },
-  { inputs: ['dist/esm/index.js'], format: 'esm', dir: 'dist', minify: true },
+  { inputs: ['lib/index.js'], format: 'esm', dir: 'dist', minify: true },
   { inputs: ['lib/index.js'], format: 'esm', dir: 'dist', development: true },
 ];
 
@@ -28,9 +28,9 @@ const configs = bundles
           replace({
             __DEV__: minify ? 'false' : 'true',
           }),
-        format === 'esm' && development &&
+        format === 'esm' &&
           replace({
-            'process.env.NODE_ENV': '"development"',
+            'process.env.NODE_ENV': development ? '"development"' : '"production"',
           }),
         babel({ babelHelpers: 'bundled' }),
         // The two minifiers together seem to procude a smaller bundle 🤷‍♂️

--- a/.config/rollup.config.js
+++ b/.config/rollup.config.js
@@ -15,8 +15,8 @@ const bundles = [
   { inputs, format: 'umd', dir: 'dist', minify: true, flow: true },
   { inputs, format: 'umd', dir: 'dist' },
   { inputs, format: 'cjs', dir: 'dist', flow: true },
-  { inputs: ['lib/index.js'], format: 'esm', dir: 'dist', minify: true },
-  { inputs: ['lib/index.js'], format: 'esm', dir: 'dist', development: true },
+  { inputs: ['src/index.js'], format: 'esm', dir: 'dist', minify: true },
+  { inputs: ['src/index.js'], format: 'esm', dir: 'dist', development: true },
 ];
 
 const configs = bundles

--- a/package.json
+++ b/package.json
@@ -5,6 +5,17 @@
   "main": "dist/cjs/popper.js",
   "main:umd": "dist/umd/popper.js",
   "module": "lib/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "development": "./dist/esm/index.development.js",
+        "production": "./dist/esm/index.min.js",
+        "default": "./lib/index.js"
+      },
+      "require": "./dist/cjs/popper.js"
+    },
+    "./package.json": "./package.json"
+  },
   "unpkg": "dist/umd/popper.min.js",
   "author": "Federico Zivolo <federico.zivolo@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Fixes #1465.

This pull request is similar to https://github.com/floating-ui/floating-ui/pull/1502, but for the `v2.x` branch.

I've left all existing distributions in place and have added 2 new files to use in the `development` and `production` conditional exports:

Exports Entry | File Name | Notes
:--- | :--- | :---
`import.development` | `dist/esm/index.development.js` | New un-minified ESM build with debugging on.
`import.production` | `dist/esm/index.min.js` | New minified ESM build with debugging off.
`import.default` |  `lib/index.js` | Existing ESM build.  Same as `module`.
`require` | `dist/cjs/popper.js` | Existing CJS build.  Same as `main`.

I copied the entire "exports" format from the current version which means I also brought back the update from https://github.com/floating-ui/floating-ui/pull/1462.  I can leave that out if you'd prefer.

Please let me know if I'm doing anything wrong here or if there's a different approach you would recommend.