### PR TITLE
fix(useHover): restMs

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -144,7 +144,11 @@ export const useHover = (
     function onMouseEnter(event: MouseEvent) {
       clearTimeout(timeoutRef.current);
 
-      if (open || (mouseOnly && pointerTypeRef.current !== 'mouse')) {
+      if (
+        open ||
+        (mouseOnly && pointerTypeRef.current !== 'mouse') ||
+        (restMs > 0 && getDelay(delay, 'open') === 0)
+      ) {
         return;
       }
 
@@ -213,6 +217,7 @@ export const useHover = (
     onOpenChangeRef,
     open,
     tree,
+    restMs,
     refs.reference,
     refs.floating,
   ]);

--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -110,7 +110,7 @@ export const useHover = (
 
   const closeWithDelay = useCallback(
     (runElseBranch = true) => {
-      if (delay) {
+      if (delay && !handlerRef.current) {
         clearTimeout(timeoutRef.current);
         timeoutRef.current = setTimeout(
           () => onOpenChangeRef.current(false),
@@ -129,6 +129,7 @@ export const useHover = (
         'pointermove',
         handlerRef.current
       );
+      handlerRef.current = undefined;
     }
   }, [open, enabled, refs.floating]);
 


### PR DESCRIPTION
Fixes two issues:

- Using `restMs` as the hover type in a 2nd-depth level floating element would close it while the user tried to navigate to the 3rd depth level
- The default DX of `delay: 0` not making `restMs` work is poor. Further they need to specify a really high delay if they don't want the delay to ever occur (`Infinity` does not work). This is mainly useful for nested submenus when the submenu renders and the cursor happens to be resting on an item which has a nested submenu, it shouldn't open until the cursor moves.