### PR TITLE
fix(FloatingFocusManager): add combobox `aria-hidden` handling

### DIFF
--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -199,16 +199,16 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
       let cleanup: () => void;
       if (modal) {
         if (orderRef.current.includes('reference')) {
-          hideOthers([reference, floating]);
+          cleanup = hideOthers([reference, floating]);
         } else {
-          hideOthers(floating);
+          cleanup = hideOthers(floating);
         }
         // Comboboxes should not have "modal" focus management, but every other
         // node between the input and listbox popup needs to be hidden from
         // screen readers, so that touch-based screen readers immediately focus
         // the listbox options.
       } else if (reference.getAttribute('role') === 'combobox') {
-        hideOthers([reference, floating]);
+        cleanup = hideOthers([reference, floating]);
       }
 
       return () => {

--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -108,18 +108,14 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     }
 
     // If the floating element has no focusable elements inside it, fallback
-    // to focusing the floating element and preventing tab navigation, unless
-    // the reference element is a combobox.
+    // to focusing the floating element and preventing tab navigation
     const noTabbableContentElements =
       getTabbableElements().filter(
         (el) =>
           el !== refs.floating.current &&
           // @ts-expect-error
           el !== refs.reference.current
-      ).length === 0 &&
-      (isHTMLElement(refs.reference.current)
-        ? refs.reference.current.getAttribute('role') !== 'combobox'
-        : true);
+      ).length === 0;
 
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === 'Tab') {

--- a/packages/react-dom-interactions/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react-dom-interactions/test/unit/FloatingFocusManager.test.tsx
@@ -238,6 +238,44 @@ describe('modal', () => {
 
     cleanup();
   });
+
+  test('false - comboboxes hide all other nodes', async () => {
+    function App() {
+      const [open, setOpen] = useState(false);
+      const {reference, floating, context} = useFloating({
+        open,
+        onOpenChange: setOpen,
+      });
+
+      return (
+        <>
+          <button
+            role="combobox"
+            data-testid="reference"
+            ref={reference}
+            onFocus={() => setOpen(!open)}
+          />
+          <button data-testid="btn-1" />
+          <button data-testid="btn-2" />
+          {open && (
+            <FloatingFocusManager context={context} modal={false}>
+              <div role="listbox" ref={floating} data-testid="floating" />
+            </FloatingFocusManager>
+          )}
+        </>
+      );
+    }
+
+    render(<App />);
+
+    fireEvent.focus(screen.getByTestId('reference'));
+    expect(screen.getByTestId('reference')).not.toHaveAttribute('aria-hidden');
+    expect(screen.getByTestId('floating')).not.toHaveAttribute('aria-hidden');
+    expect(screen.getByTestId('btn-1')).toHaveAttribute('aria-hidden');
+    expect(screen.getByTestId('btn-2')).toHaveAttribute('aria-hidden');
+
+    cleanup();
+  });
 });
 
 describe('order', () => {


### PR DESCRIPTION
For touch-based screen readers, combobox popups can't be portalled unless every other node between the input and popup have `aria-hidden` — this change allows the popup to be portalled while remaining accessible to touch-based screen readers