### PR TITLE
fix(dom): fallback to ?? 0 when visualViewport is not present

### DIFF
--- a/packages/dom/src/utils/getBoundingClientRect.ts
+++ b/packages/dom/src/utils/getBoundingClientRect.ts
@@ -28,10 +28,12 @@ export function getBoundingClientRect(
   const addVisualOffsets = !isLayoutViewport() && isFixedStrategy;
 
   const x =
-    (clientRect.left + (addVisualOffsets ? win.visualViewport.offsetLeft : 0)) /
+    (clientRect.left +
+      (addVisualOffsets ? win.visualViewport?.offsetLeft ?? 0 : 0)) /
     scaleX;
   const y =
-    (clientRect.top + (addVisualOffsets ? win.visualViewport.offsetTop : 0)) /
+    (clientRect.top +
+      (addVisualOffsets ? win.visualViewport?.offsetTop ?? 0 : 0)) /
     scaleY;
   const width = clientRect.width / scaleX;
   const height = clientRect.height / scaleY;


### PR DESCRIPTION
Supports Safari/iOS <=12 (old, but still has a bit of usage on legacy devices)