### PR TITLE
fix(dom): type elements in MiddlewareArguments

### DIFF
--- a/packages/dom/index.test-d.ts
+++ b/packages/dom/index.test-d.ts
@@ -170,7 +170,10 @@ const middleware: Middleware = {
   name: 'test',
   fn(args) {
     const {elements} = args;
-    elements.floating;
+    // @ts-expect-error
+    elements.floating.$$unknown$$;
+    // @ts-expect-error
+    elements.reference.focus();
     return {};
   },
 };

--- a/packages/dom/index.test-d.ts
+++ b/packages/dom/index.test-d.ts
@@ -1,4 +1,3 @@
-import {Middleware} from '@floating-ui/core';
 import {
   computePosition,
   shift,
@@ -10,6 +9,7 @@ import {
   size,
   arrow,
   detectOverflow,
+  Middleware,
 } from '.';
 
 // @ts-expect-error
@@ -168,7 +168,9 @@ const middlewareWithoutName: Middleware = {
 
 const middleware: Middleware = {
   name: 'test',
-  fn() {
+  fn(args) {
+    const {elements} = args;
+    elements.floating;
     return {};
   },
 };

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -1,6 +1,5 @@
 import type {
-  Middleware,
-  MiddlewareArguments,
+  Middleware as CoreMiddleware,
   SideObject,
   ClientRectObject,
   Padding,
@@ -9,6 +8,8 @@ import type {
   RootBoundary,
   Rect,
   Dimensions,
+  MiddlewareArguments as CoreMiddlewareArguments,
+  MiddlewareReturn,
 } from '@floating-ui/core';
 import type {Options as CoreDetectOverflowOptions} from '@floating-ui/core/src/detectOverflow';
 import type {Options as AutoPlacementOptions} from '@floating-ui/core/src/middleware/autoPlacement';
@@ -77,6 +78,14 @@ export interface Elements {
   reference: ReferenceElement;
   floating: FloatingElement;
 }
+
+export type MiddlewareArguments = Omit<CoreMiddlewareArguments, 'elements'> & {
+  elements: Elements;
+};
+
+export type Middleware = Omit<CoreMiddleware, 'fn'> & {
+  fn(args: MiddlewareArguments): Promisable<MiddlewareReturn>;
+};
 
 /**
  * Automatically chooses the `placement` which has the most space available.
@@ -151,7 +160,6 @@ export {offset, limitShift, inline} from '@floating-ui/core';
 export type {
   Placement,
   Strategy,
-  Middleware,
   Alignment,
   Side,
   AlignedPlacement,
@@ -166,7 +174,6 @@ export type {
   ClientRectObject,
   Padding,
   RootBoundary,
-  MiddlewareArguments,
   MiddlewareReturn,
   MiddlewareData,
   ComputePositionConfig,


### PR DESCRIPTION
Previously typed as `any`