### PR TITLE
fix(react-dom-interactions): some edge cases

### DIFF
--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -6,6 +6,7 @@ import {activeElement} from './utils/activeElement';
 import {getChildren} from './utils/getChildren';
 import {getDocument} from './utils/getDocument';
 import {isElement, isHTMLElement} from './utils/is';
+import {isTypeableElement, TYPEABLE_SELECTOR} from './utils/isTypeableElement';
 import {stopEvent} from './utils/stopEvent';
 import {useLatestRef} from './utils/useLatestRef';
 
@@ -18,10 +19,9 @@ function focus(el: HTMLElement | undefined) {
 }
 
 const SELECTOR =
-  "input:not([type='hidden']):not([disabled]),select:not([disabled])," +
-  'textarea:not([disabled]),a[href],button:not([disabled]),[tabindex],' +
+  'select:not([disabled]),a[href],button:not([disabled]),[tabindex],' +
   'iframe,object,embed,area[href],audio[controls],video[controls],' +
-  "[contenteditable]:not([contenteditable='false'])";
+  TYPEABLE_SELECTOR;
 
 const FocusGuard = React.forwardRef<
   HTMLSpanElement,
@@ -100,15 +100,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
           return tabIndex[0].trim() !== '-';
         }
       }) as Array<HTMLElement>;
