### PR TITLE
Bugfix: element positioning with strategy fixed and containig block in Popper v2

### DIFF
--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -120,7 +120,7 @@ export function mapToStyles({
     ) {
       sideY = bottom;
       const offsetY =
-        isFixed && win.visualViewport
+        isFixed && offsetParent === win && win.visualViewport
           ? win.visualViewport.height
           : // $FlowFixMe[prop-missing]
             offsetParent[heightProp];
@@ -134,7 +134,7 @@ export function mapToStyles({
     ) {
       sideX = right;
       const offsetX =
-        isFixed && win.visualViewport
+        isFixed && offsetParent === win && win.visualViewport
           ? win.visualViewport.width
           : // $FlowFixMe[prop-missing]
             offsetParent[widthProp];


### PR DESCRIPTION
Fix issue #1577

I've only fixed the conditions that calculate offset X and Y because an element with the position fixed can be also relative to the parent containing block, not only to the viewport.
