### PR TITLE
build: fix package entry points

### DIFF
--- a/packages/core/babel.config.js
+++ b/packages/core/babel.config.js
@@ -1,3 +1,3 @@
-export default {
+module.exports = {
   presets: [['@babel/env', {loose: true}], '@babel/typescript'],
 };

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-export default {
+module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   globals: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,18 +12,16 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/floating-ui.core.js",
-  "module": "dist/floating-ui.core.esm.js",
-  "unpkg": "dist/floating-ui.core.min.js",
-  "type": "module",
+  "main": "./dist/floating-ui.core.js",
+  "module": "./dist/floating-ui.core.esm.js",
+  "unpkg": "./dist/floating-ui.core.min.js",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "development": "./dist/floating-ui.core.esm.development.js",
-        "production": "./dist/floating-ui.core.esm.min.js",
-        "default": "./dist/floating-ui.core.esm.js"
-      },
-      "require": "./dist/floating-ui.core.cjs"
+      "types": "./index.d.ts",
+      "module": "./dist/floating-ui.core.esm.js",
+      "import": "./dist/floating-ui.core.mjs",
+      "default": "./dist/floating-ui.core.js"
     },
     "./package.json": "./package.json",
     "./src/index.ts": "./src/index.ts"

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -48,8 +48,8 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.core.cjs'),
-      format: 'cjs',
+      file: path.join(__dirname, 'dist/floating-ui.core.mjs'),
+      format: 'esm',
     },
   },
 ];
@@ -58,7 +58,8 @@ const isDevEnv = (file) => file.includes('.development.');
 const isUMD = (file) => file.includes('.core.js');
 const isMinEnv = (file) => file.includes('.min.');
 const isSpecificEnv = (file) => isMinEnv(file) || isDevEnv(file);
-const isDebugAlways = (file) => isDevEnv(file) || isUMD(file) ? 'true' : 'false';
+const isDebugAlways = (file) =>
+  isDevEnv(file) || isUMD(file) ? 'true' : 'false';
 
 const buildExport = bundles.map(({input, output}) => ({
   input,

--- a/packages/dom/babel.config.js
+++ b/packages/dom/babel.config.js
@@ -1,3 +1,3 @@
-export default {
+module.exports = {
   presets: [['@babel/env', {loose: true}], '@babel/typescript'],
 };

--- a/packages/dom/jest.config.js
+++ b/packages/dom/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-export default {
+module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   globals: {

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -12,18 +12,16 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/floating-ui.dom.js",
-  "module": "dist/floating-ui.dom.esm.js",
-  "unpkg": "dist/floating-ui.dom.min.js",
-  "type": "module",
+  "main": "./dist/floating-ui.dom.js",
+  "module": "./dist/floating-ui.dom.esm.js",
+  "unpkg": "./dist/floating-ui.dom.min.js",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "development": "./dist/floating-ui.dom.esm.development.js",
-        "production": "./dist/floating-ui.dom.esm.min.js",
-        "default": "./dist/floating-ui.dom.esm.js"
-      },
-      "require": "./dist/floating-ui.dom.cjs"
+      "types": "./index.d.ts",
+      "module": "./dist/floating-ui.dom.esm.js",
+      "import": "./dist/floating-ui.dom.mjs",
+      "default": "./dist/floating-ui.dom.js"
     },
     "./package.json": "./package.json",
     "./src/index.ts": "./src/index.ts"

--- a/packages/dom/rollup.config.js
+++ b/packages/dom/rollup.config.js
@@ -53,8 +53,8 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.dom.cjs'),
-      format: 'cjs',
+      file: path.join(__dirname, 'dist/floating-ui.dom.mjs'),
+      format: 'esm',
     },
   },
 ];

--- a/packages/react-dom-interactions/babel.config.js
+++ b/packages/react-dom-interactions/babel.config.js
@@ -1,3 +1,3 @@
-export default {
+module.exports = {
   presets: [['@babel/env', {loose: true}], '@babel/typescript', '@babel/react'],
 };

--- a/packages/react-dom-interactions/jest.config.js
+++ b/packages/react-dom-interactions/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-export default {
+module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   globals: {

--- a/packages/react-dom-interactions/package.json
+++ b/packages/react-dom-interactions/package.json
@@ -12,14 +12,16 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/floating-ui.react-dom-interactions.js",
-  "module": "dist/floating-ui.react-dom-interactions.esm.js",
-  "unpkg": "dist/floating-ui.react-dom-interactions.min.js",
-  "type": "module",
+  "main": "./dist/floating-ui.react-dom-interactions.js",
+  "module": "./dist/floating-ui.react-dom-interactions.esm.js",
+  "unpkg": "./dist/floating-ui.react-dom-interactions.min.js",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/floating-ui.react-dom-interactions.esm.js",
-      "require": "./dist/floating-ui.react-dom-interactions.cjs"
+      "types": "./index.d.ts",
+      "module": "./dist/floating-ui.react-dom-interactions.esm.js",
+      "import": "./dist/floating-ui.react-dom-interactions.mjs",
+      "default": "./dist/floating-ui.react-dom-interactions.js"
     },
     "./package.json": "./package.json",
     "./src/index.ts": "./src/index.ts"

--- a/packages/react-dom-interactions/rollup.config.js
+++ b/packages/react-dom-interactions/rollup.config.js
@@ -66,8 +66,8 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.react-dom-interactions.cjs'),
-      format: 'cjs',
+      file: path.join(__dirname, 'dist/floating-ui.react-dom-interactions.mjs'),
+      format: 'esm',
     },
   },
 ];