-  }, [orderRef, refs.floating, refs.reference]);
-
-  const isInputCombobox = React.useCallback(
-    () =>
-      isHTMLElement(refs.reference.current) &&
-      refs.reference.current.getAttribute('role') === 'combobox' &&
-      refs.reference.current.tagName === 'INPUT',
-    [refs]
-  );
+  }, [orderRef, refs]);
 
   React.useEffect(() => {
     if (!modal) {
@@ -168,14 +160,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     return () => {
       doc.removeEventListener('keydown', onKeyDown);
     };
-  }, [
-    preventTabbing,
-    modal,
-    getTabbableElements,
-    orderRef,
-    refs.floating,
-    refs.reference,
-  ]);
+  }, [preventTabbing, modal, getTabbableElements, orderRef, refs]);
 
   React.useEffect(() => {
     function onFloatingFocusOut(event: FocusEvent) {
@@ -226,8 +211,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     orderRef,
     getTabbableElements,
     initialFocus,
-    refs.floating,
-    refs.reference,
+    refs,
   ]);
 
   React.useEffect(() => {
@@ -255,15 +239,20 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     initialFocus,
     modal,
     returnFocus,
-    refs.floating,
+    refs,
   ]);
+
+  const isTypeableCombobox = () =>
+    isHTMLElement(refs.reference.current) &&
+    refs.reference.current.getAttribute('role') === 'combobox' &&
+    isTypeableElement(refs.reference.current);
 
   return (
     <>
       {modal && (
         <FocusGuard
           onFocus={(event) => {
-            if (isInputCombobox()) {
+            if (isTypeableCombobox()) {
               return;
             }
 
@@ -284,7 +273,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
       {modal && endGuard && (
         <FocusGuard
           onFocus={(event) => {
-            if (isInputCombobox()) {
+            if (isTypeableCombobox()) {
               return;
             }
 

--- a/packages/react-dom-interactions/src/hooks/useClick.ts
+++ b/packages/react-dom-interactions/src/hooks/useClick.ts
@@ -1,6 +1,7 @@
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import * as React from 'react';
 import {isHTMLElement} from '../utils/is';
+import {isTypeableElement} from '../utils/isTypeableElement';
 
 export interface Props {
   enabled?: boolean;
@@ -31,6 +32,10 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
     );
   }
 
+  function isSpaceIgnored() {
+    return isTypeableElement(refs.reference.current);
+  }
+
   if (!enabled) {
     return {};
   }
@@ -38,6 +43,12 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
   return {
     reference: {
       onPointerDown(event) {
+        // Ignore all buttons except for the "main" button.
+        // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+        if (event.button !== 0) {
+          return;
+        }
+
         pointerTypeRef.current = event.pointerType;
 
         if (pointerTypeRef.current === 'mouse' && ignoreMouse) {
@@ -85,7 +96,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
           return;
         }
 
-        if (event.key === ' ') {
+        if (event.key === ' ' && !isSpaceIgnored()) {
           // Prvent scrolling
           event.preventDefault();
         }
@@ -101,7 +112,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
         }
       },
       onKeyUp(event) {
-        if (isButton()) {
+        if (isButton() || isSpaceIgnored()) {
           return;
         }
 

--- a/packages/react-dom-interactions/src/hooks/useFocus.ts
+++ b/packages/react-dom-interactions/src/hooks/useFocus.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
+import {activeElement} from '../utils/activeElement';
 import {getDocument} from '../utils/getDocument';
 import {isElement} from '../utils/is';
 
@@ -28,7 +29,10 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
     const win = doc.defaultView ?? window;
 
     function onBlur() {
-      if (pointerTypeRef.current) {
+      if (
+        pointerTypeRef.current &&
+        refs.reference.current === activeElement(doc)
+      ) {
         blockFocusRef.current = !open;
       }
     }
@@ -46,7 +50,7 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
       win.removeEventListener('focus', onFocus);
       win.removeEventListener('blur', onBlur);
     };
-  }, [refs.floating, open, enabled]);
+  }, [refs, open, enabled]);
 
   React.useEffect(() => {
     if (!enabled) {

--- a/packages/react-dom-interactions/src/utils/isTypeableElement.ts
+++ b/packages/react-dom-interactions/src/utils/isTypeableElement.ts
@@ -1,0 +1,9 @@
+import {isHTMLElement} from './is';
+
+export const TYPEABLE_SELECTOR =
+  "input:not([type='hidden']):not([disabled])," +
+  "[contenteditable]:not([contenteditable='false']),textarea:not([disabled])";
+
+export function isTypeableElement(element: unknown): boolean {
+  return isHTMLElement(element) && element.matches(TYPEABLE_SELECTOR);
+}

--- a/packages/react-dom-interactions/test/unit/useClick.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useClick.test.tsx
@@ -3,7 +3,11 @@ import {useState} from 'react';
 import {useClick, useFloating, useInteractions} from '../../src';
 import type {Props} from '../../src/hooks/useClick';
 
-function App({button = true, ...props}: Props & {button?: boolean}) {
+function App({
+  button = true,
+  typeable = false,
+  ...props
+}: Props & {button?: boolean; typeable?: boolean}) {
   const [open, setOpen] = useState(false);
   const {reference, floating, context} = useFloating({
     open,
@@ -13,7 +17,7 @@ function App({button = true, ...props}: Props & {button?: boolean}) {
     useClick(context, props),
   ]);
 
-  const Tag = button ? 'button' : 'div';
+  const Tag = typeable ? 'input' : button ? 'button' : 'div';
 
   return (
     <>
@@ -136,6 +140,27 @@ describe('non-buttons', () => {
 
     const button = screen.getByTestId('reference');
     fireEvent.keyUp(button, {key: ' '});
+
+    expect(screen.queryByRole('tooltip')).toBeInTheDocument();
+    cleanup();
+  });
+
+  test('typeable reference does not receive space key handler', async () => {
+    render(<App typeable={true} />);
+
+    const button = screen.getByTestId('reference');
+    fireEvent.keyDown(button, {key: ' '});
+    fireEvent.keyUp(button, {key: ' '});
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    cleanup();
+  });
+
+  test('typeable reference does receive Enter key handler', async () => {
+    render(<App typeable={true} />);
+
+    const button = screen.getByTestId('reference');
+    fireEvent.keyDown(button, {key: 'Enter'});
 
     expect(screen.queryByRole('tooltip')).toBeInTheDocument();
     cleanup();


### PR DESCRIPTION
Addresses some small edge cases:

- fix(useFocus): `pointerDown` on reference, then `shift+tab` outside the reference when it was first in the focus order (window blurred) would not run the focus handler when tabbing back into it.
- fix(useClick): enabling `pointerDown` should not respond to right click or other mouse buttons, only the "main" button.
- fix(FloatingFocusManager/useClick): improve `isInputCombobox()` check by checking for typeability (incl. `textarea` and `contenteditable` elements). In addition, don't add a Space keyboard handler for `useClick()` when the reference is typeable.