### PR TITLE
fix: avoid navigator.userAgent

### DIFF
--- a/packages/dom/src/utils/is.ts
+++ b/packages/dom/src/utils/is.ts
@@ -1,5 +1,6 @@
 import {getComputedStyle} from './getComputedStyle';
 import {getNodeName} from './getNodeName';
+import {getUAString} from './userAgent';
 import {getWindow} from './window';
 
 declare global {
@@ -45,7 +46,7 @@ export function isTableElement(element: Element): boolean {
 
 export function isContainingBlock(element: Element): boolean {
   // TODO: Try and use feature detection here instead
-  const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
+  const isFirefox = /firefox/i.test(getUAString());
   const css = getComputedStyle(element);
 
   // This is non-exhaustive but covers the most common CSS properties that
@@ -64,7 +65,7 @@ export function isContainingBlock(element: Element): boolean {
 
 export function isLayoutViewport(): boolean {
   // Not Safari
-  return !/^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  return !/^((?!chrome|android).)*safari/i.test(getUAString());
   // Feature detection for this fails in various ways
   // • Always-visible scrollbar or not
   // • Width of <html>, etc.

--- a/packages/dom/src/utils/userAgent.ts
+++ b/packages/dom/src/utils/userAgent.ts
@@ -1,0 +1,19 @@
+interface NavigatorUAData {
+  brands: Array<{brand: string; version: number}>;
+  mobile: boolean;
+  platform: string;
+}
+
+export function getUAString(): string {
+  const uaData = (navigator as any).userAgentData as
+    | NavigatorUAData
+    | undefined;
+
+  if (uaData?.brands) {
+    return uaData.brands
+      .map((item) => `${item.brand}/${item.version}`)
+      .join(' ');
+  }
+
+  return navigator.userAgent;
+}

--- a/packages/dom/src/utils/userAgent.ts
+++ b/packages/dom/src/utils/userAgent.ts
@@ -1,5 +1,5 @@
 interface NavigatorUAData {
-  brands: Array<{brand: string; version: number}>;
+  brands: Array<{brand: string; version: string}>;
   mobile: boolean;
   platform: string;
 }


### PR DESCRIPTION
Avoids the blue icon in Chrome DevTools, doesn't actually change anything. 

Closes #1423

[MDN says "brands" is experimental](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/brands) so I hope it doesn't change 😒 