### PR TITLE
fix: normalize `autoUpdate` to always call update fn immediately

### DIFF
--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -97,7 +97,11 @@ export function autoUpdate(
     frameId = requestAnimationFrame(frameLoop);
   }
 
-  function cleanup() {
+  if (!elementResize) {
+    update();
+  }
+
+  return () => {
     ancestors.forEach((ancestor) => {
       ancestorScroll && ancestor.removeEventListener('scroll', update);
       ancestorResize && ancestor.removeEventListener('resize', update);
@@ -109,8 +113,5 @@ export function autoUpdate(
     if (animationFrame) {
       cancelAnimationFrame(frameId);
     }
-  }
-
-  cleanup.$$immediate = !!elementResize;
-  return cleanup;
+  };
 }

--- a/packages/react-dom-interactions/src/types.ts
+++ b/packages/react-dom-interactions/src/types.ts
@@ -52,11 +52,6 @@ export interface ElementProps {
   item?: React.HTMLProps<HTMLElement>;
 }
 
-interface CleanupFn {
-  (): void;
-  $$immediate?: boolean;
-}
-
 export type ReferenceType = Element | VirtualElement;
 
 export type UseFloatingData = Omit<ComputePositionReturn, 'x' | 'y'> & {
@@ -86,5 +81,5 @@ export interface UseFloatingProps<RT extends ReferenceType = ReferenceType> {
     reference: RT,
     floating: HTMLElement,
     update: () => void
-  ) => void | CleanupFn;
+  ) => void | (() => void);
 }

--- a/packages/react-dom/src/types.ts
+++ b/packages/react-dom/src/types.ts
@@ -10,11 +10,6 @@ export * from '@floating-ui/dom';
 export {useFloating} from './';
 export {arrow} from './';
 
-export interface CleanupFn {
-  (): void;
-  $$immediate?: boolean;
-}
-
 export type UseFloatingData = Omit<ComputePositionReturn, 'x' | 'y'> & {
   x: number | null;
   y: number | null;
@@ -41,5 +36,5 @@ export type UseFloatingProps<RT extends ReferenceType = ReferenceType> = Omit<
     reference: RT,
     floating: HTMLElement,
     update: () => void
-  ) => void | CleanupFn;
+  ) => void | (() => void);
 };

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -7,7 +7,6 @@ import type {
   UseFloatingReturn,
   UseFloatingData,
   ReferenceType,
-  CleanupFn,
 } from './types';
 import {deepEqual} from './utils/deepEqual';
 import {useLatestRef} from './utils/useLatestRef';
@@ -22,7 +21,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
   const floating = React.useRef<HTMLElement | null>(null);
 
   const whileElementsMountedRef = useLatestRef(whileElementsMounted);
-  const cleanupRef = React.useRef<CleanupFn | void | null>(null);
+  const cleanupRef = React.useRef<(() => void) | void | null>(null);
 
   const [data, setData] = React.useState<UseFloatingData>({
     // Setting these to `null` will allow the consumer to determine if
@@ -93,12 +92,6 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
         );
 
         cleanupRef.current = cleanupFn;
-
-        // Per spec, `ResizeObserver` invokes the update function immediately,
-        // so we can skip the update if that is added as an option (the default).
-        if (!(cleanupFn && cleanupFn.$$immediate)) {
-          update();
-        }
       } else {
         update();
       }


### PR DESCRIPTION
This is better as a default and prevents the need to know if it will immediately fire or not (due to the `ResizeObserver`).