### PR TITLE
feat(dom): autoUpdate

### DIFF
--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -17,6 +17,7 @@ export function autoUpdate(
   update: () => void,
   options: Partial<Options> = {}
 ) {
+  let cleanedUp = false;
   const everyFrame = options.everyFrame;
   const ancestorScroll = options.ancestorScroll && !everyFrame;
   const ancestorResize = options.ancestorResize && !everyFrame;
@@ -47,6 +48,10 @@ export function autoUpdate(
   }
 
   function frameLoop() {
+    if (cleanedUp) {
+      return;
+    }
+
     const nextRefRect = reference.getBoundingClientRect();
 
     if (
@@ -64,6 +69,8 @@ export function autoUpdate(
   }
 
   return () => {
+    cleanedUp = true;
+
     ancestors.forEach((ancestor) => {
       ancestorScroll && ancestor.removeEventListener('scroll', update);
       ancestorResize && ancestor.removeEventListener('resize', update);

--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -1,0 +1,80 @@
+import type {ClientRectObject} from '@floating-ui/core';
+import {getScrollableAncestors} from './utils/getScrollableAncestors';
+import {isElement} from './utils/is';
+
+type Options = {
+  ancestorScroll: boolean;
+  ancestorResize: boolean;
+  elementResize: boolean;
+  everyFrame: boolean;
+};
+
+export function autoUpdate(
+  reference:
+    | Element
+    | {getBoundingClientRect(): ClientRectObject; contextElement?: Element},
+  floating: HTMLElement,
+  update: () => void,
+  options: Partial<Options> = {}
+) {
+  const everyFrame = options.everyFrame;
+  const ancestorScroll = options.ancestorScroll && !everyFrame;
+  const ancestorResize = options.ancestorResize && !everyFrame;
+  const elementResize = options.elementResize && !everyFrame;
+
+  const ancestors = [
+    ...(isElement(reference) ? getScrollableAncestors(reference) : []),
+    ...getScrollableAncestors(floating),
+  ];
+
+  ancestors.forEach((ancestor) => {
+    ancestorScroll && ancestor.addEventListener('scroll', update);
+    ancestorResize && ancestor.addEventListener('resize', update);
+  });
+
+  let observer: ResizeObserver | null = null;
+  if (elementResize) {
+    observer = new ResizeObserver(update);
+    isElement(reference) && observer.observe(reference);
+    observer.observe(floating);
+  }
+
+  let frameId: number;
+  let prevRefRect = everyFrame ? reference.getBoundingClientRect() : null;
+
+  if (everyFrame) {
+    frameLoop();
+  }
+
+  function frameLoop() {
+    const nextRefRect = reference.getBoundingClientRect();
+
+    if (
+      prevRefRect &&
+      (nextRefRect.x !== prevRefRect.x ||
+        nextRefRect.y !== prevRefRect.y ||
+        nextRefRect.width !== prevRefRect.width ||
+        nextRefRect.height !== prevRefRect.height)
+    ) {
+      update();
+    }
+
+    prevRefRect = nextRefRect;
+    frameId = requestAnimationFrame(frameLoop);
+  }
+
+  return () => {
+    ancestors.forEach((ancestor) => {
+      ancestorScroll && ancestor.removeEventListener('scroll', update);
+      ancestorResize && ancestor.removeEventListener('resize', update);
+    });
+
+    if (elementResize) {
+      observer?.disconnect();
+    }
+
+    if (everyFrame) {
+      cancelAnimationFrame(frameId);
+    }
+  };
+}

--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -15,7 +15,12 @@ export function autoUpdate(
     | {getBoundingClientRect(): ClientRectObject; contextElement?: Element},
   floating: HTMLElement,
   update: () => void,
-  options: Partial<Options> = {}
+  options: Partial<Options> = {
+    ancestorScroll: true,
+    ancestorResize: true,
+    elementResize: true,
+    everyFrame: false,
+  }
 ) {
   let cleanedUp = false;
   const everyFrame = options.everyFrame;

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -31,4 +31,4 @@ export {
   detectOverflow,
 } from '@floating-ui/core';
 
-export {getScrollParents} from './utils/getScrollParents';
+export {getScrollableAncestors} from './utils/getScrollableAncestors';

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -31,4 +31,6 @@ export {
   detectOverflow,
 } from '@floating-ui/core';
 
+export {autoUpdate} from './autoUpdate';
+
 export {getScrollableAncestors} from './utils/getScrollableAncestors';

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -83,4 +83,4 @@ export type {
   Middleware,
 } from '@floating-ui/core';
 export {computePosition} from './';
-export {getScrollParents} from './utils/getScrollParents';
+export {getScrollableAncestors} from './utils/getScrollableAncestors';

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -83,4 +83,5 @@ export type {
   Middleware,
 } from '@floating-ui/core';
 export {computePosition} from './';
+export {autoUpdate} from './autoUpdate';
 export {getScrollableAncestors} from './utils/getScrollableAncestors';

--- a/packages/dom/src/utils/getClippingClientRect.ts
+++ b/packages/dom/src/utils/getClippingClientRect.ts
@@ -6,7 +6,7 @@ import {
 } from '@floating-ui/core';
 import {getViewportRect} from './getViewportRect';
 import {getDocumentRect} from './getDocumentRect';
-import {getScrollParents} from './getScrollParents';
+import {getScrollableAncestors} from './getScrollableAncestors';
 import {getOffsetParent} from './getOffsetParent';
 import {getDocumentElement} from './getDocumentElement';
 import {getComputedStyle} from './getComputedStyle';
@@ -52,7 +52,7 @@ function getClientRectFromClippingParent(
 // clipping (or hiding) overflowing elements with a position different from
 // `initial`
 function getClippingParents(element: Element): Array<Element> {
-  const clippingParents = getScrollParents(getParentNode(element));
+  const clippingParents = getScrollableAncestors(getParentNode(element));
   const canEscapeClipping = ['absolute', 'fixed'].includes(
     getComputedStyle(element).position
   );

--- a/packages/dom/src/utils/getNearestScrollableAncestor.ts
+++ b/packages/dom/src/utils/getNearestScrollableAncestor.ts
@@ -2,7 +2,7 @@ import {getParentNode} from './getParentNode';
 import {getNodeName} from './getNodeName';
 import {isScrollParent, isHTMLElement} from './is';
 
-export function getScrollParent(node: Node): HTMLElement {
+export function getNearestScrollableAncestor(node: Node): HTMLElement {
   if (['html', 'body', '#document'].includes(getNodeName(node))) {
     // @ts-ignore assume body is always available
     return node.ownerDocument.body;
@@ -12,5 +12,5 @@ export function getScrollParent(node: Node): HTMLElement {
     return node;
   }
 
-  return getScrollParent(getParentNode(node));
+  return getNearestScrollableAncestor(getParentNode(node));
 }

--- a/packages/dom/src/utils/getScrollableAncestors.ts
+++ b/packages/dom/src/utils/getScrollableAncestors.ts
@@ -1,13 +1,13 @@
-import {getScrollParent} from './getScrollParent';
+import {getNearestScrollableAncestor} from './getNearestScrollableAncestor';
 import {getParentNode} from './getParentNode';
 import {getWindow} from './window';
 import {isScrollParent} from './is';
 
-export function getScrollParents(
+export function getScrollableAncestors(
   node: Node,
   list: Array<Element | Window> = []
 ): Array<Element | Window | VisualViewport> {
-  const scrollParent = getScrollParent(node);
+  const scrollParent = getNearestScrollableAncestor(node);
   const isBody = scrollParent === node.ownerDocument?.body;
   const win = getWindow(scrollParent);
   const target = isBody
@@ -21,5 +21,5 @@ export function getScrollParents(
   return isBody
     ? updatedList
     : // @ts-ignore: isBody tells us target will be an HTMLElement here
-      updatedList.concat(getScrollParents(getParentNode(target)));
+      updatedList.concat(getScrollableAncestors(getParentNode(target)));
 }

--- a/packages/dom/test/visual/utils/useScroll.tsx
+++ b/packages/dom/test/visual/utils/useScroll.tsx
@@ -5,7 +5,11 @@ import {
   useRef,
   useState,
 } from 'react';
-import {getScrollParents, useFloating, shift} from '@floating-ui/react-dom';
+import {
+  getScrollableAncestors,
+  useFloating,
+  shift,
+} from '@floating-ui/react-dom';
 
 export const useScroll = ({
   refs,
@@ -44,8 +48,8 @@ export const useScroll = ({
     }
 
     const parents = [
-      ...getScrollParents(refs.reference.current),
-      ...getScrollParents(refs.floating.current),
+      ...getScrollableAncestors(refs.reference.current),
+      ...getScrollableAncestors(refs.floating.current),
     ];
 
     const localUpdate = () => {

--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -19,7 +19,7 @@ export {
   limitShift,
   size,
   inline,
-  getScrollParents,
+  getScrollableAncestors,
   detectOverflow,
 } from '@floating-ui/dom';
 

--- a/packages/react-dom/src/types.ts
+++ b/packages/react-dom/src/types.ts
@@ -10,7 +10,7 @@ export {
   size,
   inline,
   detectOverflow,
-  getScrollParents,
+  getScrollableAncestors,
 } from '@floating-ui/dom';
 
 export type {Platform, Placement, Strategy, Middleware} from '@floating-ui/dom';


### PR DESCRIPTION
Solves No. 3 in #1538

⚠️  WIP, needs tests, first I want to get the API ideas right

cc: @diondiondion

Firstly, `getScrollParents` has been renamed to `getScrollableAncestors` as I think it is more accurate. Though, it still considers `overflow: hidden` elements. Maybe, `getOverflowAncestors` instead?

Secondly, this export has 4 options and it looks like this:

```js
import {autoUpdate} from '@floating-ui/dom';

async function update() {
  // computePosition call in here
}

const cleanup = autoUpdate(reference, floating, update, {
  // default options
  ancestorScroll: true,
  ancestorResize: true,
  elementResize: true,
  everyFrame: false,
});
```

## ancestorScroll

Update whenever a scrollable ancestor is scrolled

## ancestorResize

Update whenever a scrollable ancestor is resized (as this is only the native `resize` event, only works on `window` and `VisualViewport`)

## elementResize

Update whenever the reference or floating elements change in size using a `ResizeObserver`

## everyFrame

Watch every frame for reference rect changes and only update when it changes location on the screen (e.g. for animations or general layout changes). This disables all the above listeners since they become unnecessary. I think there may be situations where the floating element needs to be updated even if its `clientRect` values didn't change, but sure of which.