### PR TITLE
fix(useTypeahead): improve dataRef typing detection

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useTypeahead.ts
+++ b/packages/react-dom-interactions/src/hooks/useTypeahead.ts
@@ -72,11 +72,7 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
       return;
     }
 
-    if (
-      stringRef.current.length > 0 &&
-      stringRef.current[0] !== ' ' &&
-      !stringRef.current.split('').every((char) => char === ' ')
-    ) {
+    if (stringRef.current.length > 0 && stringRef.current[0] !== ' ') {
       dataRef.current.typing = true;
 
       if (event.key === ' ') {

--- a/packages/react-dom-interactions/src/hooks/useTypeahead.ts
+++ b/packages/react-dom-interactions/src/hooks/useTypeahead.ts
@@ -72,7 +72,11 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
       return;
     }
 
-    if (stringRef.current.length > 0) {
+    if (
+      stringRef.current.length > 0 &&
+      stringRef.current[0] !== ' ' &&
+      !stringRef.current.split('').every((char) => char === ' ')
+    ) {
       dataRef.current.typing = true;
 
       if (event.key === ' ') {


### PR DESCRIPTION
If the transient string starts with a space, it's assumed the `Space` key should prefer opening/closing the floating element, not adding to the typeahead string