### PR TITLE
fix: Fix README.md top banner size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img height="560" src="https://github.com/floating-ui/floating-ui/blob/master/website/assets/floating-ui-banner.png" alt="Floating UI">
+  <img max-height="560" src="https://github.com/floating-ui/floating-ui/blob/master/website/assets/floating-ui-banner.png" alt="Floating UI">
 <p>
 
 > **Popper is now Floating UI! For Popper v2, visit


### PR DESCRIPTION
The README.md top banner ratio is broken on narrow devices (or narrow window tab).

| before | after |
| ------ | ----- |
| <img width="409" alt="image" src="https://user-images.githubusercontent.com/32478597/168583023-9e77b5b2-ffae-4e1f-aa58-aa15491e2b89.png"> | <img width="407" alt="image" src="https://user-images.githubusercontent.com/32478597/168583087-de01a743-1a58-42d9-8715-ba571ce2de9b.png"> |

