### PR TITLE
fix(useHover): block `pointer-events` when using safePolygon

### DIFF
--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -1,6 +1,6 @@
 import {hideOthers} from 'aria-hidden';
 import * as React from 'react';
-import {useFloatingParentNodeId, useFloatingTree} from './FloatingTree';
+import {useFloatingTree} from './FloatingTree';
 import type {FloatingContext, ReferenceType} from './types';
 import {activeElement} from './utils/activeElement';
 import {getAncestors} from './utils/getAncestors';
@@ -71,7 +71,6 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
   const orderRef = useLatestRef(order);
   const onOpenChangeRef = useLatestRef(onOpenChange);
   const tree = useFloatingTree();
-  const parentId = useFloatingParentNodeId();
 
   const getTabbableElements = React.useCallback(() => {
     return orderRef.current
@@ -220,12 +219,10 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
   }, [
     nodeId,
     tree,
-    parentId,
     modal,
     onOpenChangeRef,
     orderRef,
     getTabbableElements,
-    initialFocus,
     refs,
   ]);
 
@@ -248,14 +245,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
         focus(previouslyFocusedElement);
       }
     };
-  }, [
-    preventTabbing,
-    getTabbableElements,
-    initialFocus,
-    modal,
-    returnFocus,
-    refs,
-  ]);
+  }, [preventTabbing, getTabbableElements, initialFocus, returnFocus, refs]);
 
   const isTypeableCombobox = () =>
     isHTMLElement(refs.reference.current) &&

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -68,7 +68,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     function onPointerDown(event: MouseEvent) {
       const targetIsInsideChildren =
         tree &&
-        getChildren(tree, nodeId).some((node) =>
+        getChildren(tree.nodesRef.current, nodeId).some((node) =>
           isEventTargetWithin(event, node.context?.refs.floating.current)
         );
 

--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -245,7 +245,6 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     mouseOnly,
     onOpenChangeRef,
     open,
-    parentId,
     tree,
     restMs,
     cleanupPointerMoveHandler,

--- a/packages/react-dom-interactions/src/safePolygon.ts
+++ b/packages/react-dom-interactions/src/safePolygon.ts
@@ -80,7 +80,9 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
       // If any nested child is open, abort.
       if (
         tree &&
-        getChildren(tree, nodeId).some(({context}) => context?.open)
+        getChildren(tree.nodesRef.current, nodeId).some(
+          ({context}) => context?.open
+        )
       ) {
         return;
       }

--- a/packages/react-dom-interactions/src/utils/getAncestors.ts
+++ b/packages/react-dom-interactions/src/utils/getAncestors.ts
@@ -1,0 +1,20 @@
+import type {FloatingNodeType, ReferenceType} from '../types';
+
+export function getAncestors<RT extends ReferenceType = ReferenceType>(
+  nodes: Array<FloatingNodeType<RT>>,
+  id: string | undefined
+) {
+  let allAncestors: Array<FloatingNodeType<RT>> = [];
+  let currentParentId = nodes.find((node) => node.id === id)?.parentId;
+
+  while (currentParentId) {
+    const currentNode = nodes.find((node) => node.id === currentParentId);
+    currentParentId = currentNode?.parentId;
+
+    if (currentNode) {
+      allAncestors = allAncestors.concat(currentNode);
+    }
+  }
+
+  return allAncestors;
+}

--- a/packages/react-dom-interactions/src/utils/getChildren.ts
+++ b/packages/react-dom-interactions/src/utils/getChildren.ts
@@ -1,18 +1,16 @@
-import type {FloatingTreeType, ReferenceType} from '../types';
+import type {FloatingNodeType, ReferenceType} from '../types';
 
 export function getChildren<RT extends ReferenceType = ReferenceType>(
-  tree: FloatingTreeType<RT>,
+  nodes: Array<FloatingNodeType<RT>>,
   id: string | undefined
 ) {
   let allChildren =
-    tree?.nodesRef.current.filter(
-      (node) => node.parentId === id && node.context?.open
-    ) ?? [];
+    nodes.filter((node) => node.parentId === id && node.context?.open) ?? [];
   let currentChildren = allChildren;
 
   while (currentChildren.length) {
     currentChildren =
-      tree?.nodesRef.current.filter((node) =>
+      nodes.filter((node) =>
         currentChildren?.some(
           (n) => node.parentId === n.id && node.context?.open
         )

--- a/packages/react-dom-interactions/test/unit/getAncestors.test.ts
+++ b/packages/react-dom-interactions/test/unit/getAncestors.test.ts
@@ -1,0 +1,17 @@
+import {getAncestors} from '../../src/utils/getAncestors';
+
+test('returns an array of ancestors', () => {
+  expect(
+    getAncestors(
+      [
+        {id: '0', parentId: null},
+        {id: '1', parentId: '0'},
+        {id: '2', parentId: '1'},
+      ],
+      '2'
+    )
+  ).toEqual([
+    {id: '1', parentId: '0'},
+    {id: '0', parentId: null},
+  ]);
+});

--- a/packages/react-dom-interactions/test/unit/getChildren.test.ts
+++ b/packages/react-dom-interactions/test/unit/getChildren.test.ts
@@ -1,0 +1,24 @@
+import {FloatingContext} from '../../src/types';
+import {getChildren} from '../../src/utils/getChildren';
+
+const contextOpen = {open: true} as FloatingContext;
+const contextClosed = {open: false} as FloatingContext;
+
+test('returns an array of children, ignoring closed ones', () => {
+  expect(
+    getChildren(
+      [
+        {id: '0', parentId: null, context: contextOpen},
+        {id: '1', parentId: '0', context: contextOpen},
+        {id: '2', parentId: '1', context: contextOpen},
+        {id: '3', parentId: '1', context: contextOpen},
+        {id: '4', parentId: '1', context: contextClosed},
+      ],
+      '0'
+    )
+  ).toEqual([
+    {id: '1', parentId: '0', context: contextOpen},
+    {id: '2', parentId: '1', context: contextOpen},
+    {id: '3', parentId: '1', context: contextOpen},
+  ]);
+});

--- a/packages/react-dom-interactions/test/visual/components/Menu.tsx
+++ b/packages/react-dom-interactions/test/visual/components/Menu.tsx
@@ -80,6 +80,7 @@ export const MenuComponent = forwardRef<
 >(({children, label, ...props}, ref) => {
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [allowHover, setAllowHover] = useState(false);
 
   const listItemsRef = useRef<Array<HTMLButtonElement | null>>([]);
   const listContentRef = useRef(
@@ -93,8 +94,8 @@ export const MenuComponent = forwardRef<
   const parentId = useFloatingParentNodeId();
   const nested = parentId != null;
 
-  const {x, y, reference, floating, strategy, refs, update, context} =
-    useFloating({
+  const {x, y, reference, floating, strategy, refs, context} =
+    useFloating<HTMLButtonElement>({
       open,
       onOpenChange: setOpen,
       middleware: [
@@ -104,14 +105,20 @@ export const MenuComponent = forwardRef<
       ],
       placement: nested ? 'right-start' : 'bottom-start',
       nodeId,
+      whileElementsMounted: autoUpdate,
     });
 
   const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
     useHover(context, {
-      handleClose: safePolygon(),
-      enabled: nested,
+      handleClose: safePolygon({restMs: 25}),
+      enabled: nested && allowHover,
+      delay: {open: 50},
     }),
-    useClick(context),
+    useClick(context, {
+      toggle: !nested,
+      pointerDown: true,
+      ignoreMouse: nested,
+    }),
     useRole(context, {role: 'menu'}),
     useDismiss(context),
     useListNavigation(context, {
@@ -127,48 +134,47 @@ export const MenuComponent = forwardRef<
     }),
   ]);
 
+  // Event emitter closes all menus when an item gets clicked anywhere in the
+  // tree.
   useEffect(() => {
-    if (open && refs.reference.current && refs.floating.current) {
-      return autoUpdate(refs.reference.current, refs.floating.current, update);
-    }
-  }, [open, nested, update, refs.reference, refs.floating]);
+    function onTreeClick() {
+      setOpen(false);
 
-  // Block pointer events of sibling list items while a nested submenu is open
-  useEffect(() => {
-    function onTreeOpenChange({
-      open,
-      reference,
-      parentId,
-    }: {
-      open: boolean;
-      reference: Element;
-      parentId: string;
-    }) {
-      if (parentId !== nodeId) {
-        return;
+      if (parentId === null) {
+        refs.reference.current?.focus();
       }
-
-      listItemsRef.current.forEach((item) => {
-        if (item && item !== reference) {
-          item.style.pointerEvents = open ? 'none' : '';
-        }
-      });
     }
 
-    tree?.events.on('openChange', onTreeOpenChange);
-
+    tree?.events.on('click', onTreeClick);
     return () => {
-      tree?.events.off('openChange', onTreeOpenChange);
+      tree?.events.off('click', onTreeClick);
     };
-  }, [nodeId, tree?.events, refs.reference, refs.floating]);
+  }, [nodeId, open, parentId, tree, refs.reference]);
 
+  // Determine if "hover" logic can run based on the modality of input. This
+  // prevents unwanted focus synchronization as menus open and close with
+  // keyboard navigation and the cursor is resting on the menu.
   useEffect(() => {
-    tree?.events.emit('openChange', {
-      open,
-      parentId,
-      reference: refs.reference.current,
+    function onPointerMove() {
+      setAllowHover(true);
+    }
+
+    function onKeyDown() {
+      setAllowHover(false);
+    }
+
+    window.addEventListener('pointermove', onPointerMove, {
+      once: true,
+      capture: true,
     });
-  }, [tree, open, parentId, refs.reference]);
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      window.removeEventListener('pointermove', onPointerMove, {
+        capture: true,
+      });
+      window.removeEventListener('keydown', onKeyDown, true);
+    };
+  }, [allowHover]);
 
   const mergedReferenceRef = useMemo(
     () => mergeRefs([ref, reference]),
@@ -187,17 +193,26 @@ export const MenuComponent = forwardRef<
             ? {
                 role: 'menuitem',
                 className: `MenuItem${open ? ' open' : ''}`,
+                onKeyDown(event) {
+                  // Prevent more than one menu from being open.
+                  if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+                    setOpen(false);
+                  }
+                },
               }
-            : {
-                className: `RootMenu${open ? ' open' : ''}`,
-              }),
+            : {className: `RootMenu${open ? ' open' : ''}`}),
         })}
       >
-        {label} {nested && <span>➔</span>}
+        {label} {nested && <span style={{marginLeft: 10}}>➔</span>}
       </button>
       <FloatingPortal>
         {open && (
-          <FloatingFocusManager context={context} preventTabbing>
+          <FloatingFocusManager
+            context={context}
+            preventTabbing
+            modal={!nested}
+            order={['reference', 'content']}
+          >
             <div
               {...getFloatingProps({
                 className: 'Menu',
@@ -220,6 +235,17 @@ export const MenuComponent = forwardRef<
                       className: 'MenuItem',
                       ref(node: HTMLButtonElement) {
                         listItemsRef.current[index] = node;
+                      },
+                      onClick() {
+                        tree?.events.emit('click');
+                      },
+                      // By default `focusItemOnHover` uses `pointermove` sync,
+                      // but when a menu closes we want this to sync it on
+                      // `enter` even if the cursor didn't move.
+                      onPointerEnter() {
+                        if (allowHover) {
+                          setActiveIndex(index);
+                        }
                       },
                     })
                   )


### PR DESCRIPTION
As a benefit, nested dropdown menus now no longer need to block sibling list items' `pointer-events`. This assumes something else is not controlling document.body's `pointer-events` style

Closes #1722