--- a/packages/react-dom/babel.config.js
+++ b/packages/react-dom/babel.config.js
@@ -1,3 +1,3 @@
-export default {
+module.exports = {
   presets: [['@babel/env', {loose: true}], '@babel/typescript', '@babel/react'],
 };

--- a/packages/react-dom/jest.config.js
+++ b/packages/react-dom/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-export default {
+module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   globals: {

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -12,14 +12,16 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/floating-ui.react-dom.js",
-  "module": "dist/floating-ui.react-dom.esm.js",
-  "unpkg": "dist/floating-ui.react-dom.min.js",
-  "type": "module",
+  "main": "./dist/floating-ui.react-dom.js",
+  "module": "./dist/floating-ui.react-dom.esm.js",
+  "unpkg": "./dist/floating-ui.react-dom.min.js",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/floating-ui.react-dom.esm.js",
-      "require": "./dist/floating-ui.react-dom.cjs"
+      "types": "./index.d.ts",
+      "module": "./dist/floating-ui.react-dom.esm.js",
+      "import": "./dist/floating-ui.react-dom.mjs",
+      "default": "./dist/floating-ui.react-dom.js"
     },
     "./package.json": "./package.json",
     "./src/index.ts": "./src/index.ts"

--- a/packages/react-dom/rollup.config.js
+++ b/packages/react-dom/rollup.config.js
@@ -53,8 +53,8 @@ const bundles = [
   {
     input,
     output: {
-      file: path.join(__dirname, 'dist/floating-ui.react-dom.cjs'),
-      format: 'cjs',
+      file: path.join(__dirname, 'dist/floating-ui.react-dom.mjs'),
+      format: 'esm',
     },
   },
 ];


### PR DESCRIPTION
This copies `zustand`. The previous builds did not allow CJS to work in `create-react-app` because they don't handle `.cjs` correctly.

This PR:
- Removes `type: "module"`
- Removes `.cjs` file, replaces it with`.mjs` file

The magic line seems to be adding `import` with a `.mjs` file, which makes it work in native Node/Nuxt. `create-react-app@4` continues to work because the top-level `"module"` key points to a non-.mjs file.

Tested with:

- CRA 5
- CRA 4
- Nuxt 3
- webpack 5
- Parcel 2

Closes #1676