### PR TITLE
fix(dom): Prevent crash in browsers without ShadowRoot support

### DIFF
--- a/packages/dom/src/utils/is.ts
+++ b/packages/dom/src/utils/is.ts
@@ -24,6 +24,11 @@ export function isNode(value: any): value is Node {
 }
 
 export function isShadowRoot(node: Node): node is ShadowRoot {
+  // Legacy Edge doesn't support ShadowRoot.
+  if (typeof ShadowRoot === 'undefined') {
+    return false;
+  }
+
   const OwnElement = getWindow(node).ShadowRoot;
   return node instanceof OwnElement || node instanceof ShadowRoot;
 }

--- a/packages/dom/src/utils/is.ts
+++ b/packages/dom/src/utils/is.ts
@@ -24,7 +24,7 @@ export function isNode(value: any): value is Node {
 }
 
 export function isShadowRoot(node: Node): node is ShadowRoot {
-  // Legacy Edge doesn't support ShadowRoot.
+  // Browsers without `ShadowRoot` support
   if (typeof ShadowRoot === 'undefined') {
     return false;
   }


### PR DESCRIPTION
ShadowRoot support was only implemented as of [Modern Edge](https://caniuse.com/mdn-api_shadowroot), so any Legacy Edge version (including the latest, v18) currently suffers a crash when invoking `isShadowRoot()`. I'm aware Legacy Edge support is probably not something that is actively being chased but @floating-ui seems to work just fine apart from this small hitch. Would be great if you'd consider just popping this fix in.

This is basically the same issue that also occurred and was fixed back in the day in popper by @eps1lon, see #1253.