### PR TITLE
fix: update getOffsetParent#getContainingBlock to use host if a starting element's parent is a shadow root

### DIFF
--- a/src/dom-utils/getOffsetParent.js
+++ b/src/dom-utils/getOffsetParent.js
@@ -2,7 +2,7 @@
 import getWindow from './getWindow';
 import getNodeName from './getNodeName';
 import getComputedStyle from './getComputedStyle';
-import { isHTMLElement } from './instanceOf';
+import { isHTMLElement, isShadowRoot } from './instanceOf';
 import isTableElement from './isTableElement';
 import getParentNode from './getParentNode';
 
@@ -33,6 +33,10 @@ function getContainingBlock(element: Element) {
   }
 
   let currentNode = getParentNode(element);
+
+  if (isShadowRoot(currentNode)) {
+    currentNode = currentNode.host;
+  }
 
   while (
     isHTMLElement(currentNode) &&

--- a/tests/visual/transform/shadow-dom-fixed-host-translated.html
+++ b/tests/visual/transform/shadow-dom-fixed-host-translated.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html> <title>Transform Visual Test</title>
+
+<style>
+  @import '/tests/visual/reset.css';
+
+  .moved {
+    transform: translate(100px, 100px);
+  }
+</style>
+
+<test-element class='moved'></test-element>
+
+<script type="module">
+  import { createPopper } from '../dist/popper.js';
+
+  class TestElement extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.innerHTML = this.template;
+    }
+
+    connectedCallback() {
+      const reference = this.shadowRoot.querySelector('#reference');
+      const popper = this.shadowRoot.querySelector('#popper');
+
+      window.instance = createPopper(reference, popper, {
+        placement: 'bottom-start'
+      });
+    }
+
+    get template() {
+      return `
+                <style>
+  @import '/reset.css';
+
+                  #reference {
+                    width: 200px;
+                    height: 200px;
+                    background-color: red;
+                    box-shadow: inset 0 0 0 1px black;
+                  }
+
+                  #popper {
+                    width: 100px;
+                    height: 100px;
+                    background-color: rebeccapurple;
+                    box-shadow: inset 0 0 0 1px black;
+                  }
+                </style>
+                <div id='reference'>Reference Box</div>
+                <div id='popper'>Popper Box</div>
+            `;
+    }
+  }
+  customElements.define('test-element', TestElement);
+</script>

--- a/tests/visual/transform/shadow-dom-fixed-parent-host-translated.html
+++ b/tests/visual/transform/shadow-dom-fixed-parent-host-translated.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <title>Transform Visual Test</title>
+
+<style>
+  @import '/tests/visual/reset.css';
+
+  .moved {
+    transform: translate(100px, 100px);
+  }
+</style>
+
+<div class='moved'>
+  <test-element class='moved'></test-element>
+</div>
+
+<script type="module">
+  import { createPopper } from '../dist/popper.js';
+
+  class TestElement extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.innerHTML = this.template;
+    }
+
+    connectedCallback() {
+      const reference = this.shadowRoot.querySelector('#reference');
+      const popper = this.shadowRoot.querySelector('#popper');
+
+      window.instance = createPopper(reference, popper, {
+        placement: 'bottom-start'
+      });
+    }
+
+    get template() {
+      return `
+                <style>
+  @import '/reset.css';
+
+                  #reference {
+                    width: 200px;
+                    height: 200px;
+                    background-color: red;
+                    box-shadow: inset 0 0 0 1px black;
+                  }
+
+                  #popper {
+                    width: 100px;
+                    height: 100px;
+                    background-color: rebeccapurple;
+                    box-shadow: inset 0 0 0 1px black;
+                  }
+                </style>
+                <div id='reference'>Reference Box</div>
+                <div id='popper'>Popper Box</div>
+            `;
+    }
+  }
+  customElements.define('test-element', TestElement);
+</script>

--- a/tests/visual/transform/shadow-dom-fixed-parent-translated.html
+++ b/tests/visual/transform/shadow-dom-fixed-parent-translated.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <title>Transform Visual Test</title>
+
+<style>
+  @import '/tests/visual/reset.css';
+
+  .moved {
+    transform: translate(100px, 100px);
+  }
+</style>
+
+<div class='moved'>
+  <test-element></test-element>
+</div>
+
+<script type="module">
+  import { createPopper } from '../dist/popper.js';
+
+  class TestElement extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.innerHTML = this.template;
+    }
+
+    connectedCallback() {
+      const reference = this.shadowRoot.querySelector('#reference');
+      const popper = this.shadowRoot.querySelector('#popper');
+
+      window.instance = createPopper(reference, popper, {
+        placement: 'bottom-start'
+      });
+    }
+
+    get template() {
+      return `
+                <style>
+  @import '/reset.css';
+
+                  #reference {
+                    width: 200px;
+                    height: 200px;
+                    background-color: red;
+                    box-shadow: inset 0 0 0 1px black;
+                  }
+
+                  #popper {
+                    width: 100px;
+                    height: 100px;
+                    background-color: rebeccapurple;
+                    box-shadow: inset 0 0 0 1px black;
+                  }
+                </style>
+                <div id='reference'>Reference Box</div>
+                <div id='popper'>Popper Box</div>
+            `;
+    }
+  }
+  customElements.define('test-element', TestElement);
+</script>

