### PR TITLE
feat(hide): pass options

### DIFF
--- a/packages/core/src/computePosition.ts
+++ b/packages/core/src/computePosition.ts
@@ -1,4 +1,8 @@
-import type {ComputePosition, ComputePositionReturn} from './types';
+import type {
+  ComputePosition,
+  ComputePositionReturn,
+  MiddlewareData,
+} from './types';
 import {computeCoordsFromPlacement} from './computeCoordsFromPlacement';
 
 /**
@@ -51,7 +55,7 @@ export const computePosition: ComputePosition = async (
   let rects = await platform.getElementRects({reference, floating, strategy});
   let {x, y} = computeCoordsFromPlacement({...rects, placement, rtl});
   let statefulPlacement = placement;
-  let middlewareData = {};
+  let middlewareData: MiddlewareData = {};
 
   const skippedMiddlewareNames = new Set<string>();
 
@@ -96,7 +100,13 @@ export const computePosition: ComputePosition = async (
     x = nextX ?? x;
     y = nextY ?? y;
 
-    middlewareData = {...middlewareData, [name]: data ?? {}};
+    middlewareData = {
+      ...middlewareData,
+      [name]: {
+        ...middlewareData[name],
+        ...data,
+      },
+    };
 
     if (reset) {
       if (typeof reset === 'object') {

--- a/packages/core/src/middleware/hide.ts
+++ b/packages/core/src/middleware/hide.ts
@@ -1,6 +1,9 @@
 import type {Middleware, Rect, SideObject} from '../types';
 import {sides} from '../enums';
-import {detectOverflow} from '../detectOverflow';
+import {
+  detectOverflow,
+  Options as DetectOverflowOptions,
+} from '../detectOverflow';
 
 function getSideOffsets(overflow: SideObject, rect: Rect) {
   return {
@@ -15,39 +18,53 @@ function isAnySideFullyClipped(overflow: SideObject) {
   return sides.some((side) => overflow[side] >= 0);
 }
 
+export interface Options {
+  strategy: 'referenceHidden' | 'escaped';
+}
+
 /**
  * Provides data to hide the floating element in applicable situations, such as
  * when it is not in the same clipping context as the reference element.
  * @see https://floating-ui.com/docs/hide
  */
-export const hide = (): Middleware => ({
+export const hide = ({
+  strategy,
+  ...detectOverflowOptions
+}: Partial<Options & DetectOverflowOptions> = {}): Middleware => ({
   name: 'hide',
-  async fn(modifierArguments) {
-    const referenceOverflow = await detectOverflow(modifierArguments, {
-      elementContext: 'reference',
-    });
-    const floatingAltOverflow = await detectOverflow(modifierArguments, {
-      altBoundary: true,
-    });
+  async fn(middlewareArguments) {
+    const {rects} = middlewareArguments;
 
-    const referenceHiddenOffsets = getSideOffsets(
-      referenceOverflow,
-      modifierArguments.rects.reference
-    );
-    const escapedOffsets = getSideOffsets(
-      floatingAltOverflow,
-      modifierArguments.rects.floating
-    );
-    const referenceHidden = isAnySideFullyClipped(referenceHiddenOffsets);
-    const escaped = isAnySideFullyClipped(escapedOffsets);
-
-    return {
-      data: {
-        referenceHidden,
-        referenceHiddenOffsets,
-        escaped,
-        escapedOffsets,
-      },
-    };
+    switch (strategy) {
+      case 'referenceHidden': {
+        const overflow = await detectOverflow(middlewareArguments, {
+          ...detectOverflowOptions,
+          elementContext: 'reference',
+        });
+        const offsets = getSideOffsets(overflow, rects.reference);
+        return {
+          data: {
+            referenceHiddenOffsets: offsets,
+            referenceHidden: isAnySideFullyClipped(offsets),
+          },
+        };
+      }
+      case 'escaped': {
+        const overflow = await detectOverflow(middlewareArguments, {
+          ...detectOverflowOptions,
+          altBoundary: true,
+        });
+        const offsets = getSideOffsets(overflow, rects.floating);
+        return {
+          data: {
+            escapedOffsets: offsets,
+            escaped: isAnySideFullyClipped(offsets),
+          },
+        };
+      }
+      default: {
+        return {};
+      }
+    }
   },
 });

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -10,6 +10,7 @@ import type {Options as AutoPlacementOptions} from '@floating-ui/core/src/middle
 import type {Options as SizeOptions} from '@floating-ui/core/src/middleware/size';
 import type {Options as FlipOptions} from '@floating-ui/core/src/middleware/flip';
 import type {Options as ShiftOptions} from '@floating-ui/core/src/middleware/shift';
+import type {Options as HideOptions} from '@floating-ui/core/src/middleware/hide';
 
 export interface NodeScroll {
   scrollLeft: number;
@@ -84,6 +85,15 @@ declare const arrow: (options: {
 }) => Middleware;
 
 /**
+ * Provides data to hide the floating element in applicable situations, such as
+ * when it is not in the same clipping context as the reference element.
+ * @see https://floating-ui.com/docs/hide
+ */
+declare const hide: (
+  options?: Partial<HideOptions & DetectOverflowOptions>
+) => Middleware;
+
+/**
  * Resolves with an object of overflow side offsets that determine how much the
  * element is overflowing a given clipping boundary.
  * - positive = overflowing the boundary by that number of pixels
@@ -95,8 +105,8 @@ declare const detectOverflow: (
   options?: Partial<DetectOverflowOptions>
 ) => Promise<SideObject>;
 
-export {autoPlacement, shift, arrow, size, flip, detectOverflow};
-export {hide, offset, limitShift, inline} from '@floating-ui/core';
+export {autoPlacement, shift, arrow, size, flip, hide, detectOverflow};
+export {offset, limitShift, inline} from '@floating-ui/core';
 export type {
   Platform,
   Placement,

--- a/packages/dom/test/visual/spec/Hide.tsx
+++ b/packages/dom/test/visual/spec/Hide.tsx
@@ -18,7 +18,10 @@ export function Hide() {
     middlewareData: {hide: {referenceHidden, escaped} = {}},
   } = useFloating({
     placement,
-    middleware: [hide()],
+    middleware: [
+      hide({strategy: 'referenceHidden'}),
+      hide({strategy: 'escaped'}),
+    ],
   });
 
   const {scrollRef, indicator} = useScroll({refs, update});


### PR DESCRIPTION
Closes #1252

Since there are two calls this changes the API of `hide` to only accept a `strategy` string so there's only one call. Now you can pass `...detectOverflowOptions` in.

To get both properties as before, just pass two of them in:

```js
middleware: [
  hide({strategy: 'referenceHidden'}),
  hide({strategy: 'escaped'})
],
```