### PR TITLE
refactor: remove skipping

### DIFF
--- a/packages/core/src/computePosition.ts
+++ b/packages/core/src/computePosition.ts
@@ -57,8 +57,6 @@ export const computePosition: ComputePosition = async (
   let statefulPlacement = placement;
   let middlewareData: MiddlewareData = {};
 
-  const skippedMiddlewareNames = new Set<string>();
-
   let _debug_loop_count_ = 0;
   for (let i = 0; i < middleware.length; i++) {
     if (__DEV__) {
@@ -75,11 +73,6 @@ export const computePosition: ComputePosition = async (
     }
 
     const {name, fn} = middleware[i];
-
-    if (skippedMiddlewareNames.has(name)) {
-      skippedMiddlewareNames.delete(name);
-      continue;
-    }
 
     const {
       x: nextX,
@@ -123,10 +116,6 @@ export const computePosition: ComputePosition = async (
         }
 
         ({x, y} = computeCoordsFromPlacement(rects, statefulPlacement, rtl));
-
-        if (reset.skip !== false) {
-          skippedMiddlewareNames.add(name);
-        }
       }
 
       i = -1;

--- a/packages/core/src/middleware/autoPlacement.ts
+++ b/packages/core/src/middleware/autoPlacement.ts
@@ -92,6 +92,11 @@ export const autoPlacement = (
 
     const currentIndex = middlewareData.autoPlacement?.index ?? 0;
     const currentPlacement = placements[currentIndex];
+
+    if (currentPlacement == null) {
+      return {};
+    }
+
     const {main, cross} = getAlignmentSides(
       currentPlacement,
       rects,
@@ -104,7 +109,6 @@ export const autoPlacement = (
         x,
         y,
         reset: {
-          skip: false,
           placement: placements[0],
         },
       };
@@ -131,7 +135,6 @@ export const autoPlacement = (
           overflows: allOverflows,
         },
         reset: {
-          skip: false,
           placement: nextPlacement,
         },
       };
@@ -144,12 +147,22 @@ export const autoPlacement = (
       ({overflows}) => overflows.every((overflow) => overflow <= 0)
     )?.placement;
 
-    return {
-      reset: {
-        placement:
-          placementThatFitsOnAllSides ??
-          placementsSortedByLeastOverflow[0].placement,
-      },
-    };
+    const resetPlacement =
+      placementThatFitsOnAllSides ??
+      placementsSortedByLeastOverflow[0].placement;
+
+    if (resetPlacement !== placement) {
+      return {
+        data: {
+          index: currentIndex + 1,
+          overflows: allOverflows,
+        },
+        reset: {
+          placement: resetPlacement,
+        },
+      };
+    }
+
+    return {};
   },
 });

--- a/packages/core/src/middleware/flip.ts
+++ b/packages/core/src/middleware/flip.ts
@@ -113,7 +113,6 @@ export const flip = (
             overflows: overflowsData,
           },
           reset: {
-            skip: false,
             placement: nextPlacement,
           },
         };
@@ -144,11 +143,13 @@ export const flip = (
         default:
       }
 
-      return {
-        reset: {
-          placement: resetPlacement,
-        },
-      };
+      if (placement !== resetPlacement) {
+        return {
+          reset: {
+            placement: resetPlacement,
+          },
+        };
+      }
     }
 
     return {};

--- a/packages/core/src/middleware/inline.ts
+++ b/packages/core/src/middleware/inline.ts
@@ -129,14 +129,25 @@ export const inline = (options: Partial<Options> = {}): Middleware => ({
       return fallback;
     }
 
-    return {
-      reset: {
-        rects: await platform.getElementRects({
-          reference: {getBoundingClientRect},
-          floating: elements.floating,
-          strategy,
-        }),
-      },
-    };
+    const resetRects = await platform.getElementRects({
+      reference: {getBoundingClientRect},
+      floating: elements.floating,
+      strategy,
+    });
+
+    if (
+      rects.reference.x !== resetRects.reference.x ||
+      rects.reference.y !== resetRects.reference.y ||
+      rects.reference.width !== resetRects.reference.width ||
+      rects.reference.height !== resetRects.reference.height
+    ) {
+      return {
+        reset: {
+          rects: resetRects,
+        },
+      };
+    }
+
+    return {};
   },
 });

--- a/packages/core/src/middleware/size.ts
+++ b/packages/core/src/middleware/size.ts
@@ -77,12 +77,23 @@ export const size = (
           : overflow[widthSide]),
     };
 
+    const prevDimensions = await platform.getDimensions(elements.floating);
+
     apply?.({...dimensions, ...rects});
 
-    return {
-      reset: {
-        rects: true,
-      },
-    };
+    const nextDimensions = await platform.getDimensions(elements.floating);
+
+    if (
+      prevDimensions.width !== nextDimensions.width ||
+      prevDimensions.height !== nextDimensions.height
+    ) {
+      return {
+        reset: {
+          rects: true,
+        },
+      };
+    }
+
+    return {};
   },
 });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -100,7 +100,6 @@ export interface MiddlewareReturn extends Partial<Coords> {
     | {
         placement?: Placement;
         rects?: true | ElementRects;
-        skip?: false;
       };
 }
 

--- a/packages/dom/test/visual/spec/Inline.tsx
+++ b/packages/dom/test/visual/spec/Inline.tsx
@@ -1,6 +1,6 @@
 import {Coords, Placement} from '@floating-ui/core';
 import {useFloating, inline, flip, size} from '@floating-ui/react-dom';
-import React, {useRef, useState} from 'react';
+import React, {useLayoutEffect, useRef, useState} from 'react';
 import {allPlacements} from '../utils/allPlacements';
 import {Controls} from '../utils/Controls';
 
@@ -17,7 +17,7 @@ export function Inline() {
   const [open, setOpen] = useState(false);
   const [status, setStatus] = useState<ConnectedStatus>('2-disjoined');
   const mouseCoordsRef = useRef<undefined | Coords>();
-  const {x, y, reference, floating, strategy} = useFloating({
+  const {x, y, reference, floating, strategy, update} = useFloating({
     placement,
     middleware: [inline(mouseCoordsRef.current), flip(), size()],
   });
@@ -50,6 +50,8 @@ export function Inline() {
       break;
     default:
   }
+
+  useLayoutEffect(update, [update, status]);
 
   return (
     <>


### PR DESCRIPTION
Skipping avoided doing unneeded work after a `reset`, but it's difficult to know when a middleware can be skipped when other middleware cause resets, resulting in either stale logic or an infinite loop, so this removes it entirely for now.

Each middleware now checks if it needs to cause a `reset` without relying on skipping.

- ✅  Always runs when it needs to
- ✅  No infinite loops possible
- ⚠️ Slightly reduced perf