### PR TITLE
fix(FloatingFocusManager): `shift+tab` outside reference element closes floating element

### DIFF
--- a/packages/react-dom-interactions/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react-dom-interactions/test/unit/FloatingFocusManager.test.tsx
@@ -232,9 +232,7 @@ describe('modal', () => {
     await userEvent.tab({shift: true});
     await userEvent.tab({shift: true});
 
-    expect(
-      screen.getByTestId('floating').contains(document.activeElement)
-    ).toBe(false);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
     cleanup();
   });


### PR DESCRIPTION
Brought up in https://github.com/floating-ui/floating-ui/discussions/1717. In non-modal mode, `shift+tab` outside of the reference element should close the floating element if it is open. 