### PR TITLE
fix(dom): getOverflowAncestors should ignore current node

### DIFF
--- a/packages/dom/src/utils/getClippingRect.ts
+++ b/packages/dom/src/utils/getClippingRect.ts
@@ -13,7 +13,6 @@ import {getDocumentElement} from './getDocumentElement';
 import {getComputedStyle} from './getComputedStyle';
 import {isElement, isHTMLElement} from './is';
 import {getBoundingClientRect} from './getBoundingClientRect';
-import {getParentNode} from './getParentNode';
 import {contains} from './contains';
 import {getNodeName} from './getNodeName';
 import {max, min} from './math';
@@ -53,7 +52,7 @@ function getClientRectFromClippingAncestor(
 // clipping (or hiding) overflowing elements with a position different from
 // `initial`
 function getClippingAncestors(element: Element): Array<Element> {
-  const clippingAncestors = getOverflowAncestors(getParentNode(element));
+  const clippingAncestors = getOverflowAncestors(element);
   const canEscapeClipping = ['absolute', 'fixed'].includes(
     getComputedStyle(element).position
   );

--- a/packages/dom/src/utils/getNearestOverflowAncestor.ts
+++ b/packages/dom/src/utils/getNearestOverflowAncestor.ts
@@ -3,14 +3,16 @@ import {getNodeName} from './getNodeName';
 import {isOverflowElement, isHTMLElement} from './is';
 
 export function getNearestOverflowAncestor(node: Node): HTMLElement {
-  if (['html', 'body', '#document'].includes(getNodeName(node))) {
+  const parentNode = getParentNode(node);
+
+  if (['html', 'body', '#document'].includes(getNodeName(parentNode))) {
     // @ts-ignore assume body is always available
     return node.ownerDocument.body;
   }
 
-  if (isHTMLElement(node) && isOverflowElement(node)) {
-    return node;
+  if (isHTMLElement(parentNode) && isOverflowElement(parentNode)) {
+    return parentNode;
   }
 
-  return getNearestOverflowAncestor(getParentNode(node));
+  return getNearestOverflowAncestor(parentNode);
 }


### PR DESCRIPTION
If the floating element is scrollable it gets considered as a scrollable ancestor but should be ignored.