### PR TITLE
Fix link to Tether in docs

### DIFF
--- a/website/pages/docs/motivation.mdx
+++ b/website/pages/docs/motivation.mdx
@@ -7,7 +7,7 @@ package was created.
 
 [Popper](https://popper.js.org) is currently the most popular
 open source solution to position floating elements, created
-in 2016. Prior to that it was [Tether](http://tether.io/).
+in 2016. Prior to that it was [Tether](https://tetherjs.dev/docs/welcome/).
 
 Floating UI is the evolution of Popper v2, with a more modern
 API. It also aims to be more ambitious by offering components


### PR DESCRIPTION
The link to Tether was pointing to the crypto token by the same name. This fixes the link to point to Tether's latest homepage (per their GitHub repo[1] link).

1. https://github.com/shipshapecode/tether