### PR TITLE
Adds requestAnimationFrame to new ResizeObserver

### DIFF
--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -68,7 +68,17 @@ export function autoUpdate(
 
   let observer: ResizeObserver | null = null;
   if (elementResize) {
-    observer = new ResizeObserver(update);
+    observer = new ResizeObserver((props) => {
+      // Wrap callback call in requestAnimationFrame to avoid error: "ResizeObserver loop limit exceeded"
+      // https://stackoverflow.com/a/58701523
+      // REF:
+      // - https://github.com/WICG/resize-observer/issues/38
+      // - https://github.com/w3c/csswg-drafts/issues/5023
+      // - https://github.com/w3c/csswg-drafts/issues/5488
+      requestAnimationFrame(() => {
+        update(props);
+      });
+    });
     isElement(reference) && !animationFrame && observer.observe(reference);
     observer.observe(floating);
   }

--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -68,16 +68,14 @@ export function autoUpdate(
 
   let observer: ResizeObserver | null = null;
   if (elementResize) {
-    observer = new ResizeObserver((props) => {
+    observer = new ResizeObserver(() => {
       // Wrap callback call in requestAnimationFrame to avoid error: "ResizeObserver loop limit exceeded"
       // https://stackoverflow.com/a/58701523
       // REF:
       // - https://github.com/WICG/resize-observer/issues/38
       // - https://github.com/w3c/csswg-drafts/issues/5023
       // - https://github.com/w3c/csswg-drafts/issues/5488
-      requestAnimationFrame(() => {
-        update(props);
-      });
+      requestAnimationFrame(update);
     });
     isElement(reference) && !animationFrame && observer.observe(reference);
     observer.observe(floating);


### PR DESCRIPTION
Fixes #1569

Wrap callback call in requestAnimationFrame to avoid error: "ResizeObserver loop limit exceeded"
ref: https://stackoverflow.com/a/58701523