### PR TITLE
fix(types): Constrain `Modifier` `Options` to same type as `Options` in `ModifierArguments`

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -132,7 +132,7 @@ export type ModifierArguments<Options: Obj> = {
   options: $Shape<Options>,
   name: string,
 };
-export type Modifier<Name, Options> = {|
+export type Modifier<Name, Options: Obj> = {|
   name: Name,
   enabled: boolean,
   phase: ModifierPhases,


### PR DESCRIPTION
This targets 2.x.

Fixes issues with TypeScript 4.7 canary (https://github.com/microsoft/TypeScript/pull/48366 specifically) that are blocking https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210

Ran `yarn build:typescript` and made sure the same diff that fixed https://github.com/DefinitelyTyped/DefinitelyTyped/runs/5752176130?check_suite_focus=true#step:6:1271 was applied:

```diff
-export declare type Modifier<Name, Options> = {
+export declare type Modifier<Name, Options extends Obj> = {
     name: Name;
     enabled: boolean;
     phase: ModifierPhases;
     requires?: Array<string>;
     requiresIfExists?: Array<string>;
     fn: (arg0: ModifierArguments<Options>) => State | void;
     effect?: (arg0: ModifierArguments<Options>) => (() => void) | void;
     options?: Partial<Options>;
     data?: Obj;
 };