### PR TITLE
fix(types): React 18 types

### DIFF
--- a/packages/react-dom-interactions/src/FloatingDelayGroup.tsx
+++ b/packages/react-dom-interactions/src/FloatingDelayGroup.tsx
@@ -18,6 +18,11 @@ interface GroupState {
   currentId: any;
 }
 
+interface GroupContext extends GroupState {
+  setCurrentId: React.Dispatch<React.SetStateAction<any>>;
+  setState: React.Dispatch<React.SetStateAction<GroupState>>;
+}
+
 const FloatingDelayGroupContext = createContext<
   GroupState & {
     setCurrentId: (currentId: any) => void;
@@ -31,16 +36,20 @@ const FloatingDelayGroupContext = createContext<
   setState: () => {},
 });
 
-export const useDelayGroupContext = () => useContext(FloatingDelayGroupContext);
+export const useDelayGroupContext = (): GroupContext =>
+  useContext(FloatingDelayGroupContext);
 
 /**
  * Provides context for a group of floating elements that should share a
  * `delay`.
  * @see https://floating-ui.com/docs/FloatingDelayGroup
  */
-export const FloatingDelayGroup: React.FC<{delay: Delay}> = ({
+export const FloatingDelayGroup = ({
   children,
   delay,
+}: {
+  children?: React.ReactNode;
+  delay: Delay;
 }) => {
   const [state, setState] = useState<GroupState>({
     delay,

--- a/packages/react-dom-interactions/src/FloatingPortal.tsx
+++ b/packages/react-dom-interactions/src/FloatingPortal.tsx
@@ -8,9 +8,12 @@ const DEFAULT_ID = 'floating-ui-root';
  * Portals your floating element outside of the main app node.
  * @see https://floating-ui.com/docs/FloatingPortal
  */
-export const FloatingPortal: React.FC<{id?: string}> = ({
+export const FloatingPortal = ({
   children,
   id = DEFAULT_ID,
+}: {
+  children?: React.ReactNode;
+  id?: string;
 }) => {
   const [mounted, setMounted] = useState(false);
   const portalRef = useRef<HTMLDivElement | null>(null);

--- a/packages/react-dom-interactions/src/FloatingTree.tsx
+++ b/packages/react-dom-interactions/src/FloatingTree.tsx
@@ -14,14 +14,15 @@ import {createPubSub} from './createPubSub';
 const FloatingNodeContext = createContext<FloatingNodeType | null>(null);
 const FloatingTreeContext = createContext<FloatingTreeType | null>(null);
 
-export const useFloatingParentNodeId = () =>
+export const useFloatingParentNodeId = (): string | null =>
   useContext(FloatingNodeContext)?.id ?? null;
-export const useFloatingTree = () => useContext(FloatingTreeContext);
+export const useFloatingTree = (): FloatingTreeType | null =>
+  useContext(FloatingTreeContext);
 
 /**
  * Registers a node into the floating tree, returning its id.
  */
-export const useFloatingNodeId = () => {
+export const useFloatingNodeId = (): string => {
   const id = useId();
   const tree = useFloatingTree();
   const parentId = useFloatingParentNodeId();
@@ -41,7 +42,13 @@ export const useFloatingNodeId = () => {
  * Provides parent node context for nested floating elements.
  * @see https://floating-ui.com/docs/FloatingTree
  */
-export const FloatingNode: React.FC<{id: string}> = ({children, id}) => {
+export const FloatingNode = ({
+  children,
+  id,
+}: {
+  children?: React.ReactNode;
+  id: string;
+}) => {
   const parentId = useFloatingParentNodeId();
 
   return (
@@ -59,7 +66,7 @@ export const FloatingNode: React.FC<{id: string}> = ({children, id}) => {
  * respective parent).
  * @see https://floating-ui.com/docs/FloatingTree
  */
-export const FloatingTree: React.FC = ({children}) => {
+export const FloatingTree = ({children}: {children?: React.ReactNode}) => {
   const nodesRef = useRef<Array<FloatingNodeType>>([]);
 
   const addNode = useCallback((node: FloatingNodeType) => {


### PR DESCRIPTION
https://twitter.com/reactjs/status/1512453230504124420

Some of the context types seem to also not get their return types inferred correctly upon compiling, so this makes them explicit. 

Was going to update the playground but `react-router-dom` seems to have an issue with React 18 😕 