### PR TITLE
refactor(useInteractions): simplify merging logic

### DIFF
--- a/packages/react-dom-interactions/test/unit/useInteractions.test.ts
+++ b/packages/react-dom-interactions/test/unit/useInteractions.test.ts
@@ -1,0 +1,36 @@
+import {useInteractions} from '../../src/useInteractions';
+
+test('returns prop getters', () => {
+  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions(
+    []
+  );
+
+  expect(typeof getReferenceProps).toBe('function');
+  expect(typeof getFloatingProps).toBe('function');
+  expect(typeof getItemProps).toBe('function');
+});
+
+test('correctly merges functions', () => {
+  const firstInteractionOnClick = jest.fn();
+  const secondInteractionOnClick = jest.fn();
+  const userOnClick = jest.fn();
+
+  const {getReferenceProps} = useInteractions([
+    {reference: {onClick: firstInteractionOnClick}},
+    {reference: {onClick: secondInteractionOnClick}},
+  ]);
+
+  getReferenceProps({onClick: userOnClick}).onClick();
+
+  expect(firstInteractionOnClick).toHaveBeenCalledTimes(1);
+  expect(secondInteractionOnClick).toHaveBeenCalledTimes(1);
+  expect(userOnClick).toHaveBeenCalledTimes(1);
+});
+
+test('does not error with undefined user supplied functions', () => {
+  const {getReferenceProps} = useInteractions([{reference: {onClick() {}}}]);
+
+  expect(() =>
+    getReferenceProps({onClick: undefined}).onClick()
+  ).not.toThrowError();
+});

--- a/packages/react-dom-interactions/test/unit/useInteractions.test.ts
+++ b/packages/react-dom-interactions/test/unit/useInteractions.test.ts
@@ -13,18 +13,28 @@ test('returns prop getters', () => {
 test('correctly merges functions', () => {
   const firstInteractionOnClick = jest.fn();
   const secondInteractionOnClick = jest.fn();
+  const secondInteractionOnKeyDown = jest.fn();
   const userOnClick = jest.fn();
 
   const {getReferenceProps} = useInteractions([
     {reference: {onClick: firstInteractionOnClick}},
-    {reference: {onClick: secondInteractionOnClick}},
+    {
+      reference: {
+        onClick: secondInteractionOnClick,
+        onKeyDown: secondInteractionOnKeyDown,
+      },
+    },
   ]);
 
-  getReferenceProps({onClick: userOnClick}).onClick();
+  const {onClick, onKeyDown} = getReferenceProps({onClick: userOnClick});
+
+  onClick();
+  onKeyDown();
 
   expect(firstInteractionOnClick).toHaveBeenCalledTimes(1);
   expect(secondInteractionOnClick).toHaveBeenCalledTimes(1);
   expect(userOnClick).toHaveBeenCalledTimes(1);
+  expect(secondInteractionOnKeyDown).toHaveBeenCalledTimes(1);
 });
 
 test('does not error with undefined user supplied functions', () => {


### PR DESCRIPTION
Also allows `undefined` to be passed in the prop getter rather than needing to pass a no-op like `() => {}`:

```js
getFloatingProps({onKeyDown: cond ? func : undefined}),
```