### PR TITLE
refactor: platform

### DIFF
--- a/packages/core/src/detectOverflow.ts
+++ b/packages/core/src/detectOverflow.ts
@@ -64,15 +64,17 @@ export async function detectOverflow(
   const altContext = elementContext === 'floating' ? 'reference' : 'floating';
   const element = elements[altBoundary ? altContext : elementContext];
 
-  const clippingClientRect = await platform.getClippingClientRect({
-    element:
-      (await platform.isElement?.(element)) ?? true
-        ? element
-        : element.contextElement ||
-          (await platform.getDocumentElement?.({element: elements.floating})),
-    boundary,
-    rootBoundary,
-  });
+  const clippingClientRect = rectToClientRect(
+    await platform.getClippingRect({
+      element:
+        (await platform.isElement?.(element)) ?? true
+          ? element
+          : element.contextElement ||
+            (await platform.getDocumentElement?.(elements.floating)),
+      boundary,
+      rootBoundary,
+    })
+  );
 
   const elementClientRect = rectToClientRect(
     platform.convertOffsetParentRelativeRectToViewportRelativeRect
@@ -81,9 +83,7 @@ export async function detectOverflow(
             elementContext === 'floating'
               ? {...rects.floating, x, y}
               : rects.reference,
-          offsetParent: await platform.getOffsetParent?.({
-            element: elements.floating,
-          }),
+          offsetParent: await platform.getOffsetParent?.(elements.floating),
           strategy,
         })
       : rects[elementContext]

--- a/packages/core/src/middleware/arrow.ts
+++ b/packages/core/src/middleware/arrow.ts
@@ -44,7 +44,7 @@ export const arrow = (options: Options): Middleware => ({
     const coords = {x, y};
     const axis = getMainAxisFromPlacement(placement);
     const length = getLengthFromAxis(axis);
-    const arrowDimensions = await platform.getDimensions({element});
+    const arrowDimensions = await platform.getDimensions(element);
     const minProp = axis === 'y' ? 'top' : 'left';
     const maxProp = axis === 'y' ? 'bottom' : 'right';
 
@@ -55,7 +55,7 @@ export const arrow = (options: Options): Middleware => ({
       rects.floating[length];
     const startDiff = coords[axis] - rects.reference[axis];
 
-    const arrowOffsetParent = await platform.getOffsetParent?.({element});
+    const arrowOffsetParent = await platform.getOffsetParent?.(element);
     const clientSize = arrowOffsetParent
       ? axis === 'y'
         ? arrowOffsetParent.clientHeight || 0

--- a/packages/core/src/middleware/inline.ts
+++ b/packages/core/src/middleware/inline.ts
@@ -45,15 +45,13 @@ export const inline = (options: Partial<Options> = {}): Middleware => ({
       platform.convertOffsetParentRelativeRectToViewportRelativeRect
         ? await platform.convertOffsetParentRelativeRectToViewportRelativeRect({
             rect: rects.reference,
-            offsetParent: await platform.getOffsetParent?.({
-              element: elements.floating,
-            }),
+            offsetParent: await platform.getOffsetParent?.(elements.floating),
             strategy,
           })
         : rects.reference
     );
     const clientRects = Array.from(
-      (await platform.getClientRects?.({element: elements.reference})) ?? []
+      (await platform.getClientRects?.(elements.reference)) ?? []
     );
     const paddingObject = getSideObjectFromPadding(padding);
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -19,12 +19,12 @@ export interface Platform {
     floating: FloatingElement;
     strategy: Strategy;
   }) => Promisable<ElementRects>;
-  getClippingClientRect: (args: {
+  getClippingRect: (args: {
     element: any;
     boundary: Boundary;
     rootBoundary: RootBoundary;
-  }) => Promisable<ClientRectObject>;
-  getDimensions: (args: {element: any}) => Promisable<Dimensions>;
+  }) => Promisable<Rect>;
+  getDimensions: (element: any) => Promisable<Dimensions>;
 
   // Optional
   convertOffsetParentRelativeRectToViewportRelativeRect?: (args: {
@@ -32,13 +32,11 @@ export interface Platform {
     offsetParent: any;
     strategy: Strategy;
   }) => Promisable<Rect>;
-  getOffsetParent?: (args: {element: any}) => Promisable<any>;
-  isElement?: (value: unknown) => Promisable<boolean>;
-  getDocumentElement?: (args: {element: any}) => Promisable<any>;
-  getClientRects?: (args: {
-    element: any;
-  }) => Promisable<Array<ClientRectObject>>;
-  isRTL?: (reference: ReferenceElement) => Promisable<boolean>;
+  getOffsetParent?: (element: any) => Promisable<any>;
+  isElement?: (value: any) => Promisable<boolean>;
+  getDocumentElement?: (element: any) => Promisable<any>;
+  getClientRects?: (element: any) => Promisable<Array<ClientRectObject>>;
+  isRTL?: (element: any) => Promisable<boolean>;
 }
 
 export type Coords = {[key in Axis]: number};

--- a/packages/dom/src/platform.ts
+++ b/packages/dom/src/platform.ts
@@ -5,10 +5,16 @@ import {getDimensions} from './utils/getDimensions';
 import {convertOffsetParentRelativeRectToViewportRelativeRect} from './utils/convertOffsetParentRelativeRectToViewportRelativeRect';
 import {isElement} from './utils/is';
 import {getDocumentElement} from './utils/getDocumentElement';
-import {getClippingClientRect} from './utils/getClippingClientRect';
+import {getClippingRect} from './utils/getClippingRect';
 import {getComputedStyle} from './utils/getComputedStyle';
 
 export const platform: Platform = {
+  getClippingRect,
+  convertOffsetParentRelativeRectToViewportRelativeRect,
+  isElement,
+  getDimensions,
+  getOffsetParent,
+  getDocumentElement,
   getElementRects: ({reference, floating, strategy}) => ({
     reference: getRectRelativeToOffsetParent(
       reference,
@@ -17,12 +23,6 @@ export const platform: Platform = {
     ),
     floating: {...getDimensions(floating), x: 0, y: 0},
   }),
-  convertOffsetParentRelativeRectToViewportRelativeRect,
-  getOffsetParent: ({element}) => getOffsetParent(element),
-  isElement,
-  getDocumentElement: ({element}) => getDocumentElement(element),
-  getClippingClientRect,
-  getDimensions: ({element}) => getDimensions(element),
-  getClientRects: ({element}) => element.getClientRects(),
-  isRTL: (reference) => getComputedStyle(reference).direction === 'rtl',
+  getClientRects: (element) => element.getClientRects(),
+  isRTL: (element) => getComputedStyle(element).direction === 'rtl',
 };

--- a/packages/dom/src/utils/getClippingRect.ts
+++ b/packages/dom/src/utils/getClippingRect.ts
@@ -3,6 +3,7 @@ import {
   ClientRectObject,
   Boundary,
   RootBoundary,
+  Rect,
 } from '@floating-ui/core';
 import {getViewportRect} from './getViewportRect';
 import {getDocumentRect} from './getDocumentRect';
@@ -76,7 +77,7 @@ function getClippingAncestors(element: Element): Array<Element> {
 
 // Gets the maximum area that the element is visible in due to any number of
 // clipping ancestors
-export function getClippingClientRect({
+export function getClippingRect({
   element,
   boundary,
   rootBoundary,
@@ -84,7 +85,7 @@ export function getClippingClientRect({
   element: Element;
   boundary: Boundary;
   rootBoundary: RootBoundary;
-}): ClientRectObject {
+}): Rect {
   const mainClippingAncestors =
     boundary === 'clippingAncestors'
       ? getClippingAncestors(element)
@@ -103,10 +104,10 @@ export function getClippingClientRect({
     return accRect;
   }, getClientRectFromClippingAncestor(element, firstClippingAncestor));
 
-  clippingRect.width = clippingRect.right - clippingRect.left;
-  clippingRect.height = clippingRect.bottom - clippingRect.top;
-  clippingRect.x = clippingRect.left;
-  clippingRect.y = clippingRect.top;
-
-  return clippingRect;
+  return {
+    width: clippingRect.right - clippingRect.left,
+    height: clippingRect.bottom - clippingRect.top,
+    x: clippingRect.left,
+    y: clippingRect.top,
+  };
 }

--- a/packages/react-native/src/createPlatform.ts
+++ b/packages/react-native/src/createPlatform.ts
@@ -1,9 +1,5 @@
 import {Dimensions} from 'react-native';
-import {
-  Platform,
-  Dimensions as DimensionsType,
-  rectToClientRect,
-} from '@floating-ui/core';
+import {Platform, Dimensions as DimensionsType} from '@floating-ui/core';
 
 const ORIGIN = {x: 0, y: 0};
 
@@ -50,15 +46,13 @@ export const createPlatform = ({
       }
     });
   },
-  getClippingClientRect() {
+  getClippingRect() {
     const {width, height} = Dimensions.get('window');
-    return Promise.resolve(
-      rectToClientRect({
-        width,
-        height,
-        ...(sameScrollView ? scrollOffsets : ORIGIN),
-      })
-    );
+    return Promise.resolve({
+      width,
+      height,
+      ...(sameScrollView ? scrollOffsets : ORIGIN),
+    });
   },
   convertOffsetParentRelativeRectToViewportRelativeRect({rect}) {
     return new Promise((resolve) => {
@@ -73,20 +67,10 @@ export const createPlatform = ({
       }
     });
   },
-  getDocumentElement: () => Promise.resolve({}),
-  // these are the properties accessed on an offsetParent
-  getOffsetParent: () =>
-    Promise.resolve({
-      clientLeft: 0,
-      clientTop: 0,
-      clientWidth: 0,
-      clientHeight: 0,
-    }),
   getDimensions: ({element}) =>
     new Promise((resolve) =>
       element.measure(({width, height}: DimensionsType) =>
         resolve({width, height})
       )
     ),
-  isElement: () => Promise.resolve(true),
 });


### PR DESCRIPTION
- `({element})` => `(element)` as it's unlikely more properties will be added to the argument
- `getClippingClientRect` => `getClippingRect` for consistency and simplicity