### PR TITLE
fix(FloatingDelayGroup): use 1ms open delay

### DIFF
--- a/packages/react-dom-interactions/src/FloatingDelayGroup.tsx
+++ b/packages/react-dom-interactions/src/FloatingDelayGroup.tsx
@@ -87,7 +87,7 @@ export const useDelayGroup = (
     if (currentId && onOpenChange) {
       setState((state) => ({
         ...state,
-        delay: {open: 0, close: getDelay(initialDelay, 'close')},
+        delay: {open: 1, close: getDelay(initialDelay, 'close')},
       }));
 
       if (currentId !== id) {


### PR DESCRIPTION
Open `delay: 0` is infinite

The `isGroupPhase` boolean in the example doesn't seem to work with `framer-motion` in React 18 😥 