### PR TITLE
refactor: rename `clippingParents` to `clippingAncestors`

### DIFF
--- a/packages/core/src/detectOverflow.ts
+++ b/packages/core/src/detectOverflow.ts
@@ -24,7 +24,7 @@ export type Options = {
   elementContext: ElementContext;
   /**
    * Whether to check for overflow using the alternate element's boundary
-   * (`clippingParents` boundary only).
+   * (`clippingAncestors` boundary only).
    */
   altBoundary: boolean;
   /**
@@ -47,7 +47,7 @@ export async function detectOverflow(
   const {x, y, platform, rects, elements, strategy} = middlewareArguments;
 
   const {
-    boundary = 'clippingParents',
+    boundary = 'clippingAncestors',
     rootBoundary = 'viewport',
     elementContext = 'floating',
     altBoundary = false,

--- a/packages/dom/index.test-d.ts
+++ b/packages/dom/index.test-d.ts
@@ -103,7 +103,7 @@ shift({
 });
 shift({boundary: document.body});
 shift({boundary: [document.body]});
-shift({boundary: 'clippingParents'});
+shift({boundary: 'clippingAncestors'});
 shift({limiter: limitShift()});
 shift({limiter: limitShift({offset: 5})});
 shift({limiter: limitShift({offset: {mainAxis: 5}})});
@@ -122,21 +122,21 @@ flip({
 });
 flip({boundary: document.body});
 flip({boundary: [document.body]});
-flip({boundary: 'clippingParents'});
+flip({boundary: 'clippingAncestors'});
 size({
   // @ts-expect-error
   boundary: '',
 });
 size({boundary: document.body});
 size({boundary: [document.body]});
-size({boundary: 'clippingParents'});
+size({boundary: 'clippingAncestors'});
 autoPlacement({
   // @ts-expect-error
   boundary: '',
 });
 size({boundary: document.body});
 size({boundary: [document.body]});
-size({boundary: 'clippingParents'});
+size({boundary: 'clippingAncestors'});
 
 offset();
 offset(5);
@@ -181,7 +181,7 @@ const middlewareWDetectOverflow: Middleware = {
     detectOverflow(args);
     detectOverflow(args, {
       elementContext: 'reference',
-      boundary: 'clippingParents',
+      boundary: 'clippingAncestors',
       rootBoundary: 'document',
       padding: 5,
       altBoundary: true,

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -18,7 +18,7 @@ export type DOMDetectOverflowOptions = Omit<
   DetectOverflowOptions,
   'boundary'
 > & {
-  boundary: 'clippingParents' | Element | Array<Element>;
+  boundary: 'clippingAncestors' | Element | Array<Element>;
 };
 
 /**

--- a/packages/dom/src/utils/getClippingClientRect.ts
+++ b/packages/dom/src/utils/getClippingClientRect.ts
@@ -33,7 +33,7 @@ function getInnerBoundingClientRect(element: Element): ClientRectObject {
   };
 }
 
-function getClientRectFromClippingParent(
+function getClientRectFromClippingAncestor(
   element: Element,
   clippingParent: Element | RootBoundary
 ): ClientRectObject {
@@ -51,8 +51,8 @@ function getClientRectFromClippingParent(
 // A "clipping parent" is an overflowable container with the characteristic of
 // clipping (or hiding) overflowing elements with a position different from
 // `initial`
-function getClippingParents(element: Element): Array<Element> {
-  const clippingParents = getOverflowAncestors(getParentNode(element));
+function getClippingAncestors(element: Element): Array<Element> {
+  const clippingAncestors = getOverflowAncestors(getParentNode(element));
   const canEscapeClipping = ['absolute', 'fixed'].includes(
     getComputedStyle(element).position
   );
@@ -66,11 +66,11 @@ function getClippingParents(element: Element): Array<Element> {
   }
 
   // @ts-ignore isElement check ensures we return Array<Element>
-  return clippingParents.filter(
-    (clippingParent) =>
-      isElement(clippingParent) &&
-      contains(clippingParent, clipperElement) &&
-      getNodeName(clippingParent) !== 'body'
+  return clippingAncestors.filter(
+    (clippingAncestors) =>
+      isElement(clippingAncestors) &&
+      contains(clippingAncestors, clipperElement) &&
+      getNodeName(clippingAncestors) !== 'body'
   );
 }
 
@@ -85,15 +85,15 @@ export function getClippingClientRect({
   boundary: Boundary;
   rootBoundary: RootBoundary;
 }): ClientRectObject {
-  const mainClippingParents =
-    boundary === 'clippingParents'
-      ? getClippingParents(element)
+  const mainClippingAncestors =
+    boundary === 'clippingAncestors'
+      ? getClippingAncestors(element)
       : [].concat(boundary);
-  const clippingParents = [...mainClippingParents, rootBoundary];
-  const firstClippingParent = clippingParents[0];
+  const clippingAncestors = [...mainClippingAncestors, rootBoundary];
+  const firstClippingAncestor = clippingAncestors[0];
 
-  const clippingRect = clippingParents.reduce((accRect, clippingParent) => {
-    const rect = getClientRectFromClippingParent(element, clippingParent);
+  const clippingRect = clippingAncestors.reduce((accRect, clippingAncestor) => {
+    const rect = getClientRectFromClippingAncestor(element, clippingAncestor);
 
     accRect.top = max(rect.top, accRect.top);
     accRect.right = min(rect.right, accRect.right);
@@ -101,7 +101,7 @@ export function getClippingClientRect({
     accRect.left = max(rect.left, accRect.left);
 
     return accRect;
-  }, getClientRectFromClippingParent(element, firstClippingParent));
+  }, getClientRectFromClippingAncestor(element, firstClippingAncestor));
 
   clippingRect.width = clippingRect.right - clippingRect.left;
   clippingRect.height = clippingRect.bottom - clippingRect.top;

--- a/packages/dom/src/utils/getClippingClientRect.ts
+++ b/packages/dom/src/utils/getClippingClientRect.ts
@@ -48,7 +48,7 @@ function getClientRectFromClippingAncestor(
   return rectToClientRect(getDocumentRect(getDocumentElement(element)));
 }
 
-// A "clipping parent" is an overflowable container with the characteristic of
+// A "clipping ancestor" is an overflowable container with the characteristic of
 // clipping (or hiding) overflowing elements with a position different from
 // `initial`
 function getClippingAncestors(element: Element): Array<Element> {
@@ -75,7 +75,7 @@ function getClippingAncestors(element: Element): Array<Element> {
 }
 
 // Gets the maximum area that the element is visible in due to any number of
-// clipping parents
+// clipping ancestors
 export function getClippingClientRect({
   element,
   boundary,


### PR DESCRIPTION
In line with `getOverflowAncestors` renaming.