### PR TITLE
Add workflow_dispatch for manual releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   repository_dispatch:
     types: [rollingversions_publish_approved]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Unfortunately GitHub doesn't let us specify a branch with a `repository_dispatch` event, so they can only be used to release from the default branch. If you need to release from a different branch, you can use a `workflow_dispatch` instead. This will let you manually trigger the workflow on your desired branch from the GitHub actions UI.

I plan on updating Rolling Versions to use `workflow_dispatch` in the future as well, this will likely be done by allowing custom configuration of the trigger with something like:

```toml
[release_trigger]
  type = "github_workflow_trigger"
  name = "release"
```

This likely will not be ready for at least a month or two though. For now, you can specify both `repository_dispatch` and `workflow_dispatch` in your workflow file, and then use the GitHub UI when you need to release from a custom branch.