--- a/tests/visual/transform/shadow-dom-host-translated.html
+++ b/tests/visual/transform/shadow-dom-host-translated.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html> <title>Transform Visual Test</title>
+
+<style>
+  @import '/tests/visual/reset.css';
+
+  .moved {
+    transform: translate(100px, 100px);
+  }
+</style>
+
+<test-element class='moved'></test-element>
+
+<script type="module">
+  import { createPopper } from '../dist/popper.js';
+
+  class TestElement extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.innerHTML = this.template;
+    }
+
+    connectedCallback() {
+      const reference = this.shadowRoot.querySelector('#reference');
+      const popper = this.shadowRoot.querySelector('#popper');
+
+      window.instance = createPopper(reference, popper, {
+        placement: 'bottom-start'
+      });
+    }
+
+    get template() {
+      return `
+                <style>
+  @import '/reset.css';
+
+                  #reference {
+                    width: 200px;
+                    height: 200px;
+                    background-color: red;
+                    box-shadow: inset 0 0 0 1px black;
+                  }
+
+                  #popper {
+                    width: 100px;
+                    height: 100px;
+                    background-color: rebeccapurple;
+                    box-shadow: inset 0 0 0 1px black;
+                  }
+                </style>
+                <div id='reference'>Reference Box</div>
+                <div id='popper'>Popper Box</div>
+            `;
+    }
+  }
+  customElements.define('test-element', TestElement);
+</script>

--- a/tests/visual/transform/shadow-dom-parent-host-translated.html
+++ b/tests/visual/transform/shadow-dom-parent-host-translated.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <title>Transform Visual Test</title>
+
+<style>
+  @import '/tests/visual/reset.css';
+
+  .moved {
+    transform: translate(100px, 100px);
+  }
+</style>
+
+<div class='moved'>
+  <test-element class='moved'></test-element>
+</div>
+
+<script type="module">
+  import { createPopper } from '../dist/popper.js';
+
+  class TestElement extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.innerHTML = this.template;
+    }
+
+    connectedCallback() {
+      const reference = this.shadowRoot.querySelector('#reference');
+      const popper = this.shadowRoot.querySelector('#popper');
+
+      window.instance = createPopper(reference, popper, {
+        placement: 'bottom-start'
+      });
+    }
+
+    get template() {
+      return `
+                <style>
+  @import '/reset.css';
+
+                  #reference {
+                    width: 200px;
+                    height: 200px;
+                    background-color: red;
+                    box-shadow: inset 0 0 0 1px black;
+                  }
+
+                  #popper {
+                    width: 100px;
+                    height: 100px;
+                    background-color: rebeccapurple;
+                    box-shadow: inset 0 0 0 1px black;
+                  }
+                </style>
+                <div id='reference'>Reference Box</div>
+                <div id='popper'>Popper Box</div>
+            `;
+    }
+  }
+  customElements.define('test-element', TestElement);
+</script>

--- a/tests/visual/transform/shadow-dom-parent-translated.html
+++ b/tests/visual/transform/shadow-dom-parent-translated.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <title>Transform Visual Test</title>
+
+<style>
+  @import '/tests/visual/reset.css';
+
+  .moved {
+    transform: translate(100px, 100px);
+  }
+</style>
+
+<div class='moved'>
+  <test-element></test-element>
+</div>
+
+<script type="module">
+  import { createPopper } from '../dist/popper.js';
+
+  class TestElement extends HTMLElement {
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.innerHTML = this.template;
+    }
+
+    connectedCallback() {
+      const reference = this.shadowRoot.querySelector('#reference');
+      const popper = this.shadowRoot.querySelector('#popper');
+
+      window.instance = createPopper(reference, popper, {
+        placement: 'bottom-start'
+      });
+    }
+
+    get template() {
+      return `
+                <style>
+  @import '/reset.css';
+
+                  #reference {
+                    width: 200px;
+                    height: 200px;
+                    background-color: red;
+                    box-shadow: inset 0 0 0 1px black;
+                  }
+
+                  #popper {
+                    width: 100px;
+                    height: 100px;
+                    background-color: rebeccapurple;
+                    box-shadow: inset 0 0 0 1px black;
+                  }
+                </style>
+                <div id='reference'>Reference Box</div>
+                <div id='popper'>Popper Box</div>
+            `;
+    }
+  }
+  customElements.define('test-element', TestElement);
+</script>


### PR DESCRIPTION
Related issue: #1488 

This fixes a placement issue that is caused when the starting offset parent element is inside shadow DOM. You can see this in the following repro cases based on the original issue:

**w/ shadow DOM ❌**
https://codepen.io/jcfranco/pen/podrpaR

**w/o shadow DOM ✅**
https://codepen.io/jcfranco/pen/BamdJEK

Basically, if the starting element's parent is a shadow root, it would skip the containing-block block (ba dum tss 🥁). 

**Notes**

* I only modified `getOffsetParent` to use the host if the starting element's parent is a shadow root, but this may also be needed for [subsequent parent node lookups](https://github.com/jcfranco/floating-ui/blob/1094088a128e88e9a36401f24225b8457d34eaeb/src/dom-utils/getOffsetParent.js#L60).
* Related to ☝️, as an alternative, `getOffsetParent` could return the shadow root's host instead of the shadow root. This seems to align with the [previous version of the `"returns the shadow dom host"` test (`src/dom-utils/getParentNode.test.js`)](https://github.com/floating-ui/floating-ui/commit/fb79a18a3cf844f8db435b2dbdcf877fdaa85111). Let me know this would be the better approach.
* The following 5 visual tests were and are still failing (regardless of this PR):
  * `table-test-js-should-position-popper-on-right-when-reference-is-in-table-1-diff.png`
  * `table-test-js-should-position-popper-on-right-when-reference-and-popper-are-in-table-1-diff.png`
  * `table-test-js-should-position-popper-on-right-when-reference-is-in-table-inside-offset-parents-1-diff.png`
  * `table-test-js-should-position-popper-on-right-when-reference-and-popper-are-in-table-inside-offset-parents-1-diff.png`
  * `scrolling-fixed-test-js-should-handle-basic-offset-parent-1-diff.png`
* I added a few visual tests to cover some combinations.
