### PR TITLE
Fix typo closing `<div>` tag

### DIFF
--- a/website/pages/docs/FloatingPortal.mdx
+++ b/website/pages/docs/FloatingPortal.mdx
@@ -8,7 +8,7 @@ import {FloatingPortal} from '@floating-ui/react-dom-interactions';
 function Tooltip() {
   return (
     <FloatingPortal>
-      {open && <div>Tooltip<div>}
+      {open && <div>Tooltip</div>}
     </FloatingPortal>
   );
 }


### PR DESCRIPTION
Fix typo closing `<div>` tag