### PR TITLE
fix: use DOM reference in place of refs.reference

### DIFF
--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -76,7 +76,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     return orderRef.current
       .map((type) => {
         if (type === 'reference') {
-          return dataRef.current.domReference;
+          return refs.domReference.current;
         }
 
         if (refs.floating.current && type === 'floating') {
@@ -93,10 +93,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
       })
       .flat()
       .filter((el) => {
-        if (
-          el === refs.floating.current ||
-          el === dataRef.current.domReference
-        ) {
+        if (el === refs.floating.current || el === refs.domReference.current) {
           return true;
         }
 
@@ -105,7 +102,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
           return tabIndex[0].trim() !== '-';
         }
       }) as Array<HTMLElement>;
-  }, [orderRef, dataRef, refs]);
+  }, [orderRef, refs]);
 
   React.useEffect(() => {
     if (!modal) {
@@ -116,8 +113,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     // to focusing the floating element and preventing tab navigation
     const noTabbableContentElements =
       getTabbableElements().filter(
-        (el) =>
-          el !== refs.floating.current && el !== dataRef.current.domReference
+        (el) => el !== refs.floating.current && el !== refs.domReference.current
       ).length === 0;
 
     function onKeyDown(event: KeyboardEvent) {
@@ -137,7 +133,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
 
         if (
           orderRef.current[0] === 'reference' &&
-          target === dataRef.current.domReference
+          target === refs.domReference.current
         ) {
           stopEvent(event);
           if (event.shiftKey) {
@@ -173,15 +169,15 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
         !refs.floating.current?.contains(relatedTarget);
 
       const focusMovedOutsideReference =
-        isElement(dataRef.current.domReference) &&
-        !dataRef.current.domReference.contains(relatedTarget);
+        isElement(refs.domReference.current) &&
+        !refs.domReference.current.contains(relatedTarget);
 
       const isChildOpen =
         tree && getChildren(tree.nodesRef.current, nodeId).length > 0;
 
       const isParentRelated =
         tree &&
-        event.currentTarget === dataRef.current.domReference &&
+        event.currentTarget === refs.domReference.current &&
         getAncestors(tree.nodesRef.current, nodeId)?.some((node) =>
           node.context?.refs.floating.current?.contains(relatedTarget)
         );
@@ -197,7 +193,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     }
 
     const floating = refs.floating.current;
-    const reference = dataRef.current.domReference;
+    const reference = refs.domReference.current;
 
     if (floating && isHTMLElement(reference)) {
       !modal && floating.addEventListener('focusout', onFocusOut);
@@ -251,8 +247,8 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
   }, [preventTabbing, getTabbableElements, initialFocus, returnFocus, refs]);
 
   const isTypeableCombobox = () =>
-    dataRef.current.domReference?.getAttribute('role') === 'combobox' &&
-    isTypeableElement(dataRef.current.domReference);
+    refs.domReference.current?.getAttribute('role') === 'combobox' &&
+    isTypeableElement(refs.domReference.current);
 
   return (
     <>

--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -159,7 +159,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     return () => {
       doc.removeEventListener('keydown', onKeyDown);
     };
-  }, [preventTabbing, modal, getTabbableElements, orderRef, dataRef, refs]);
+  }, [preventTabbing, modal, getTabbableElements, orderRef, refs]);
 
   React.useEffect(() => {
     function onFocusOut(event: FocusEvent) {

--- a/packages/react-dom-interactions/src/hooks/useClick.ts
+++ b/packages/react-dom-interactions/src/hooks/useClick.ts
@@ -14,7 +14,7 @@ export interface Props {
  * @see https://floating-ui.com/docs/useClick
  */
 export const useClick = <RT extends ReferenceType = ReferenceType>(
-  {open, onOpenChange, dataRef}: FloatingContext<RT>,
+  {open, onOpenChange, dataRef, refs}: FloatingContext<RT>,
   {
     enabled = true,
     pointerDown = false,
@@ -25,11 +25,11 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
   const pointerTypeRef = React.useRef<'mouse' | 'pen' | 'touch'>();
 
   function isButton() {
-    return dataRef.current.domReference?.tagName === 'BUTTON';
+    return refs.domReference.current?.tagName === 'BUTTON';
   }
 
   function isSpaceIgnored() {
-    return isTypeableElement(dataRef.current.domReference);
+    return isTypeableElement(refs.domReference.current);
   }
 
   if (!enabled) {

--- a/packages/react-dom-interactions/src/hooks/useClick.ts
+++ b/packages/react-dom-interactions/src/hooks/useClick.ts
@@ -1,6 +1,5 @@
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import * as React from 'react';
-import {isHTMLElement} from '../utils/is';
 import {isTypeableElement} from '../utils/isTypeableElement';
 
 export interface Props {
@@ -15,7 +14,7 @@ export interface Props {
  * @see https://floating-ui.com/docs/useClick
  */
 export const useClick = <RT extends ReferenceType = ReferenceType>(
-  {open, onOpenChange, dataRef, refs}: FloatingContext<RT>,
+  {open, onOpenChange, dataRef}: FloatingContext<RT>,
   {
     enabled = true,
     pointerDown = false,
@@ -26,14 +25,11 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
   const pointerTypeRef = React.useRef<'mouse' | 'pen' | 'touch'>();
 
   function isButton() {
-    return (
-      isHTMLElement(refs.reference.current) &&
-      refs.reference.current.tagName === 'BUTTON'
-    );
+    return dataRef.current.domReference?.tagName === 'BUTTON';
   }
 
   function isSpaceIgnored() {
-    return isTypeableElement(refs.reference.current);
+    return isTypeableElement(dataRef.current.domReference);
   }
 
   if (!enabled) {

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -23,7 +23,7 @@ export interface Props {
  * @see https://floating-ui.com/docs/useDismiss
  */
 export const useDismiss = <RT extends ReferenceType = ReferenceType>(
-  {open, onOpenChange, refs, events, nodeId, dataRef}: FloatingContext<RT>,
+  {open, onOpenChange, refs, events, nodeId}: FloatingContext<RT>,
   {
     enabled = true,
     escapeKey = true,
@@ -141,7 +141,6 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     bubbles,
     isFocusInsideFloating,
     refs,
-    dataRef,
   ]);
 
   if (!enabled) {

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -23,7 +23,7 @@ export interface Props {
  * @see https://floating-ui.com/docs/useDismiss
  */
 export const useDismiss = <RT extends ReferenceType = ReferenceType>(
-  {open, onOpenChange, refs, events, nodeId}: FloatingContext<RT>,
+  {open, onOpenChange, refs, events, nodeId, dataRef}: FloatingContext<RT>,
   {
     enabled = true,
     escapeKey = true,
@@ -40,13 +40,13 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     return refs.floating.current?.contains(
       activeElement(getDocument(refs.floating.current))
     );
-  }, [refs.floating]);
+  }, [refs]);
 
   const focusReference = React.useCallback(() => {
-    if (isHTMLElement(refs.reference.current)) {
-      refs.reference.current.focus();
+    if (isHTMLElement(dataRef.current.domReference)) {
+      dataRef.current.domReference.focus();
     }
-  }, [refs.reference]);
+  }, [dataRef]);
 
   React.useEffect(() => {
     if (!open || !enabled) {
@@ -74,8 +74,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
 
       if (
         isEventTargetWithin(event, refs.floating.current) ||
-        (isElement(refs.reference.current) &&
-          isEventTargetWithin(event, refs.reference.current)) ||
+        isEventTargetWithin(event, dataRef.current.domReference) ||
         targetIsInsideChildren
       ) {
         return;
@@ -141,8 +140,8 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     enabled,
     bubbles,
     isFocusInsideFloating,
-    refs.floating,
-    refs.reference,
+    refs,
+    dataRef,
   ]);
 
   if (!enabled) {

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -43,10 +43,10 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
   }, [refs]);
 
   const focusReference = React.useCallback(() => {
-    if (isHTMLElement(dataRef.current.domReference)) {
-      dataRef.current.domReference.focus();
+    if (isHTMLElement(refs.domReference.current)) {
+      refs.domReference.current.focus();
     }
-  }, [dataRef]);
+  }, [refs]);
 
   React.useEffect(() => {
     if (!open || !enabled) {
@@ -74,7 +74,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
 
       if (
         isEventTargetWithin(event, refs.floating.current) ||
-        isEventTargetWithin(event, dataRef.current.domReference) ||
+        isEventTargetWithin(event, refs.domReference.current) ||
         targetIsInsideChildren
       ) {
         return;

--- a/packages/react-dom-interactions/src/hooks/useFocus.ts
+++ b/packages/react-dom-interactions/src/hooks/useFocus.ts
@@ -49,7 +49,7 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
       win.removeEventListener('focus', onFocus);
       win.removeEventListener('blur', onBlur);
     };
-  }, [refs, open, enabled, dataRef]);
+  }, [refs, open, enabled]);
 
   React.useEffect(() => {
     if (!enabled) {

--- a/packages/react-dom-interactions/src/hooks/useFocus.ts
+++ b/packages/react-dom-interactions/src/hooks/useFocus.ts
@@ -30,7 +30,7 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
     function onBlur() {
       if (
         pointerTypeRef.current &&
-        dataRef.current.domReference === activeElement(doc)
+        refs.domReference.current === activeElement(doc)
       ) {
         blockFocusRef.current = !open;
       }
@@ -86,7 +86,7 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
         if (
           event.type === 'focus' &&
           dataRef.current.openEvent?.type === 'mousedown' &&
-          dataRef.current.domReference?.contains(
+          refs.domReference.current?.contains(
             dataRef.current.openEvent?.target as Element | null
           )
         ) {
@@ -103,7 +103,7 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
         // Note: it must be focusable, e.g. `tabindex="-1"`.
         if (
           refs.floating.current?.contains(target) ||
-          dataRef.current.domReference?.contains(target)
+          refs.domReference.current?.contains(target)
         ) {
           return;
         }

--- a/packages/react-dom-interactions/src/hooks/useFocus.ts
+++ b/packages/react-dom-interactions/src/hooks/useFocus.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import {activeElement} from '../utils/activeElement';
 import {getDocument} from '../utils/getDocument';
-import {isElement} from '../utils/is';
 
 export interface Props {
   enabled?: boolean;
@@ -31,7 +30,7 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
     function onBlur() {
       if (
         pointerTypeRef.current &&
-        refs.reference.current === activeElement(doc)
+        dataRef.current.domReference === activeElement(doc)
       ) {
         blockFocusRef.current = !open;
       }
@@ -50,7 +49,7 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
       win.removeEventListener('focus', onFocus);
       win.removeEventListener('blur', onBlur);
     };
-  }, [refs, open, enabled]);
+  }, [refs, open, enabled, dataRef]);
 
   React.useEffect(() => {
     if (!enabled) {
@@ -87,8 +86,7 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
         if (
           event.type === 'focus' &&
           dataRef.current.openEvent?.type === 'mousedown' &&
-          isElement(refs.reference.current) &&
-          refs.reference.current?.contains(
+          dataRef.current.domReference?.contains(
             dataRef.current.openEvent?.target as Element | null
           )
         ) {
@@ -105,8 +103,7 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
         // Note: it must be focusable, e.g. `tabindex="-1"`.
         if (
           refs.floating.current?.contains(target) ||
-          (isElement(refs.reference.current) &&
-            refs.reference.current.contains(target))
+          dataRef.current.domReference?.contains(target)
         ) {
           return;
         }

--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -225,7 +225,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     }
 
     const floating = refs.floating.current;
-    const reference = dataRef.current.domReference;
+    const reference = refs.domReference.current;
 
     if (isElement(reference)) {
       open && reference.addEventListener('mouseleave', onScrollMouseLeave);
@@ -269,7 +269,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     if (open && handleCloseRef.current) {
       getDocument(refs.floating.current).body.style.pointerEvents = 'none';
       performedPointerEventsMutationRef.current = true;
-      const reference = dataRef.current.domReference;
+      const reference = refs.domReference.current;
       const floating = refs.floating.current;
 
       if (isHTMLElement(reference) && floating) {

--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -225,7 +225,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     }
 
     const floating = refs.floating.current;
-    const reference = refs.reference.current;
+    const reference = dataRef.current.domReference;
 
     if (isElement(reference)) {
       open && reference.addEventListener('mouseleave', onScrollMouseLeave);
@@ -269,11 +269,10 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     if (open && handleCloseRef.current) {
       getDocument(refs.floating.current).body.style.pointerEvents = 'none';
       performedPointerEventsMutationRef.current = true;
-      const reference =
-        isHTMLElement(refs.reference.current) && refs.reference.current;
+      const reference = dataRef.current.domReference;
       const floating = refs.floating.current;
 
-      if (reference && floating) {
+      if (isHTMLElement(reference) && floating) {
         const parentFloating = tree?.nodesRef.current.find(
           (node) => node.id === parentId
         )?.context?.refs.floating.current;
@@ -291,7 +290,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         };
       }
     }
-  }, [enabled, open, parentId, refs, tree, handleCloseRef]);
+  }, [enabled, open, parentId, refs, tree, handleCloseRef, dataRef]);
 
   useLayoutEffect(() => {
     if (previousOpen && !open) {

--- a/packages/react-dom-interactions/src/hooks/useListNavigation.ts
+++ b/packages/react-dom-interactions/src/hooks/useListNavigation.ts
@@ -149,7 +149,7 @@ export interface Props {
  * @see https://floating-ui.com/docs/useListNavigation
  */
 export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
-  {open, onOpenChange, refs, dataRef}: FloatingContext<RT>,
+  {open, onOpenChange, refs}: FloatingContext<RT>,
   {
     listRef,
     activeIndex,
@@ -331,11 +331,11 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
       !open &&
       previousOpen &&
       selectedIndex != null &&
-      isHTMLElement(dataRef.current.domReference)
+      isHTMLElement(refs.domReference.current)
     ) {
-      dataRef.current.domReference.focus();
+      refs.domReference.current.focus();
     }
-  }, [dataRef, selectedIndex, open, previousOpen, enabled]);
+  }, [refs, selectedIndex, open, previousOpen, enabled]);
 
   // Ensure the parent floating element has focus when a nested child closes
   // to allow arrow key navigation to work after the pointer leaves the child.
@@ -369,8 +369,8 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
       stopEvent(event);
       onOpenChange(false);
 
-      if (isHTMLElement(dataRef.current.domReference)) {
-        dataRef.current.domReference.focus();
+      if (isHTMLElement(refs.domReference.current)) {
+        refs.domReference.current.focus();
       }
 
       return;

--- a/packages/react-dom-interactions/src/hooks/useListNavigation.ts
+++ b/packages/react-dom-interactions/src/hooks/useListNavigation.ts
@@ -149,7 +149,7 @@ export interface Props {
  * @see https://floating-ui.com/docs/useListNavigation
  */
 export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
-  {open, onOpenChange, refs}: FloatingContext<RT>,
+  {open, onOpenChange, refs, dataRef}: FloatingContext<RT>,
   {
     listRef,
     activeIndex,
@@ -331,11 +331,11 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
       !open &&
       previousOpen &&
       selectedIndex != null &&
-      isHTMLElement(refs.reference.current)
+      isHTMLElement(dataRef.current.domReference)
     ) {
-      refs.reference.current.focus();
+      dataRef.current.domReference.focus();
     }
-  }, [refs.reference, selectedIndex, open, previousOpen, enabled]);
+  }, [dataRef, selectedIndex, open, previousOpen, enabled]);
 
   // Ensure the parent floating element has focus when a nested child closes
   // to allow arrow key navigation to work after the pointer leaves the child.
@@ -369,8 +369,8 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
       stopEvent(event);
       onOpenChange(false);
 
-      if (isHTMLElement(refs.reference.current)) {
-        refs.reference.current.focus();
+      if (isHTMLElement(dataRef.current.domReference)) {
+        dataRef.current.domReference.focus();
       }
 
       return;

--- a/packages/react-dom-interactions/src/safePolygon.ts
+++ b/packages/react-dom-interactions/src/safePolygon.ts
@@ -1,6 +1,5 @@
 import type {Side} from '@floating-ui/core';
 import type {FloatingContext, FloatingTreeType, ReferenceType} from './types';
-import {isElement} from './utils/is';
 import {getChildren} from './utils/getChildren';
 
 type Point = [number, number];
@@ -39,6 +38,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
     y,
     placement,
     refs,
+    dataRef,
     onClose,
     nodeId,
     tree,
@@ -71,8 +71,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
       // is no need to run the logic.
       if (
         event.type === 'pointermove' &&
-        isElement(refs.reference.current) &&
-        refs.reference.current.contains(targetNode)
+        dataRef.current.domReference?.contains(targetNode)
       ) {
         return;
       }
@@ -94,7 +93,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
       }
 
       if (
-        !refs.reference.current ||
+        !dataRef.current.domReference ||
         !refs.floating.current ||
         placement == null ||
         x == null ||
@@ -103,7 +102,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
         return;
       }
 
-      const refRect = refs.reference.current.getBoundingClientRect();
+      const refRect = dataRef.current.domReference.getBoundingClientRect();
       const rect = refs.floating.current.getBoundingClientRect();
       const side = placement.split('-')[0] as Side;
       const cursorLeaveFromRight = x > rect.right - rect.width / 2;

--- a/packages/react-dom-interactions/src/safePolygon.ts
+++ b/packages/react-dom-interactions/src/safePolygon.ts
@@ -38,7 +38,6 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
     y,
     placement,
     refs,
-    dataRef,
     onClose,
     nodeId,
     tree,
@@ -71,7 +70,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
       // is no need to run the logic.
       if (
         event.type === 'pointermove' &&
-        dataRef.current.domReference?.contains(targetNode)
+        refs.domReference.current?.contains(targetNode)
       ) {
         return;
       }
@@ -93,7 +92,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
       }
 
       if (
-        !dataRef.current.domReference ||
+        !refs.domReference.current ||
         !refs.floating.current ||
         placement == null ||
         x == null ||
@@ -102,7 +101,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
         return;
       }
 
-      const refRect = dataRef.current.domReference.getBoundingClientRect();
+      const refRect = refs.domReference.current.getBoundingClientRect();
       const rect = refs.floating.current.getBoundingClientRect();
       const side = placement.split('-')[0] as Side;
       const cursorLeaveFromRight = x > rect.right - rect.width / 2;

--- a/packages/react-dom-interactions/src/types.ts
+++ b/packages/react-dom-interactions/src/types.ts
@@ -21,7 +21,6 @@ export interface FloatingEvents {
 export interface ContextData {
   openEvent?: MouseEvent | PointerEvent | FocusEvent;
   typing?: boolean;
-  domReference: Element | null;
   [key: string]: any;
 }
 
@@ -68,6 +67,7 @@ export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =
     refs: {
       reference: React.MutableRefObject<RT | null>;
       floating: React.MutableRefObject<HTMLElement | null>;
+      domReference: React.MutableRefObject<Element | null>;
     };
   };
 

--- a/packages/react-dom-interactions/src/types.ts
+++ b/packages/react-dom-interactions/src/types.ts
@@ -6,11 +6,18 @@ import type {
   Middleware,
   Strategy,
 } from '@floating-ui/dom';
+import type {UseFloatingReturn as UsePositionFloatingReturn} from '@floating-ui/react-dom';
 
 export * from '@floating-ui/dom';
 export * from './';
 
 export {arrow} from '@floating-ui/react-dom';
+
+interface ExtendedRefs<RT extends ReferenceType = ReferenceType> {
+  reference: React.MutableRefObject<RT | null>;
+  floating: React.MutableRefObject<HTMLElement | null>;
+  domReference: React.MutableRefObject<Element | null>;
+}
 
 export interface FloatingEvents {
   emit(event: string, data?: any): void;
@@ -25,12 +32,13 @@ export interface ContextData {
 }
 
 export interface FloatingContext<RT extends ReferenceType = ReferenceType>
-  extends UseFloatingReturn<RT> {
+  extends UsePositionFloatingReturn<RT> {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   events: FloatingEvents;
   dataRef: React.MutableRefObject<ContextData>;
   nodeId: string | undefined;
+  refs: ExtendedRefs<RT>;
 }
 
 export interface FloatingNodeType<RT extends ReferenceType = ReferenceType> {
@@ -64,11 +72,8 @@ export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =
     update: () => void;
     reference: (node: RT | null) => void;
     floating: (node: HTMLElement | null) => void;
-    refs: {
-      reference: React.MutableRefObject<RT | null>;
-      floating: React.MutableRefObject<HTMLElement | null>;
-      domReference: React.MutableRefObject<Element | null>;
-    };
+    context: FloatingContext<RT>;
+    refs: ExtendedRefs<RT>;
   };
 
 export interface UseFloatingProps<RT extends ReferenceType = ReferenceType> {

--- a/packages/react-dom-interactions/src/types.ts
+++ b/packages/react-dom-interactions/src/types.ts
@@ -21,6 +21,7 @@ export interface FloatingEvents {
 export interface ContextData {
   openEvent?: MouseEvent | PointerEvent | FocusEvent;
   typing?: boolean;
+  domReference: Element | null;
   [key: string]: any;
 }
 

--- a/packages/react-dom-interactions/src/useFloating.ts
+++ b/packages/react-dom-interactions/src/useFloating.ts
@@ -20,12 +20,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
   middleware,
   strategy,
   nodeId,
-}: Partial<UseFloatingProps> = {}): UseFloatingReturn<RT> & {
-  context: FloatingContext<RT>;
-  refs: UseFloatingReturn<RT>['refs'] & {
-    domReference: React.MutableRefObject<Element | null>;
-  };
-} {
+}: Partial<UseFloatingProps> = {}): UseFloatingReturn<RT> {
   const tree = useFloatingTree<RT>();
   const domReferenceRef = React.useRef<Element | null>(null);
   const dataRef = React.useRef<ContextData>({});

--- a/packages/react-dom-interactions/src/useFloating.ts
+++ b/packages/react-dom-interactions/src/useFloating.ts
@@ -55,7 +55,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       open,
       onOpenChange,
     }),
-    [floating, dataRef, nodeId, events, open, onOpenChange, refs]
+    [floating, nodeId, events, open, onOpenChange, refs]
   );
 
   useLayoutEffect(() => {

--- a/packages/react-dom-interactions/src/useFloating.ts
+++ b/packages/react-dom-interactions/src/useFloating.ts
@@ -10,6 +10,7 @@ import type {
 } from './types';
 import {createPubSub} from './createPubSub';
 import {useFloatingTree} from './FloatingTree';
+import {isElement} from './utils/is';
 
 export function useFloating<RT extends ReferenceType = ReferenceType>({
   open = false,
@@ -23,7 +24,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
   context: FloatingContext<RT>;
 } {
   const tree = useFloatingTree<RT>();
-  const dataRef = React.useRef<ContextData>({});
+  const dataRef = React.useRef<ContextData>({domReference: null});
   const events = React.useState(() => createPubSub())[0];
   const floating = usePositionalFloating<RT>({
     placement,
@@ -51,11 +52,24 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
     }
   });
 
+  const {reference} = floating;
+  const setReference: UseFloatingReturn<RT>['reference'] = React.useCallback(
+    (node) => {
+      if (isElement(node) || node === null) {
+        dataRef.current.domReference = node;
+      }
+
+      reference(node);
+    },
+    [reference]
+  );
+
   return React.useMemo(
     () => ({
       context,
       ...floating,
+      reference: setReference,
     }),
-    [floating, context]
+    [floating, context, setReference]
   );
 }


### PR DESCRIPTION
Closes #1659 

Now the user can call `reference()` and pass a virtual element, which changes `refs.reference.current`, but the DOM node will still be available under `refs.domReference.current`. This allows a "split" between a virtual element (positioning) and a real DOM reference element (events)