### PR TITLE
fix: delete skipped middleware names

### DIFF
--- a/packages/core/src/computePosition.ts
+++ b/packages/core/src/computePosition.ts
@@ -77,6 +77,7 @@ export const computePosition: ComputePosition = async (
     const {name, fn} = middleware[i];
 
     if (skippedMiddlewareNames.has(name)) {
+      skippedMiddlewareNames.delete(name);
       continue;
     }
 

--- a/packages/dom/test/visual/spec/Inline.tsx
+++ b/packages/dom/test/visual/spec/Inline.tsx
@@ -1,5 +1,5 @@
 import {Coords, Placement} from '@floating-ui/core';
-import {useFloating, inline, flip} from '@floating-ui/react-dom';
+import {useFloating, inline, flip, size} from '@floating-ui/react-dom';
 import React, {useRef, useState} from 'react';
 import {allPlacements} from '../utils/allPlacements';
 import {Controls} from '../utils/Controls';
@@ -19,7 +19,7 @@ export function Inline() {
   const mouseCoordsRef = useRef<undefined | Coords>();
   const {x, y, reference, floating, strategy} = useFloating({
     placement,
-    middleware: [inline(mouseCoordsRef.current), flip()],
+    middleware: [inline(mouseCoordsRef.current), flip(), size()],
   });
 
   const handleMouseEnter = (event: React.MouseEvent<HTMLElement>) => {


### PR DESCRIPTION
Closes #1570

Allows the middleware lifecycle `[inline(), size()]` to work like before:

- `inline`
- reset
- `inline` skipped
- `size`
- reset
- `inline`
- reset
- `inline` skipped
- `size` skipped
- done