### PR TITLE
build: change .cjs to .js in main field

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/floating-ui.core.cjs",
+  "main": "dist/floating-ui.core.js",
   "module": "dist/floating-ui.core.esm.js",
   "unpkg": "dist/floating-ui.core.min.js",
   "type": "module",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -12,7 +12,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/floating-ui.dom.cjs",
+  "main": "dist/floating-ui.dom.js",
   "module": "dist/floating-ui.dom.esm.js",
   "unpkg": "dist/floating-ui.dom.min.js",
   "type": "module",

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -12,7 +12,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/floating-ui.react-dom.cjs",
+  "main": "dist/floating-ui.react-dom.js",
   "module": "dist/floating-ui.react-dom.esm.js",
   "unpkg": "dist/floating-ui.react-dom.min.js",
   "type": "module",


### PR DESCRIPTION
https://github.com/floating-ui/floating-ui/pull/1529

This breaks native CJS which tries to use the `main` field (but it should use the `require` conditional export); should fix various webpack build setups which try to use `.cjs` as a transitive dep