### PR TITLE
Improve support for shadow dom / custom elements

### DIFF
--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -2,6 +2,7 @@ import {hideOthers} from 'aria-hidden';
 import * as React from 'react';
 import {useFloatingTree} from './FloatingTree';
 import type {FloatingContext, ReferenceType} from './types';
+import {activeElement} from './utils/activeElement';
 import {getChildren} from './utils/getChildren';
 import {getDocument} from './utils/getDocument';
 import {isElement, isHTMLElement} from './utils/is';
@@ -78,7 +79,6 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
         if (refs.floating.current && type === 'floating') {
           return refs.floating.current;
         }
-
         if (type === 'content') {
           return Array.from(
             refs.floating.current?.querySelectorAll(SELECTOR) ?? []
@@ -119,9 +119,15 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
 
         const els = getTabbableElements();
 
+        const target =
+          'composedPath' in event
+            ? event.composedPath()[0]
+            : // TS thinks `event` is of type never as it assumes all browsers support composedPath, but browsers without shadow dom don't
+              (event as Event).target;
+
         if (
           orderRef.current[0] === 'reference' &&
-          event.target === refs.reference.current
+          target === refs.reference.current
         ) {
           stopEvent(event);
           if (event.shiftKey) {
@@ -133,7 +139,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
 
         if (
           orderRef.current[1] === 'floating' &&
-          event.target === refs.floating.current &&
+          target === refs.floating.current &&
           event.shiftKey
         ) {
           stopEvent(event);
@@ -204,7 +210,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     const floating = refs.floating.current;
 
     const previouslyFocusedElement =
-      getDocument(floating).activeElement ?? document.activeElement;
+      activeElement(getDocument(floating)) ?? activeElement(document);
 
     if (typeof initialFocus === 'number') {
       focus(getTabbableElements()[initialFocus] ?? floating);

--- a/packages/react-dom-interactions/src/FloatingPortal.tsx
+++ b/packages/react-dom-interactions/src/FloatingPortal.tsx
@@ -21,7 +21,11 @@ export const FloatingPortal = ({
   const portalRef = React.useRef<HTMLElement | null>(null);
 
   useLayoutEffect(() => {
-    const rootNode = root ?? document.getElementById(id);
+    if (root) {
+      return;
+    }
+
+    const rootNode = document.getElementById(id);
 
     if (rootNode) {
       portalRef.current = rootNode;
@@ -30,12 +34,16 @@ export const FloatingPortal = ({
       portalRef.current.id = id;
     }
 
-    if (!root && !document.body.contains(portalRef.current)) {
+    if (!document.body.contains(portalRef.current)) {
       document.body.appendChild(portalRef.current);
     }
 
     setMounted(true);
   }, [id, root]);
+
+  if (root) {
+    return createPortal(children, root);
+  }
 
   if (mounted && portalRef.current) {
     return createPortal(children, portalRef.current);

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -2,9 +2,11 @@ import {getOverflowAncestors} from '@floating-ui/react-dom';
 import * as React from 'react';
 import {useFloatingTree} from '../FloatingTree';
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
+import {activeElement} from '../utils/activeElement';
 import {getChildren} from '../utils/getChildren';
 import {getDocument} from '../utils/getDocument';
 import {isElement, isHTMLElement} from '../utils/is';
+import {isEventTargetWithin} from '../utils/isEventTargetWithin';
 import {useLatestRef} from '../utils/useLatestRef';
 
 export interface Props {
@@ -36,7 +38,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
 
   const isFocusInsideFloating = React.useCallback(() => {
     return refs.floating.current?.contains(
-      getDocument(refs.floating.current).activeElement
+      activeElement(getDocument(refs.floating.current))
     );
   }, [refs.floating]);
 
@@ -67,15 +69,13 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
       const targetIsInsideChildren =
         tree &&
         getChildren(tree, nodeId).some((node) =>
-          node.context?.refs.floating.current?.contains(
-            event.target as Element | null
-          )
+          isEventTargetWithin(event, node.context?.refs.floating.current)
         );
 
       if (
-        refs.floating.current?.contains(event.target as Element | null) ||
+        isEventTargetWithin(event, refs.floating.current) ||
         (isElement(refs.reference.current) &&
-          refs.reference.current.contains(event.target as Element | null)) ||
+          isEventTargetWithin(event, refs.reference.current)) ||
         targetIsInsideChildren
       ) {
         return;

--- a/packages/react-dom-interactions/src/hooks/useFocusTrap.ts
+++ b/packages/react-dom-interactions/src/hooks/useFocusTrap.ts
@@ -8,6 +8,7 @@ import {stopEvent} from '../utils/stopEvent';
 import {useLatestRef} from '../utils/useLatestRef';
 import {useFloatingTree} from '../FloatingTree';
 import {getChildren} from '../utils/getChildren';
+import {activeElement} from '../utils/activeElement';
 
 const FOCUSABLE_ELEMENT_SELECTOR =
   'a[href],area[href],input:not([disabled]),select:not([disabled]),textarea:not([disabled]),button:not([disabled]),iframe,object,embed,*[tabindex],*[contenteditable]';
@@ -182,7 +183,7 @@ export const useFocusTrap = <RT extends ReferenceType = ReferenceType>(
         const first = focusableElements[0];
         if (
           first === refs.floating.current &&
-          !first.contains(first.ownerDocument.activeElement)
+          !first.contains(activeElement(first.ownerDocument))
         ) {
           focus(first);
         }

--- a/packages/react-dom-interactions/src/hooks/useListNavigation.ts
+++ b/packages/react-dom-interactions/src/hooks/useListNavigation.ts
@@ -3,6 +3,7 @@ import useLayoutEffect from 'use-isomorphic-layout-effect';
 import {useFloatingParentNodeId, useFloatingTree} from '../FloatingTree';
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import {getDocument} from '../utils/getDocument';
+import {activeElement} from '../utils/activeElement';
 import {isHTMLElement} from '../utils/is';
 import {stopEvent} from '../utils/stopEvent';
 import {useLatestRef} from '../utils/useLatestRef';
@@ -339,7 +340,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
 
       if (
         parentFloating &&
-        !parentFloating.contains(getDocument(parentFloating).activeElement)
+        !parentFloating.contains(activeElement(getDocument(parentFloating)))
       ) {
         parentFloating.focus({preventScroll: true});
       }
@@ -384,7 +385,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
 
       if (
         !virtual &&
-        event.currentTarget.ownerDocument.activeElement === event.currentTarget
+        activeElement(event.currentTarget.ownerDocument) === event.currentTarget
       ) {
         indexRef.current =
           selectedIndex ??

--- a/packages/react-dom-interactions/src/hooks/useTypeahead.ts
+++ b/packages/react-dom-interactions/src/hooks/useTypeahead.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
+import {activeElement} from '../utils/activeElement';
 import {getDocument} from '../utils/getDocument';
 import {stopEvent} from '../utils/stopEvent';
 
@@ -66,7 +67,7 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
   function onKeyDown(event: React.KeyboardEvent) {
     if (
       !event.currentTarget.contains(
-        getDocument(event.currentTarget as HTMLElement).activeElement
+        activeElement(getDocument(event.currentTarget as HTMLElement))
       )
     ) {
       return;

--- a/packages/react-dom-interactions/src/safePolygon.ts
+++ b/packages/react-dom-interactions/src/safePolygon.ts
@@ -73,7 +73,11 @@ export function safePolygon({
         return;
       }
 
-      const {target, clientX, clientY} = event;
+      const {clientX, clientY} = event;
+      const target =
+        'composedPath' in event
+          ? event.composedPath()[0]
+          : (event as Event).target;
       const targetNode = target as Element | null;
 
       // If the pointer is over the reference or floating element already, there

--- a/packages/react-dom-interactions/src/utils/activeElement.ts
+++ b/packages/react-dom-interactions/src/utils/activeElement.ts
@@ -1,0 +1,12 @@
+/**
+ * Find the real active element. Traverses into shadowRoots.
+ */
+export function activeElement(doc: Document) {
+  let activeElement = doc.activeElement;
+
+  while (activeElement?.shadowRoot?.activeElement != null) {
+    activeElement = activeElement.shadowRoot.activeElement;
+  }
+
+  return activeElement;
+}

--- a/packages/react-dom-interactions/src/utils/isEventTargetWithin.ts
+++ b/packages/react-dom-interactions/src/utils/isEventTargetWithin.ts
@@ -1,0 +1,23 @@
+/**
+ * Check whether the event.target is within the provided node. Uses event.composedPath if available for custom element support.
+ *
+ * @param event The event whose target/composedPath to check
+ * @param node The node to check against
+ * @returns Whether the event.target/composedPath is within the node.
+ */
+export function isEventTargetWithin(
+  event: Event,
+  node: Node | null | undefined
+) {
+  if (node == null) {
+    return false;
+  }
+
+  if ('composedPath' in event) {
+    return event.composedPath().includes(node);
+  }
+
+  // TS thinks `event` is of type never as it assumes all browsers support composedPath, but browsers without shadow dom don't
+  const e = event as Event;
+  return e.target != null && node.contains(e.target as Node);
+}

--- a/website/pages/docs/FloatingPortal.mdx
+++ b/website/pages/docs/FloatingPortal.mdx
@@ -5,9 +5,7 @@ Portals your floating element outside the main app node.
 ```js
 import {FloatingPortal} from '@floating-ui/react-dom-interactions';
 
-function App() {
-  // ...
-
+function Tooltip() {
   return (
     <FloatingPortal>
       {open && <div>Tooltip<div>}
@@ -24,6 +22,7 @@ function App() {
 ```js
 interface Props {
   id?: string;
+  root?: HTMLElement | null;
 }
 ```
 
@@ -32,4 +31,21 @@ interface Props {
 default: `'floating-ui-root'{:js}`
 
 If this node does not exist on the document, it will be created
-for you.
+for you and will be appended to the end of the `<body>{:html}`.
+
+```js
+<FloatingPortal id="custom-root-id">
+  {open && <div>Tooltip</div>}
+</FloatingPortal>
+```
+
+### root
+
+Alternatively, you may pass the root element itself, which
+supports shadow roots.
+
+```js
+<FloatingPortal root={shadowRootNode}>
+  {open && <div>Tooltip</div>}
+</FloatingPortal>
+```


### PR DESCRIPTION
When using shadow DOM

- events of event listeners attached to the `document`/`window` object will have the first element with a shadow root as their `event.target`. This currently causes issues with a bunch of "contains" checks. To work around this, `event.composedPath()` should be used, as it will give the complete path of the event, including elements contained in an (open) shadow root.
- `document.activeElement` will not traverse into shadow roots, one has to manually traverse into (open) shadow roots to find the actually focused element within a shadow root.

