### PR TITLE
fix(autoUpdate): retain floating ResizeObserver with animationFrame

### DIFF
--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -45,14 +45,13 @@ export function autoUpdate(
   const {
     ancestorScroll: _ancestorScroll = true,
     ancestorResize: _ancestorResize = true,
-    elementResize: _elementResize = true,
+    elementResize = true,
     animationFrame = false,
   } = options;
 
   let cleanedUp = false;
   const ancestorScroll = _ancestorScroll && !animationFrame;
   const ancestorResize = _ancestorResize && !animationFrame;
-  const elementResize = _elementResize && !animationFrame;
 
   const ancestors =
     ancestorScroll || ancestorResize
@@ -71,7 +70,7 @@ export function autoUpdate(
   let observer: ResizeObserver | null = null;
   if (elementResize) {
     observer = new ResizeObserver(update);
-    isElement(reference) && observer.observe(reference);
+    isElement(reference) && !animationFrame && observer.observe(reference);
     observer.observe(floating);
   }
 

--- a/website/pages/docs/autoUpdate.mdx
+++ b/website/pages/docs/autoUpdate.mdx
@@ -89,8 +89,11 @@ Whether to update the position of the floating element on every
 animation frame if required. This is optimized for performance
 but can still be costly.
 
-Setting this to `true{:js}` disables every other listener as they
-become unnecessary.
+Setting this to `true{:js}` disables the scroll, resize, and
+reference `ResizeObserver{:.class}` listeners as they become
+unnecessary. Only the floating element's
+`ResizeObserver{:.class}` remains active, if
+`elementResize{:.objectKey}` is `true{:js}`.
 
 ```js
 const cleanup = autoUpdate(referenceEl, floatingEl, update, {


### PR DESCRIPTION
The `animationFrame` loop only watches the reference rect, but there's one more case that needs to be watched: if the floating element resized. 

There's two ways to fix this:

- Add another frame loop to watch the floating rect (not performant, especially since it only needs a `ResizeObserver`)
- Retain the `ResizeObserver` but only for the floating element (this PR)