### PR TITLE
fix(FloatingOverlay): Safari pinch-zoom lockScroll

### DIFF
--- a/packages/react-dom-interactions/src/FloatingOverlay.tsx
+++ b/packages/react-dom-interactions/src/FloatingOverlay.tsx
@@ -15,10 +15,8 @@ export function getPlatform(): string {
     | NavigatorUAData
     | undefined;
 
-  if (uaData?.brands) {
-    return uaData.brands
-      .map((item) => `${item.brand}/${item.version}`)
-      .join(' ');
+  if (uaData?.platform) {
+    return uaData.platform;
   }
 
   return navigator.platform;
@@ -57,7 +55,7 @@ export const FloatingOverlay = React.forwardRef<
 
     // Only iOS doesn't respect `overflow: hidden` on document.body, and this
     // technique has fewer side effects.
-    if (!/iP(hone|ad|od)/.test(getPlatform())) {
+    if (!/iP(hone|ad|od)|iOS/.test(getPlatform())) {
       Object.assign(document.body.style, {
         overflow: 'hidden',
         [paddingProp]: `${scrollbarWidth}px`,

--- a/packages/react-dom-interactions/src/FloatingOverlay.tsx
+++ b/packages/react-dom-interactions/src/FloatingOverlay.tsx
@@ -44,20 +44,7 @@ export const FloatingOverlay = React.forwardRef<
       return;
     }
 
-    // Only iOS doesn't respect `overflow: hidden` on document.body, and this
-    // technique has fewer side effects.
-    if (!/iP(hone|ad|od)/.test(getUAString())) {
-      document.body.style.overflow = 'hidden';
-      return () => {
-        document.body.style.overflow = '';
-      };
-    }
-
-    // iOS 12 does not support `visuaViewport`.
-    const offsetLeft = window.visualViewport?.offsetLeft ?? 0;
-    const offsetTop = window.visualViewport?.offsetTop ?? 0;
-    const scrollX = window.pageXOffset;
-    const scrollY = window.pageYOffset;
+    document.body.setAttribute(identifier, '');
 
     // RTL <body> scrollbar
     const scrollbarX =
@@ -68,6 +55,29 @@ export const FloatingOverlay = React.forwardRef<
     const scrollbarWidth =
       window.innerWidth - document.documentElement.clientWidth;
 
+    // Only iOS doesn't respect `overflow: hidden` on document.body, and this
+    // technique has fewer side effects.
+    if (!/iP(hone|ad|od)/.test(getUAString())) {
+      Object.assign(document.body.style, {
+        overflow: 'hidden',
+        [paddingProp]: `${scrollbarWidth}px`,
+      });
+
+      return () => {
+        document.body.removeAttribute(identifier);
+        Object.assign(document.body.style, {
+          overflow: '',
+          [paddingProp]: '',
+        });
+      };
+    }
+
+    // iOS 12 does not support `visuaViewport`.
+    const offsetLeft = window.visualViewport?.offsetLeft ?? 0;
+    const offsetTop = window.visualViewport?.offsetTop ?? 0;
+    const scrollX = window.pageXOffset;
+    const scrollY = window.pageYOffset;
+
     Object.assign(document.body.style, {
       position: 'fixed',
       overflow: 'hidden',
@@ -76,8 +86,6 @@ export const FloatingOverlay = React.forwardRef<
       right: '0',
       [paddingProp]: `${scrollbarWidth}px`,
     });
-
-    document.body.setAttribute(identifier, '');
 
     return () => {
       Object.assign(document.body.style, {

--- a/packages/react-dom-interactions/src/FloatingOverlay.tsx
+++ b/packages/react-dom-interactions/src/FloatingOverlay.tsx
@@ -10,7 +10,7 @@ interface NavigatorUAData {
 }
 
 // Avoid Chrome DevTools blue warning
-export function getUAString(): string {
+export function getPlatform(): string {
   const uaData = (navigator as any).userAgentData as
     | NavigatorUAData
     | undefined;
@@ -21,7 +21,7 @@ export function getUAString(): string {
       .join(' ');
   }
 
-  return navigator.userAgent;
+  return navigator.platform;
 }
 
 /**
@@ -57,7 +57,7 @@ export const FloatingOverlay = React.forwardRef<
 
     // Only iOS doesn't respect `overflow: hidden` on document.body, and this
     // technique has fewer side effects.
-    if (!/iP(hone|ad|od)/.test(getUAString())) {
+    if (!/iP(hone|ad|od)/.test(getPlatform())) {
       Object.assign(document.body.style, {
         overflow: 'hidden',
         [paddingProp]: `${scrollbarWidth}px`,


### PR DESCRIPTION
- Use `overflow: hidden` is possible, has less side effects (so, only iOS needs the `position: fixed` hack).
- Account for `visualViewport` pinch-zoom in iOS