### PR TITLE
Autoupdate -> fix for ancestor scrolling

### DIFF
--- a/packages/dom/src/utils/getOverflowAncestors.ts
+++ b/packages/dom/src/utils/getOverflowAncestors.ts
@@ -1,5 +1,4 @@
 import {getNearestOverflowAncestor} from './getNearestOverflowAncestor';
-import {getParentNode} from './getParentNode';
 import {getWindow} from './window';
 import {isOverflowElement} from './is';
 
@@ -21,5 +20,5 @@ export function getOverflowAncestors(
   return isBody
     ? updatedList
     : // @ts-ignore: isBody tells us target will be an HTMLElement here
-      updatedList.concat(getOverflowAncestors(getParentNode(target)));
+      updatedList.concat(getOverflowAncestors(target));
 }


### PR DESCRIPTION
Hi! 

This PR fixes autoupdate for following case
```
<div id="scroll" style="overflow: auto">
  <div id="container" style="overflow: hidden">
       <div id="reference></div>
  <div/>
</div>
```
In this case the popup position is not updated when user scrolls the div with id "scroll".  
That happens because getOverflowAncestors misses the parent element of the found overflow ancestor:  

`// take parent first time`  
https://github.com/floating-ui/floating-ui/blob/ffdaa13142fcc3ff300c3472c1fc773a8ba88452/packages/dom/src/utils/getOverflowAncestors.ts#L24  

https://github.com/floating-ui/floating-ui/blob/ffdaa13142fcc3ff300c3472c1fc773a8ba88452/packages/dom/src/utils/getOverflowAncestors.ts#L10
`// take parent second time`  
https://github.com/floating-ui/floating-ui/blob/ffdaa13142fcc3ff300c3472c1fc773a8ba88452/packages/dom/src/utils/getNearestOverflowAncestor.ts#L5-L6
____________
Looks like this behavior was broken in this PR https://github.com/floating-ui/floating-ui/pull/1565/files .   
To fix this  just run getOverflowAncestors recursion on the current overflow element 

Also here the example https://codesandbox.io/s/cranky-meadow-pz7m1g?file=/src/App.js of this issue