### PR TITLE
Add missing peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19551,6 +19551,10 @@
         "rollup": "^2.60.1",
         "rollup-plugin-terser": "^7.0.2",
         "ts-jest": "^27.0.7"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "packages/react-native": {
@@ -21059,7 +21063,7 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.1.1",
         "@testing-library/react-hooks": "^7.0.2",
-        "@testing-library/user-event": "*",
+        "@testing-library/user-event": "^14.1.1",
         "@types/jest": "^27.0.3",
         "@types/react": "^18.0.1",
         "aria-hidden": "^1.1.3",

--- a/packages/react-dom-interactions/package.json
+++ b/packages/react-dom-interactions/package.json
@@ -56,6 +56,10 @@
     "react",
     "react-dom"
   ],
+  "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+  },
   "dependencies": {
     "@floating-ui/react-dom": "^0.6.1",
     "aria-hidden": "^1.1.3",


### PR DESCRIPTION
Yarn requires peer dependencies to be specified at each level of nesting if you have deeply nested packages with peer deps.  This adds the missing peer deps to react-dom-interactions since it depends on `@floating-ui/react-dom` which has peer deps.

This is what the error currently looks like that this will fix.

![image](https://user-images.githubusercontent.com/25914066/170558516-6a77e3c2-fb8d-4855-a080-d82463e33f96.png)
