### PR TITLE
fix(types): missing DOM types

### DIFF
--- a/packages/dom/index.test-d.ts
+++ b/packages/dom/index.test-d.ts
@@ -137,6 +137,16 @@ autoPlacement({
 size({boundary: document.body});
 size({boundary: [document.body]});
 size({boundary: 'clippingAncestors'});
+size({
+  apply({elements, availableHeight, availableWidth}) {
+    availableHeight;
+    availableWidth;
+    // @ts-expect-error
+    elements.floating.style = '';
+    // @ts-expect-error
+    elements.reference.style = '';
+  },
+});
 
 offset();
 offset(5);

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -14,8 +14,9 @@ import type {
   RootBoundary,
   ShiftOptions,
   SideObject,
-  SizeOptions,
-  Strategy
+  SizeOptions as CoreSizeOptions,
+  Strategy,
+  ComputePositionConfig as CoreComputePositionConfig,
 } from '@floating-ui/core';
 
 type Promisable<T> = T | Promise<T>;
@@ -60,6 +61,27 @@ export type DetectOverflowOptions = Omit<
   'boundary'
 > & {
   boundary: Boundary;
+};
+
+export type SizeOptions = Omit<CoreSizeOptions, 'apply'> & {
+  /**
+   * Function that is called to perform style mutations to the floating element
+   * to change its size.
+   * @default undefined
+   */
+  apply(
+    middlewareArguments: MiddlewareArguments & {
+      availableWidth: number;
+      availableHeight: number;
+    }
+  ): void;
+};
+
+export type ComputePositionConfig = Omit<
+  CoreComputePositionConfig,
+  'middleware'
+> & {
+  middleware?: Middleware[];
 };
 
 /**
@@ -176,7 +198,6 @@ export type {
   RootBoundary,
   MiddlewareReturn,
   MiddlewareData,
-  ComputePositionConfig,
   ComputePositionReturn,
 } from '@floating-ui/core';
 

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -70,7 +70,7 @@ export type SizeOptions = Omit<CoreSizeOptions, 'apply'> & {
    * @default undefined
    */
   apply(
-    middlewareArguments: MiddlewareArguments & {
+    args: MiddlewareArguments & {
       availableWidth: number;
       availableHeight: number;
     }

--- a/packages/react-dom/index.test-d.tsx
+++ b/packages/react-dom/index.test-d.tsx
@@ -7,7 +7,18 @@ function App() {
   useFloating();
   const {reference, floating, update} = useFloating({
     placement: 'right',
-    middleware: [shift(), arrow({element: arrowRef})],
+    middleware: [
+      shift(),
+      arrow({element: arrowRef}),
+      {
+        name: 'test',
+        async fn({elements}) {
+          // @ts-expect-error
+          elements.floating.style = '';
+          return {};
+        },
+      },
+    ],
     strategy: 'fixed',
   });
   reference(null);


### PR DESCRIPTION
`elements` was typed as `any` but should have strict DOM types