### PR TITLE
refactor: improve callback signatures

### DIFF
--- a/packages/core/src/middleware/size.ts
+++ b/packages/core/src/middleware/size.ts
@@ -1,4 +1,4 @@
-import type {Dimensions, ElementRects, Middleware} from '../types';
+import type {Middleware, MiddlewareArguments} from '../types';
 import {
   detectOverflow,
   Options as DetectOverflowOptions,
@@ -13,7 +13,12 @@ export interface Options {
    * to change its size.
    * @default undefined
    */
-  apply(args: Dimensions & ElementRects): void;
+  apply(
+    args: MiddlewareArguments & {
+      availableWidth: number;
+      availableHeight: number;
+    }
+  ): void;
 }
 
 /**
@@ -59,7 +64,7 @@ export const size = (
     const yMax = max(overflow.bottom, 0);
 
     const dimensions = {
-      height:
+      availableHeight:
         rects.floating.height -
         (['left', 'right'].includes(placement)
           ? 2 *
@@ -67,7 +72,7 @@ export const size = (
               ? yMin + yMax
               : max(overflow.top, overflow.bottom))
           : overflow[heightSide]),
-      width:
+      availableWidth:
         rects.floating.width -
         (['top', 'bottom'].includes(placement)
           ? 2 *
@@ -79,7 +84,10 @@ export const size = (
 
     const prevDimensions = await platform.getDimensions(elements.floating);
 
-    apply?.({...dimensions, ...rects});
+    apply?.({
+      ...middlewareArguments,
+      ...dimensions,
+    });
 
     const nextDimensions = await platform.getDimensions(elements.floating);
 

--- a/packages/dom/test/visual/spec/Offset.tsx
+++ b/packages/dom/test/visual/spec/Offset.tsx
@@ -11,9 +11,9 @@ const VALUES: Array<{offset: Options; name: string}> = [
   {offset: -10, name: '-10'},
   {offset: {crossAxis: 10}, name: 'cA: 10'},
   {offset: {mainAxis: 5, crossAxis: -10}, name: 'mA: 5, cA: -10'},
-  {offset: ({floating}) => -floating.height, name: '() => -f.height'},
+  {offset: ({elements}) => -elements.floating.height, name: '() => -f.height'},
   {
-    offset: ({floating}) => ({crossAxis: -floating.width / 2}),
+    offset: ({elements}) => ({crossAxis: -elements.floating.width / 2}),
     name: '() => cA: -f.width/2',
   },
   {offset: {alignmentAxis: 5}, name: 'aA: 5'},

--- a/packages/dom/test/visual/spec/Offset.tsx
+++ b/packages/dom/test/visual/spec/Offset.tsx
@@ -11,9 +11,9 @@ const VALUES: Array<{offset: Options; name: string}> = [
   {offset: -10, name: '-10'},
   {offset: {crossAxis: 10}, name: 'cA: 10'},
   {offset: {mainAxis: 5, crossAxis: -10}, name: 'mA: 5, cA: -10'},
-  {offset: ({elements}) => -elements.floating.height, name: '() => -f.height'},
+  {offset: ({rects}) => -rects.floating.height, name: '() => -f.height'},
   {
-    offset: ({elements}) => ({crossAxis: -elements.floating.width / 2}),
+    offset: ({rects}) => ({crossAxis: -rects.floating.width / 2}),
     name: '() => cA: -f.width/2',
   },
   {offset: {alignmentAxis: 5}, name: 'aA: 5'},

--- a/packages/dom/test/visual/spec/Size.tsx
+++ b/packages/dom/test/visual/spec/Size.tsx
@@ -1,22 +1,21 @@
-import type {Dimensions, ElementRects, Placement} from '@floating-ui/core';
+import type {Placement} from '@floating-ui/core';
 import {useFloating, size} from '@floating-ui/react-dom';
 import {allPlacements} from '../utils/allPlacements';
 import {useState, useLayoutEffect} from 'react';
 import {Controls} from '../utils/Controls';
 import {useScroll} from '../utils/useScroll';
-import {flushSync} from 'react-dom';
 
 export function Size() {
   const [rtl, setRtl] = useState(false);
-  const [sizeData, setSizeData] = useState<ElementRects & Dimensions>();
   const [placement, setPlacement] = useState<Placement>('bottom');
   const {x, y, reference, floating, strategy, update, refs} = useFloating({
     placement,
     middleware: [
       size({
-        apply: (data) => {
-          flushSync(() => {
-            setSizeData(data);
+        apply({availableHeight, availableWidth, elements}) {
+          Object.assign(elements.floating.style, {
+            maxWidth: `${availableWidth}px`,
+            maxHeight: `${availableHeight}px`,
           });
         },
         padding: 10,
@@ -50,8 +49,6 @@ export function Size() {
               position: strategy,
               top: y ?? '',
               left: x ?? '',
-              maxHeight: sizeData?.height ?? '',
-              maxWidth: sizeData?.width ?? '',
               width: 400,
               height: 300,
             }}

--- a/packages/react-dom/test/index.test.tsx
+++ b/packages/react-dom/test/index.test.tsx
@@ -14,7 +14,6 @@ import {
 import {renderHook} from '@testing-library/react-hooks';
 import {render, waitFor, fireEvent} from '@testing-library/react';
 import {useRef, useState} from 'react';
-import type {Dimensions, ElementRects} from '@floating-ui/core';
 
 test('`x` and `y` are initially `null`', async () => {
   const {result} = renderHook(() => useFloating());
@@ -25,9 +24,6 @@ test('`x` and `y` are initially `null`', async () => {
 
 test('middleware is always fresh and does not cause an infinite loop', async () => {
   function InlineMiddleware() {
-    const [sizeData, setSizeData] = useState<
-      (ElementRects & Dimensions) | null
-    >(null);
     const arrowRef = useRef(null);
     const {reference, floating} = useFloating({
       placement: 'right',
@@ -54,22 +50,25 @@ test('middleware is always fresh and does not cause an infinite loop', async () 
 
         hide(),
 
-        size({apply: setSizeData}),
+        size({
+          apply({availableHeight, elements}) {
+            Object.assign(elements.floating.style, {
+              maxHeight: `${availableHeight}px`,
+            });
+          },
+        }),
       ],
     });
 
     return (
       <>
         <div ref={reference} />
-        <div ref={floating} style={{height: sizeData?.height ?? ''}} />
+        <div ref={floating} />
       </>
     );
   }
 
   function StateMiddleware() {
-    const [sizeData, setSizeData] = useState<
-      (ElementRects & Dimensions) | null
-    >(null);
     const arrowRef = useRef(null);
     const [middleware, setMiddleware] = useState([
       offset(),
@@ -97,7 +96,13 @@ test('middleware is always fresh and does not cause an infinite loop', async () 
 
       hide(),
 
-      size({apply: setSizeData}),
+      size({
+        apply({availableHeight, elements}) {
+          Object.assign(elements.floating.style, {
+            maxHeight: `${availableHeight}px`,
+          });
+        },
+      }),
     ]);
     const {x, y, reference, floating} = useFloating({
       placement: 'right',
@@ -107,7 +112,7 @@ test('middleware is always fresh and does not cause an infinite loop', async () 
     return (
       <>
         <div ref={reference} />
-        <div ref={floating} style={{height: sizeData?.height ?? ''}} />
+        <div ref={floating} />
         <button
           data-testid="step1"
           onClick={() => setMiddleware([offset(10)])}

--- a/website/pages/docs/offset.mdx
+++ b/website/pages/docs/offset.mdx
@@ -123,14 +123,18 @@ values — this enables you to read the dimensions of the reference
 or floating elements and the current `placement{:.objectKey}`.
 
 ```js
-offset(({reference, floating, placement}) =>
-  placement === 'bottom' ? floating.width : reference.width
+offset(({rects, placement}) =>
+  placement === 'bottom'
+    ? rects.floating.width
+    : rects.reference.width
 );
 
-offset(({reference, floating, placement}) => ({
+offset(({rects, placement}) => ({
   mainAxis: placement === 'top' ? 5 : -5,
   crossAxis:
-    placement === 'right' ? reference.width : floating.width,
+    placement === 'right'
+      ? rects.reference.width
+      : rects.floating.width,
 }));
 ```
 

--- a/website/pages/docs/size.mdx
+++ b/website/pages/docs/size.mdx
@@ -36,11 +36,11 @@ import {computePosition, size} from '@floating-ui/dom';
 computePosition(referenceEl, floatingEl, {
   middleware: [
     size({
-      apply({width, height, reference, floating}) {
+      apply({availableWidth, availableHeight, elements}) {
         // Do things with the data, e.g.
-        Object.assign(floatingEl.style, {
-          maxWidth: `${width}px`,
-          maxHeight: `${height}px`,
+        Object.assign(elements.floating.style, {
+          maxWidth: `${availableWidth}px`,
+          maxHeight: `${availableHeight}px`,
         });
       },
     }),
@@ -57,7 +57,12 @@ These are the options you can pass to `size(){:js}`.
 
 ```ts
 interface Options extends DetectOverflowOptions {
-  apply?: (args: Dimensions & ElementRects) => void;
+  apply?: (
+    args: MiddlewareArguments & {
+      availableWidth: number;
+      availableHeight: number;
+    }
+  ) => void;
 }
 ```
 
@@ -72,16 +77,36 @@ lifecycle:
 
 ```js
 size({
-  apply({width, height}) {
+  apply({
+    availableWidth,
+    availableHeight,
+    ...middlewareArguments
+  }) {
     // Style mutations here
   },
 });
 ```
 
-This is because the `x` and `y` coordinates become incorrect
-after you've changed the size, and so changes to the dimensions
-of the floating element need to be performed before the
-coordinates get assigned to it.
+#### availableWidth
+
+Represents how wide the floating element can be before it will
+overflow its clipping context. You'll generally set this as the
+`maxWidth{:.objectKey}` CSS property.
+
+#### availableHeight
+
+Represents how tall the floating element can be before it will
+overflow its clipping context. You'll generally set this as the
+`maxHeight{:.objectKey}` CSS property.
+
+#### ...middlewareArguments
+
+See [MiddlewareArguments](/docs/middleware#middlewarearguments).
+
+Many useful properties are also accessible via this callback,
+such as `rects{:.objectKey}` and `elements{:.objectKey}`, the
+latter of which is useful in the context of React where you need
+access to the floating element and it does not exist in scope.
 
 ### ...detectOverflowOptions
 
@@ -113,7 +138,7 @@ placement is used. In this scenario, place `size(){:js}`
 const middleware = [
   flip(),
   size({
-    apply({width, height}) {
+    apply({availableWidth, availableHeight}) {
       // ...
     },
   }),
@@ -155,11 +180,11 @@ and are setting a minimum acceptable size, place `size(){:js}`
 ```js
 const middleware = [
   size({
-    apply({width, height}) {
-      Object.assign(floatingEl.style, {
+    apply({availableHeight, elements}) {
+      Object.assign(elements.floating.style, {
         // Minimum acceptable height is 50px.
         // `flip` will then take over.
-        maxHeight: `${Math.max(50, height)}px`,
+        maxHeight: `${Math.max(50, availableHeight)}px`,
       });
     },
   }),
@@ -176,11 +201,11 @@ the width of the reference regardless of its contents. You can
 also use `size(){:js}` for this, as the `Rect{:.class}`s get
 passed in:
 
-```js
+```js /rects/
 size({
-  apply({reference}) {
+  apply({rects}) {
     Object.assign(floatingEl.style, {
-      width: `${reference.width}px`,
+      width: `${rects.reference.width}px`,
     });
   },
 });


### PR DESCRIPTION
This changes the callback signatures of `size` and `offset` to be more ergonomic. They previously used APIs similar to Popper 2's but this causes usage problems in the context of React.

Before:

```js
  const {x, y, reference, floating, strategy, refs} = useFloating({
    middleware: [
      size({
        apply({width, height, reference}) {
          Object.assign(refs.floating.current?.style ?? {}, {
            width: `${reference.width}px`,
            maxWidth: `${width}px`,
            maxHeight: `${height}px`,
          });
        },
      }),
    ],
  });
```

After:

- `width` and `height` become `availableWidth` and `availableHeight`, respectively. This better describes what the actual values are.
- `reference` and `floating` top-level keys are gone. Instead the whole `MiddlewareArguments` object gets spread in, so you get access to `rects` + `elements`, no need for the outer `refs` (which has an annoying `null` type). This also makes the usage more clear.

```js
  const {x, y, reference, floating, strategy} = useFloating({
    middleware: [
      size({
        apply({availableWidth, availableHeight, rects, elements}) {
          Object.assign(elements.floating.style, {
            width: `${rects.reference.width}px`,
            maxWidth: `${availableWidth}px`,
            maxHeight: `${availableHeight}px`,
          });
        },
      }),
    ],
  });
```

This also improves the `offset` callback naming and gives you access to more stuff if necessary.

```js
offset(({rects}) => -rects.floating.width)
```

- [ ] Docs