### PR TITLE
fix: save portal node to state instead of ref

### DIFF
--- a/packages/react-dom-interactions/src/FloatingPortal.tsx
+++ b/packages/react-dom-interactions/src/FloatingPortal.tsx
@@ -49,21 +49,13 @@ export const FloatingPortal = ({
   id?: string;
   root?: HTMLElement | null;
 }): React.ReactPortal | null => {
-  const [mounted, setMounted] = React.useState(false);
   const portalNode = useFloatingPortalNode({id, enabled: !root});
-
-  useLayoutEffect(() => {
-    if (root) {
-      return;
-    }
-    setMounted(true);
-  }, [root]);
 
   if (root) {
     return createPortal(children, root);
   }
 
-  if (mounted && portalNode) {
+  if (portalNode) {
     return createPortal(children, portalNode);
   }
 

--- a/packages/react-dom-interactions/src/FloatingPortal.tsx
+++ b/packages/react-dom-interactions/src/FloatingPortal.tsx
@@ -11,7 +11,7 @@ export const useFloatingPortalNode = ({
   id?: string;
   enabled?: boolean;
 } = {}) => {
-  const portalRef = React.useRef<HTMLElement | null>(null);
+  const [portalRef, setPortalRef] = React.useState<HTMLElement | null>(null);
 
   useLayoutEffect(() => {
     if (!enabled) {
@@ -21,18 +21,21 @@ export const useFloatingPortalNode = ({
     const rootNode = document.getElementById(id);
 
     if (rootNode) {
-      portalRef.current = rootNode;
+      setPortalRef(rootNode);
     } else {
-      portalRef.current = document.createElement('div');
-      portalRef.current.id = id;
-    }
-
-    if (!document.body.contains(portalRef.current)) {
-      document.body.appendChild(portalRef.current);
+      const newPortalRef = document.createElement('div');
+      newPortalRef.id = id;
+      setPortalRef(newPortalRef);
     }
   }, [id, enabled]);
 
-  return portalRef.current;
+  useLayoutEffect(() => {
+    if (portalRef && !document.body.contains(portalRef)) {
+      document.body.appendChild(portalRef);
+    }
+  }, [portalRef]);
+
+  return portalRef;
 };
 
 /**

--- a/packages/react-dom-interactions/src/FloatingPortal.tsx
+++ b/packages/react-dom-interactions/src/FloatingPortal.tsx
@@ -23,17 +23,15 @@ export const useFloatingPortalNode = ({
     if (rootNode) {
       setPortalEl(rootNode);
     } else {
-      const newPortalRef = document.createElement('div');
-      newPortalRef.id = id;
-      setPortalEl(newPortalRef);
+      const newPortalEl = document.createElement('div');
+      newPortalEl.id = id;
+      setPortalEl(newPortalEl);
+
+      if (!document.body.contains(newPortalEl)) {
+        document.body.appendChild(newPortalEl);
+      }
     }
   }, [id, enabled]);
-
-  useLayoutEffect(() => {
-    if (portalEl && !document.body.contains(portalEl)) {
-      document.body.appendChild(portalEl);
-    }
-  }, [portalEl]);
 
   return portalEl;
 };

--- a/packages/react-dom-interactions/src/FloatingPortal.tsx
+++ b/packages/react-dom-interactions/src/FloatingPortal.tsx
@@ -11,7 +11,7 @@ export const useFloatingPortalNode = ({
   id?: string;
   enabled?: boolean;
 } = {}) => {
-  const [portalRef, setPortalRef] = React.useState<HTMLElement | null>(null);
+  const [portalEl, setPortalEl] = React.useState<HTMLElement | null>(null);
 
   useLayoutEffect(() => {
     if (!enabled) {
@@ -21,21 +21,21 @@ export const useFloatingPortalNode = ({
     const rootNode = document.getElementById(id);
 
     if (rootNode) {
-      setPortalRef(rootNode);
+      setPortalEl(rootNode);
     } else {
       const newPortalRef = document.createElement('div');
       newPortalRef.id = id;
-      setPortalRef(newPortalRef);
+      setPortalEl(newPortalRef);
     }
   }, [id, enabled]);
 
   useLayoutEffect(() => {
-    if (portalRef && !document.body.contains(portalRef)) {
-      document.body.appendChild(portalRef);
+    if (portalEl && !document.body.contains(portalEl)) {
+      document.body.appendChild(portalEl);
     }
-  }, [portalRef]);
+  }, [portalEl]);
 
-  return portalRef;
+  return portalEl;
 };
 
 /**


### PR DESCRIPTION
I ran into an issue with the current implementation. Essentially, when the portal node ref is passed into another component, it is `null` initially. Since it is saved into a ref, it won't trigger a re-render when it changes from `null` to `HTMLElement`, which causes the component not to render at all or render into a wrong node until it rerenders for some other reason.

An example, maybe it is helpful - in this case, ModalInner will never be rendered:
```
export const Modal: React.FunctionComponent<Props> = (props) => {
  const portalNode = useFloatingPortalNode();

  if (!portalNode) {
    return null;
  }

  // portalNode is required
  return <ModalInner {...props} portalNode={portalNode} />;
};
```

Happy to discuss other ways as well how this could be improved - it was easier to file this simple PR to start :)