### PR TITLE
fix(core): add a safeguard return after 50 iterations

### DIFF
--- a/packages/core/src/computePosition.ts
+++ b/packages/core/src/computePosition.ts
@@ -56,17 +56,18 @@ export const computePosition: ComputePosition = async (
   let {x, y} = computeCoordsFromPlacement(rects, placement, rtl);
   let statefulPlacement = placement;
   let middlewareData: MiddlewareData = {};
+  let loopCount = 0;
 
-  let _debug_loop_count_ = 0;
   for (let i = 0; i < middleware.length; i++) {
+    loopCount++;
+
     if (__DEV__) {
-      _debug_loop_count_++;
-      if (_debug_loop_count_ > 100) {
-        throw new Error(
+      if (loopCount > 50) {
+        console.warn(
           [
-            'Floating UI: The middleware lifecycle appears to be',
-            'running in an infinite loop. This is usually caused by a `reset`',
-            'continually being returned without a break condition.',
+            'Floating UI: The middleware lifecycle appears to be running in an',
+            'infinite loop. This is usually caused by a `reset` continually',
+            'being returned without a break condition.',
           ].join(' ')
         );
       }
@@ -102,7 +103,7 @@ export const computePosition: ComputePosition = async (
       },
     };
 
-    if (reset) {
+    if (reset && loopCount <= 50) {
       if (typeof reset === 'object') {
         if (reset.placement) {
           statefulPlacement = reset.placement;


### PR DESCRIPTION
Instead of defaulting to an infinite loop in prod, it's better to just use whatever's ready after 50 iterations, even if a `reset` is being requested. It appears in some scenarios, `size` and `flip` together can cause a loop depending on the styles. I have not yet figured out why but it was brought up in https://github.com/shoelace-style/shoelace/issues/777

This is also the case in Popper 2, where in DEV, it threw an error, but it's possible not to even discover it while developing because it requires a specific configuration. Plus, it's hard for non-dev users to debug.  

Therefore, it should just use whatever is ready after 50 iterations