### PR TITLE
fix: `shift` middleware should be a part of `MiddlewareData` type

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -70,6 +70,7 @@ export type MiddlewareData = {
     skip?: boolean;
   };
   offset?: Coords;
+  shift?: Coords;
   [key: string]: any;
 };
 


### PR DESCRIPTION
According to the [middleware documentation](https://floating-ui.com/docs/shift#data), the middleware should return the values that the floating element has been shifted by in middleware data. All other middleware data are already a part of the `MiddlewareData` type except for `shift`.