### PR TITLE
fix: correct return type for useFloatingPortalNode

### DIFF
--- a/.config/tsconfig.json
+++ b/.config/tsconfig.json
@@ -12,6 +12,7 @@
     "emitDeclarationOnly": true,
     "jsx": "react-jsx",
     "outDir": "../packages",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true
   }
 }


### PR DESCRIPTION
Without the explicit return type, the built TS definitions say that the return is always HTMLElement, which is not correct:

```ts
export declare const useFloatingPortalNode: ({ id, enabled, }?: {
    id?: string;
    enabled?: boolean;
}) => HTMLElement;
```

After this, the return type also includes `null`, as is correct.

An alternative solution would be to set `"strict": true` in tsconfig, then the null is added by TS - that might be the better solution overall, as it would add the missing nulls to other potential places as well, but it might also create more churn for users who haven't dealt with nulls..