### PR TITLE
feat(useListNavigation): `openOnArrowKeyDown` and `disabledIndices` props

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useListNavigation.ts
+++ b/packages/react-dom-interactions/src/hooks/useListNavigation.ts
@@ -266,21 +266,26 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
 
     if (open) {
       if (activeIndex == null) {
-        if (
-          !previousOpen &&
-          focusItemOnOpenRef.current &&
-          selectedIndex == null
-        ) {
-          if (!allowEscape) {
-            indexRef.current =
-              isMainOrientationToEndKey(keyRef.current, orientation, rtl) ||
-              nested
-                ? getMinIndex(listRef, disabledIndicesRef.current)
-                : getMaxIndex(listRef, disabledIndicesRef.current);
+        if (selectedIndex != null) {
+          return;
+        }
 
-            onNavigateRef.current(indexRef.current);
-            focusItem(listRef, indexRef);
-          }
+        // Reset while the floating element was open (e.g. the list changed).
+        if (previousOpen) {
+          indexRef.current = -1;
+          focusItem(listRef, indexRef);
+        }
+
+        // Initial sync
+        if (!previousOpen && focusItemOnOpenRef.current && !allowEscape) {
+          indexRef.current =
+            isMainOrientationToEndKey(keyRef.current, orientation, rtl) ||
+            nested
+              ? getMinIndex(listRef, disabledIndicesRef.current)
+              : getMaxIndex(listRef, disabledIndicesRef.current);
+
+          onNavigateRef.current(indexRef.current);
+          focusItem(listRef, indexRef);
         }
       } else if (activeIndex >= 0 && activeIndex < listRef.current.length) {
         indexRef.current = activeIndex;

--- a/packages/react-dom-interactions/test/unit/useListNavigation.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useListNavigation.test.tsx
@@ -220,10 +220,6 @@ describe('allowEscape + virtual', () => {
     render(<App allowEscape={true} virtual loop />);
     fireEvent.keyDown(screen.getByRole('button'), {key: 'ArrowDown'});
     expect(screen.getByTestId('item-0').getAttribute('aria-selected')).toBe(
-      'false'
-    );
-    fireEvent.keyDown(screen.getByRole('button'), {key: 'ArrowDown'});
-    expect(screen.getByTestId('item-0').getAttribute('aria-selected')).toBe(
       'true'
     );
     fireEvent.keyDown(screen.getByRole('button'), {key: 'ArrowUp'});

--- a/packages/react-dom-interactions/test/unit/useListNavigation.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useListNavigation.test.tsx
@@ -262,3 +262,44 @@ describe('allowEscape + virtual', () => {
     cleanup();
   });
 });
+
+describe('openOnArrowKeyDown', () => {
+  test('true ArrowDown', () => {
+    render(<App openOnArrowKeyDown={true} />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'ArrowDown'});
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    cleanup();
+  });
+
+  test('true ArrowUp', () => {
+    render(<App openOnArrowKeyDown={true} />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'ArrowUp'});
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    cleanup();
+  });
+
+  test('false ArrowDown', () => {
+    render(<App openOnArrowKeyDown={false} />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'ArrowDown'});
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    cleanup();
+  });
+
+  test('false ArrowUp', () => {
+    render(<App openOnArrowKeyDown={false} />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'ArrowUp'});
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    cleanup();
+  });
+});
+
+describe('disabledIndices', () => {
+  test('indicies are skipped in focus order', () => {
+    render(<App disabledIndices={[0]} />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'ArrowDown'});
+    expect(screen.getByTestId('item-1')).toHaveFocus();
+    fireEvent.keyDown(screen.getByRole('menu'), {key: 'ArrowUp'});
+    expect(screen.getByTestId('item-1')).toHaveFocus();
+    cleanup();
+  });
+});

--- a/website/pages/docs/useListNavigation.mdx
+++ b/website/pages/docs/useListNavigation.mdx
@@ -39,6 +39,8 @@ interface Props {
   orientation?: 'vertical' | 'horizontal' | 'both';
   focusItemOnOpen?: 'auto' | boolean;
   focusItemOnHover?: boolean;
+  openOnArrowKeyDown?: boolean;
+  disabledIndices?: Array<number>;
 }
 ```
 
@@ -219,3 +221,33 @@ useListNavigation(context, {
 default: `true{:js}`
 
 Whether hovering an item synchronizes the focus.
+
+### openOnArrowKeyDown
+
+default: `true{:js}`
+
+Whether pressing an arrow key on the navigation's main axis opens
+the floating element.
+
+```js
+useListNavigation(context, {
+  openOnArrowKeyDown: false,
+});
+```
+
+### disabledIndices
+
+default: `openOnArrowKeyDown ? undefined : []{:js}`
+
+By default elements with either a `disabled{:.keyword}` or
+`aria-disabled{:.keyword}` attribute are skipped in the list
+navigation – however, this requires the items to be rendered.
+
+This prop allows you to manually specify indices which should be
+disabled, overriding the default logic.
+
+```js
+useListNavigation(context, {
+  disabledIndices: [0, 3],
+});
+```


### PR DESCRIPTION
Adds two new props to `useListNavigation`

## `openOnArrowKeyDown`

On Windows, select menus navigate through the items rather than opening the floating element when pressing the arrow keys without it being open. This adds some flexibility for different components that should only be opened via `Enter` / `Space` with the keyboard

## `disabledIndices`

Currently the disabled check requires the items to be rendered so it can check the attributes on the nodes (`disabled` or `aria-disabled`). But, with Windows-like select menus, the menu doesn't get rendered and so we can't check these attributes, which breaks the `find` logic. This allows the user to pass an array of disabled indices as a replacement to be able to skip items while navigating when the menu is not open. It defaults to an `array` when `openOnArrowKeyDown` is null to prevent the need to specify an empty array by default.