### PR TITLE
fix(types): add AutoUpdateOptions to @floating-ui/dom types.ts

### DIFF
--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -181,6 +181,6 @@ export type {
 } from '@floating-ui/core';
 
 export {computePosition} from './';
-export {autoUpdate} from './autoUpdate';
+export {autoUpdate, Options as AutoUpdateOptions} from './autoUpdate';
 
 export {getOverflowAncestors} from './utils/getOverflowAncestors';


### PR DESCRIPTION
Closes https://github.com/floating-ui/floating-ui/issues/1622

This is a simple update to expose the `autoUpdate` options to the types.ts file in `@floating-ui/dom/types.ts` 

This allows for consumers to more easily compose `autoUpdate` into a custom react hook.  