### PR TITLE
feat: `inner` + `useInnerOffset`

### DIFF
--- a/packages/react-dom-interactions/src/FloatingOverlay.tsx
+++ b/packages/react-dom-interactions/src/FloatingOverlay.tsx
@@ -1,26 +1,8 @@
 import * as React from 'react';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
+import {getPlatform} from './utils/getPlatform';
 
 const identifier = 'data-floating-ui-scroll-lock';
-
-interface NavigatorUAData {
-  brands: Array<{brand: string; version: string}>;
-  mobile: boolean;
-  platform: string;
-}
-
-// Avoid Chrome DevTools blue warning
-export function getPlatform(): string {
-  const uaData = (navigator as any).userAgentData as
-    | NavigatorUAData
-    | undefined;
-
-  if (uaData?.platform) {
-    return uaData.platform;
-  }
-
-  return navigator.platform;
-}
 
 /**
  * Provides base styling for a fixed overlay element to dim content or block

--- a/packages/react-dom-interactions/src/index.ts
+++ b/packages/react-dom-interactions/src/index.ts
@@ -18,6 +18,7 @@ export {
   useDelayGroup,
   useDelayGroupContext,
 } from './FloatingDelayGroup';
+export {useInnerOffset, inner} from './inner';
 export {useRole} from './hooks/useRole';
 export {useClick} from './hooks/useClick';
 export {useDismiss} from './hooks/useDismiss';

--- a/packages/react-dom-interactions/src/inner.ts
+++ b/packages/react-dom-interactions/src/inner.ts
@@ -115,9 +115,9 @@ export const inner = (
         refOverflow.top >= -referenceOverflowThreshold ||
         refOverflow.bottom >= -referenceOverflowThreshold
       ) {
-        onFallbackChange(true);
+        flushSync(() => onFallbackChange(true));
       } else {
-        onFallbackChange(false);
+        flushSync(() => onFallbackChange(false));
       }
     }
 
@@ -217,13 +217,13 @@ export const useInnerOffset = (
 
   return {
     floating: {
-      onKeyDown() {
+      onKeyDown({key}) {
         controlledScrollingRef.current = true;
       },
       onWheel() {
         controlledScrollingRef.current = false;
       },
-      onTouchMove() {
+      onPointerMove() {
         controlledScrollingRef.current = false;
       },
       onScroll() {

--- a/packages/react-dom-interactions/src/inner.ts
+++ b/packages/react-dom-interactions/src/inner.ts
@@ -1,0 +1,251 @@
+import * as React from 'react';
+import {detectOverflow, offset} from '@floating-ui/react-dom';
+import type {
+  SideObject,
+  DetectOverflowOptions,
+  Middleware,
+  FloatingContext,
+  ElementProps,
+  MiddlewareArguments,
+} from './types';
+import {flushSync} from 'react-dom';
+import {getUserAgent} from './utils/getPlatform';
+import {useLatestRef} from './utils/useLatestRef';
+
+function getArgsWithCustomFloatingHeight(
+  args: MiddlewareArguments,
+  prop: 'offsetHeight' | 'scrollHeight'
+) {
+  return {
+    ...args,
+    rects: {
+      ...args.rects,
+      floating: {
+        ...args.rects.floating,
+        height: args.elements.floating[prop],
+      },
+    },
+  };
+}
+
+export const inner = (
+  options: {
+    listRef: React.MutableRefObject<Array<HTMLElement | null>>;
+    index: number;
+    onFallbackChange?: null | ((fallback: boolean) => void);
+    offset?: number;
+    overflowRef?: React.MutableRefObject<SideObject | null>;
+    minItemsVisible?: number;
+    referenceOverflowThreshold?: number;
+  } & Partial<DetectOverflowOptions>
+): Middleware => ({
+  name: 'inner',
+  options,
+  async fn(middlewareArguments) {
+    const {
+      listRef,
+      overflowRef,
+      onFallbackChange,
+      offset: innerOffset = 0,
+      index = 0,
+      minItemsVisible = 4,
+      referenceOverflowThreshold = 0,
+      ...detectOverflowOptions
+    } = options;
+
+    const {
+      rects,
+      elements: {floating},
+    } = middlewareArguments;
+
+    const item = listRef.current[index];
+
+    if (__DEV__) {
+      if (!middlewareArguments.placement.startsWith('bottom')) {
+        console.warn(
+          [
+            'Floating UI: `placement` side must be "bottom" when using the',
+            '`inner` middleware.',
+          ].join(' ')
+        );
+      }
+    }
+
+    if (!item) {
+      return {};
+    }
+
+    const nextArgs = {
+      ...middlewareArguments,
+      ...(await offset(
+        -item.offsetTop -
+          rects.reference.height / 2 -
+          item.offsetHeight / 2 -
+          innerOffset
+      ).fn(middlewareArguments)),
+    };
+
+    const overflow = await detectOverflow(
+      getArgsWithCustomFloatingHeight(nextArgs, 'scrollHeight'),
+      detectOverflowOptions
+    );
+    const refOverflow = await detectOverflow(nextArgs, {
+      ...detectOverflowOptions,
+      elementContext: 'reference',
+    });
+
+    const diffY = Math.max(0, overflow.top);
+    const nextY = nextArgs.y + diffY;
+
+    const maxHeight = Math.max(
+      0,
+      floating.scrollHeight - diffY - Math.max(0, overflow.bottom)
+    );
+
+    floating.style.maxHeight = `${maxHeight}px`;
+    floating.scrollTop = diffY;
+
+    // There is not enough space, fallback to standard anchored positioning
+    if (onFallbackChange) {
+      if (
+        floating.offsetHeight <
+          item.offsetHeight *
+            Math.min(minItemsVisible, listRef.current.length - 1) -
+            1 ||
+        refOverflow.top >= -referenceOverflowThreshold ||
+        refOverflow.bottom >= -referenceOverflowThreshold
+      ) {
+        onFallbackChange(true);
+      } else {
+        onFallbackChange(false);
+      }
+    }
+
+    if (overflowRef) {
+      overflowRef.current = await detectOverflow(
+        getArgsWithCustomFloatingHeight(
+          {...nextArgs, y: nextY},
+          'offsetHeight'
+        ),
+        detectOverflowOptions
+      );
+    }
+
+    return {
+      y: nextY,
+    };
+  },
+});
+
+export const useInnerOffset = (
+  {open, refs}: FloatingContext,
+  {
+    enabled = true,
+    overflowRef,
+    onChange,
+  }: {
+    enabled?: boolean;
+    overflowRef: React.MutableRefObject<SideObject | null>;
+    onChange: (offset: number | ((offset: number) => number)) => void;
+  }
+): ElementProps => {
+  const onChangeRef = useLatestRef(onChange);
+  const controlledScrollingRef = React.useRef(false);
+  const prevScrollTopRef = React.useRef<number | null>(null);
+  const initialOverflowRef = React.useRef<SideObject | null>(null);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    function onWheel(e: WheelEvent) {
+      if (e.ctrlKey || !el || overflowRef.current == null) {
+        return;
+      }
+
+      const dY = e.deltaY;
+      const isAtTop = overflowRef.current.top >= -0.5;
+      const isAtBottom = overflowRef.current.bottom >= -0.5;
+      const remainingScroll = el.scrollHeight - el.clientHeight;
+      const sign = dY < 0 ? -1 : 1;
+      const method = dY < 0 ? 'max' : 'min';
+
+      if (el.scrollHeight <= el.clientHeight) {
+        return;
+      }
+
+      if ((!isAtTop && dY > 0) || (!isAtBottom && dY < 0)) {
+        e.preventDefault();
+        flushSync(() => {
+          onChangeRef.current(
+            (d) => d + Math[method](dY, remainingScroll * sign)
+          );
+        });
+      } else if (/firefox/i.test(getUserAgent())) {
+        // Needed to propagate scrolling during momentum scrolling phase once
+        // it gets limited by the boundary. UX improvement, not critical.
+        el.scrollTop += dY;
+      }
+    }
+
+    const el = refs.floating.current;
+
+    if (open && el) {
+      el.addEventListener('wheel', onWheel);
+
+      // Wait for the position to be ready.
+      requestAnimationFrame(() => {
+        prevScrollTopRef.current = el.scrollTop;
+
+        if (overflowRef.current != null) {
+          initialOverflowRef.current = {...overflowRef.current};
+        }
+      });
+
+      return () => {
+        prevScrollTopRef.current = null;
+        initialOverflowRef.current = null;
+        el.removeEventListener('wheel', onWheel);
+      };
+    }
+  }, [enabled, open, refs, overflowRef, onChangeRef]);
+
+  if (!enabled) {
+    return {};
+  }
+
+  return {
+    floating: {
+      onKeyDown() {
+        controlledScrollingRef.current = true;
+      },
+      onWheel() {
+        controlledScrollingRef.current = false;
+      },
+      onTouchMove() {
+        controlledScrollingRef.current = false;
+      },
+      onScroll() {
+        const el = refs.floating.current;
+
+        if (!overflowRef.current || !el || !controlledScrollingRef.current) {
+          return;
+        }
+
+        if (prevScrollTopRef.current !== null) {
+          const scrollDiff = el.scrollTop - prevScrollTopRef.current;
+
+          if (
+            (overflowRef.current.bottom < -0.5 && scrollDiff < 0) ||
+            (overflowRef.current.top < -0.5 && scrollDiff > 0)
+          ) {
+            flushSync(() => onChange((d) => d + scrollDiff));
+          }
+        }
+
+        prevScrollTopRef.current = el.scrollTop;
+      },
+    },
+  };
+};

--- a/packages/react-dom-interactions/src/inner.ts
+++ b/packages/react-dom-interactions/src/inner.ts
@@ -217,7 +217,7 @@ export const useInnerOffset = (
 
   return {
     floating: {
-      onKeyDown({key}) {
+      onKeyDown() {
         controlledScrollingRef.current = true;
       },
       onWheel() {
@@ -237,14 +237,17 @@ export const useInnerOffset = (
           const scrollDiff = el.scrollTop - prevScrollTopRef.current;
 
           if (
-            (overflowRef.current.bottom < -0.5 && scrollDiff < 0) ||
-            (overflowRef.current.top < -0.5 && scrollDiff > 0)
+            (overflowRef.current.bottom < -0.5 && scrollDiff < -1) ||
+            (overflowRef.current.top < -0.5 && scrollDiff > 1)
           ) {
             flushSync(() => onChange((d) => d + scrollDiff));
           }
         }
 
-        prevScrollTopRef.current = el.scrollTop;
+        // [Firefox] Wait for the height change to have been applied.
+        requestAnimationFrame(() => {
+          prevScrollTopRef.current = el.scrollTop;
+        });
       },
     },
   };

--- a/packages/react-dom-interactions/src/utils/getPlatform.ts
+++ b/packages/react-dom-interactions/src/utils/getPlatform.ts
@@ -1,0 +1,32 @@
+interface NavigatorUAData {
+  brands: Array<{brand: string; version: string}>;
+  mobile: boolean;
+  platform: string;
+}
+
+// Avoid Chrome DevTools blue warning
+export function getPlatform(): string {
+  const uaData = (navigator as any).userAgentData as
+    | NavigatorUAData
+    | undefined;
+
+  if (uaData?.platform) {
+    return uaData.platform;
+  }
+
+  return navigator.platform;
+}
+
+export function getUserAgent(): string {
+  const uaData = (navigator as any).userAgentData as
+    | NavigatorUAData
+    | undefined;
+
+  if (uaData?.brands) {
+    return uaData.brands
+      .map(({brand, version}) => `${brand}/${version}`)
+      .join(' ');
+  }
+
+  return navigator.userAgent;
+}

--- a/packages/react-dom-interactions/test/visual/components/MacSelect.css
+++ b/packages/react-dom-interactions/test/visual/components/MacSelect.css
@@ -18,7 +18,8 @@
 .MacSelect-button {
   all: unset;
   font-size: 15px;
-  padding: 5px 8px;
+  padding: 12px 10px;
+  line-height: 1;
   background: white;
   border-radius: 5px;
   cursor: default;
@@ -44,19 +45,46 @@
   display: block;
   all: unset;
   width: 100%;
-  padding: 8px;
+  padding: 12px 10px;
   border-radius: 5px;
   box-sizing: inherit;
   user-select: none;
+  line-height: 1;
+  scroll-margin: 50px;
 }
 
 .MacSelect-ScrollArrow {
   display: flex;
   justify-content: center;
   align-items: center;
-  background: white;
-  border-radius: 10px;
+  border-radius: 0;
   cursor: default;
   font-size: 12px;
+  line-height: 1;
+  height: 25px;
   user-select: none;
+  position: relative;
+}
+
+.MacSelect-ScrollArrow::before {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 35px;
+  position: absolute;
+  left: 0;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.MacSelect-ScrollArrow[data-dir='up']::before {
+  background: linear-gradient(to bottom, white 50%, transparent);
+  border-radius: 8px 8px 0 0;
+  top: 0;
+}
+
+.MacSelect-ScrollArrow[data-dir='down']::before {
+  background: linear-gradient(to top, white 50%, transparent);
+  border-radius: 0 0 8px 8px;
+  top: -10px;
 }

--- a/packages/react-dom-interactions/test/visual/components/MacSelect.css
+++ b/packages/react-dom-interactions/test/visual/components/MacSelect.css
@@ -1,0 +1,62 @@
+.MacSelect {
+  background: white;
+  font-size: 15px;
+  box-shadow: rgb(0 0 0 / 50%) 0px 0px 1px, rgb(0 0 0 / 3%) 0px 100px 80px,
+    rgb(0 0 0 / 2%) 0px 41.7776px 33.4221px,
+    rgb(0 0 0 / 2%) 0px 22.3363px 17.869px,
+    rgb(0 0 0 / 4%) 0px 12.5216px 10.0172px;
+  border-radius: 8px;
+  box-sizing: border-box;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: none;
+  padding: 5px;
+  outline: 0;
+  user-select: none;
+}
+
+.MacSelect-button {
+  all: unset;
+  font-size: 15px;
+  padding: 5px 8px;
+  background: white;
+  border-radius: 5px;
+  cursor: default;
+  user-select: none;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.MacSelect-button:hover {
+  background: rgba(0, 200, 255, 0.2);
+  border-color: transparent;
+}
+
+.MacSelect-button:focus-visible {
+  border-color: royalblue;
+}
+
+.MacSelect::-webkit-scrollbar {
+  display: none;
+}
+
+.MacSelect button {
+  display: block;
+  all: unset;
+  width: 100%;
+  padding: 8px;
+  border-radius: 5px;
+  box-sizing: inherit;
+  user-select: none;
+}
+
+.MacSelect-ScrollArrow {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: white;
+  border-radius: 10px;
+  cursor: default;
+  font-size: 12px;
+  user-select: none;
+}

--- a/packages/react-dom-interactions/test/visual/components/MacSelect.tsx
+++ b/packages/react-dom-interactions/test/visual/components/MacSelect.tsx
@@ -66,9 +66,6 @@ function ScrollArrow({
   onScroll: (amount: number) => void;
   onHide: () => void;
 }) {
-  // Padding for .scrollTop for when to show the scroll arrow
-  const SCROLL_ARROW_PADDING = 15;
-
   const {x, y, reference, floating, strategy, update, refs} = useFloating({
     strategy: 'fixed',
     placement: dir === 'up' ? 'top' : 'bottom',
@@ -80,6 +77,8 @@ function ScrollArrow({
   const [element, setElement] = useState<HTMLElement | null>(null);
   const frameRef = useRef<any>();
   const statusRef = useRef<'idle' | 'active'>('idle');
+  // Padding for .scrollTop for when to show the scroll arrow
+  const SCROLL_ARROW_PADDING = 10;
 
   useLayoutEffect(() => {
     if (open) {
@@ -149,10 +148,13 @@ function ScrollArrow({
     cancelAnimationFrame(frameRef.current);
   };
 
-  const floatingCallback = useCallback((node: HTMLElement | null) => {
-    floating(node);
-    arrowRef.current = node;
-  }, []);
+  const floatingCallback = useCallback(
+    (node: HTMLElement | null) => {
+      floating(node);
+      arrowRef.current = node;
+    },
+    [arrowRef, floating]
+  );
 
   if (!element) {
     return null;
@@ -170,17 +172,16 @@ function ScrollArrow({
   return (
     <div
       className="MacSelect-ScrollArrow"
+      data-dir={dir}
       ref={floatingCallback}
       onPointerEnter={handlePointerEnter}
       onPointerLeave={handlePointerLeave}
       style={{
         width: element.offsetWidth - 2,
         position: strategy,
-        top: 0,
-        left: 0,
-        transform: `translate3d(${x}px, ${y}px, 0)`,
+        top: y ?? 0,
+        left: x ?? 0,
       }}
-      data-dir={dir}
     >
       {dir === 'up' ? '▲' : '▼'}
     </div>
@@ -236,7 +237,7 @@ export function Main() {
             onFallbackChange: setFallback,
             padding: 10,
             minItemsVisible: touch ? 10 : 4,
-            referenceOverflowThreshold: 25,
+            referenceOverflowThreshold: 20,
           }),
           offset({crossAxis: -4}),
         ],

--- a/packages/react-dom-interactions/test/visual/components/MacSelect.tsx
+++ b/packages/react-dom-interactions/test/visual/components/MacSelect.tsx
@@ -1,0 +1,493 @@
+import {
+  useFloating,
+  flip,
+  size,
+  autoUpdate,
+  SideObject,
+  useInteractions,
+  inner,
+  useInnerOffset,
+  useClick,
+  useListNavigation,
+  useDismiss,
+  useRole,
+  useTypeahead,
+  FloatingFocusManager,
+  FloatingOverlay,
+  offset,
+  shift,
+} from '@floating-ui/react-dom-interactions';
+import {useCallback, useLayoutEffect, useRef, useState} from 'react';
+import {flushSync} from 'react-dom';
+
+import './MacSelect.css';
+
+const fruits = [
+  '🍒 Cherry',
+  '🍓 Strawberry',
+  '🍇 Grape',
+  '🍎 Apple',
+  '🍉 Watermelon',
+  '🍑 Peach',
+  '🍊 Orange',
+  '🍋 Lemon',
+  '🍍 Pineapple',
+  '🍌 Banana',
+  '🥑 Avocado',
+  '🍏 Green Apple',
+  '🍈 Melon',
+  '🍐 Pear',
+  '🥝 Kiwifruit',
+  '🥭 Tropical Mango',
+  '🥥 Coconut',
+  '🍅 Tomato',
+  '🫐 Blueberry',
+];
+
+const getParts = (fruitString: string) => ({
+  emoji: fruitString.slice(0, 3),
+  text: fruitString.slice(3),
+});
+
+function ScrollArrow({
+  open,
+  dir,
+  floatingRef,
+  arrowRef,
+  scrollTop,
+  onScroll,
+  onHide,
+}: {
+  open: boolean;
+  dir: 'up' | 'down';
+  floatingRef: React.MutableRefObject<HTMLElement | null>;
+  arrowRef: React.MutableRefObject<HTMLElement | null>;
+  scrollTop: number;
+  onScroll: (amount: number) => void;
+  onHide: () => void;
+}) {
+  const {x, y, reference, floating, strategy, update, refs} = useFloating({
+    strategy: 'fixed',
+    placement: dir === 'up' ? 'top' : 'bottom',
+    middleware: [offset(({rects}) => -rects.floating.height + 1)],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const [element, setElement] = useState<HTMLElement | null>(null);
+  const frameRef = useRef<any>();
+  const statusRef = useRef<'idle' | 'active'>('idle');
+
+  useLayoutEffect(() => {
+    if (open) {
+      setElement(floatingRef.current);
+      reference(floatingRef.current);
+      requestAnimationFrame(update);
+    } else {
+      cancelAnimationFrame(frameRef.current);
+    }
+  }, [open, floatingRef, reference, update]);
+
+  useLayoutEffect(() => {
+    if (refs.floating.current == null && statusRef.current === 'active') {
+      onHide();
+    }
+    // Assuming `onHide` does not change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scrollTop, refs]);
+
+  useLayoutEffect(() => {
+    return () => {
+      cancelAnimationFrame(frameRef.current);
+    };
+  }, []);
+
+  const handlePointerEnter = () => {
+    statusRef.current = 'active';
+    let prevNow = Date.now();
+
+    function frame() {
+      if (element) {
+        const currentNow = Date.now();
+        const msElapsed = currentNow - prevNow;
+        prevNow = currentNow;
+
+        const pixelsToScroll = msElapsed / 2;
+
+        const remainingPixels =
+          dir === 'up'
+            ? element.scrollTop
+            : element.scrollHeight - element.clientHeight - element.scrollTop;
+
+        const scrollRemaining =
+          dir === 'up'
+            ? element.scrollTop - pixelsToScroll > 0
+            : element.scrollTop + pixelsToScroll <
+              element.scrollHeight - element.clientHeight;
+
+        onScroll(
+          dir === 'up'
+            ? Math.min(pixelsToScroll, remainingPixels)
+            : Math.max(-pixelsToScroll, -remainingPixels)
+        );
+
+        if (scrollRemaining) {
+          frameRef.current = requestAnimationFrame(frame);
+        }
+      }
+    }
+
+    cancelAnimationFrame(frameRef.current);
+    frameRef.current = requestAnimationFrame(frame);
+  };
+
+  const handlePointerLeave = () => {
+    statusRef.current = 'idle';
+    cancelAnimationFrame(frameRef.current);
+  };
+
+  const floatingCallback = useCallback((node: HTMLElement | null) => {
+    floating(node);
+    arrowRef.current = node;
+  }, []);
+
+  if (!element) {
+    return null;
+  }
+
+  if (
+    (dir === 'up' && scrollTop < 15) ||
+    (dir === 'down' &&
+      scrollTop > element.scrollHeight - element.clientHeight - 15)
+  ) {
+    return null;
+  }
+
+  return (
+    <div
+      className="MacSelect-ScrollArrow"
+      ref={floatingCallback}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
+      style={{
+        width: element.offsetWidth,
+        position: strategy,
+        top: y ?? 0,
+        left: x ?? 0,
+      }}
+    >
+      {dir === 'up' ? '▲' : '▼'}
+    </div>
+  );
+}
+
+export function Main() {
+  const listRef = useRef<Array<HTMLElement | null>>([]);
+  const listContentRef = useRef<Array<string | null>>([]);
+  const overflowRef = useRef<null | SideObject>(null);
+  const allowSelectRef = useRef(false);
+  const allowMouseUpRef = useRef(true);
+  const selectTimeoutRef = useRef<any>();
+  const upArrowRef = useRef<HTMLDivElement | null>(null);
+  const downArrowRef = useRef<HTMLDivElement | null>(null);
+
+  const [open, setOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [fallback, setFallback] = useState(false);
+  const [innerOffset, setInnerOffset] = useState(0);
+  const [controlledScrolling, setControlledScrolling] = useState(false);
+  const [touch, setTouch] = useState(false);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [blockSelection, setBlockSelection] = useState(false);
+
+  const {x, y, reference, floating, strategy, context, refs} = useFloating({
+    placement: 'bottom-start',
+    open,
+    onOpenChange: setOpen,
+    whileElementsMounted: autoUpdate,
+    middleware: fallback
+      ? [
+          offset(5),
+          ...[
+            touch ? shift({crossAxis: true, padding: 10}) : flip({padding: 10}),
+          ],
+          size({
+            apply({elements, availableHeight}) {
+              Object.assign(elements.floating.style, {
+                maxHeight: `${availableHeight}px`,
+              });
+            },
+            padding: 10,
+          }),
+        ]
+      : [
+          inner({
+            listRef,
+            overflowRef,
+            index: selectedIndex,
+            offset: innerOffset,
+            onFallbackChange: setFallback,
+            padding: 10,
+            minItemsVisible: touch ? 10 : 4,
+            referenceOverflowThreshold: 25,
+          }),
+          offset({crossAxis: -4}),
+        ],
+  });
+
+  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
+    useClick(context, {pointerDown: true}),
+    useDismiss(context, {outsidePointerDown: false}),
+    useRole(context, {role: 'listbox'}),
+    useInnerOffset(context, {
+      enabled: !fallback,
+      onChange: setInnerOffset,
+      overflowRef,
+    }),
+    useListNavigation(context, {
+      listRef,
+      activeIndex,
+      selectedIndex,
+      loop: true,
+      onNavigate: setActiveIndex,
+    }),
+    useTypeahead(context, {
+      listRef: listContentRef,
+      activeIndex,
+      onMatch: open ? setActiveIndex : setSelectedIndex,
+    }),
+  ]);
+
+  useLayoutEffect(() => {
+    if (open) {
+      selectTimeoutRef.current = setTimeout(() => {
+        allowSelectRef.current = true;
+      }, 300);
+
+      return () => {
+        clearTimeout(selectTimeoutRef.current);
+      };
+    } else {
+      allowSelectRef.current = false;
+      allowMouseUpRef.current = true;
+      setInnerOffset(0);
+      setFallback(false);
+      setBlockSelection(false);
+    }
+  }, [open]);
+
+  // Replacement for `useDismiss` as the arrows are outside of the floating
+  // element DOM tree.
+  useLayoutEffect(() => {
+    function onPointerDown(e: PointerEvent) {
+      const target = e.target as Node;
+      if (
+        !refs.floating.current?.contains(target) &&
+        !upArrowRef.current?.contains(target) &&
+        !downArrowRef.current?.contains(target)
+      ) {
+        setOpen(false);
+      }
+    }
+
+    if (open) {
+      document.addEventListener('pointerdown', onPointerDown);
+      return () => {
+        document.removeEventListener('pointerdown', onPointerDown);
+      };
+    }
+  }, [open, refs]);
+
+  // Scroll the `activeIndex` item into view only in "controlledScrolling"
+  // (keyboard nav) mode.
+  useLayoutEffect(() => {
+    if (open && controlledScrolling) {
+      requestAnimationFrame(() => {
+        if (activeIndex != null) {
+          listRef.current[activeIndex]?.scrollIntoView({block: 'center'});
+        }
+      });
+    }
+
+    setScrollTop(refs.floating.current?.scrollTop ?? 0);
+  }, [open, refs, controlledScrolling, activeIndex]);
+
+  // Scroll the `selectedIndex` into view upon opening the floating element.
+  useLayoutEffect(() => {
+    if (open && fallback) {
+      requestAnimationFrame(() => {
+        if (selectedIndex != null) {
+          listRef.current[selectedIndex]?.scrollIntoView({block: 'center'});
+        }
+      });
+    }
+  }, [open, fallback, selectedIndex]);
+
+  // Unset the height limiting for fallback mode. This gets executed prior to
+  // the positioning call.
+  useLayoutEffect(() => {
+    if (refs.floating.current && fallback) {
+      refs.floating.current.style.maxHeight = '';
+    }
+  }, [refs, fallback]);
+
+  const handleArrowScroll = (amount: number) => {
+    if (fallback) {
+      if (refs.floating.current) {
+        refs.floating.current.scrollTop -= amount;
+        flushSync(() => setScrollTop(refs.floating.current?.scrollTop ?? 0));
+      }
+    } else {
+      flushSync(() => setInnerOffset((value) => value - amount));
+    }
+  };
+
+  const handleArrowHide = () => {
+    if (touch) {
+      clearTimeout(selectTimeoutRef.current);
+      setBlockSelection(true);
+      selectTimeoutRef.current = setTimeout(() => {
+        setBlockSelection(false);
+      }, 400);
+    }
+  };
+
+  const {emoji, text} = getParts(fruits[selectedIndex]);
+
+  return (
+    <>
+      <h1>Inner</h1>
+      <p>
+        Anchors to an element inside the floating element. Once the user has
+        scrolled the floating element, it will no longer anchor to the item
+        inside of it.
+      </p>
+      <div className="container" style={{width: 350}}>
+        <div className="scroll" style={{position: 'relative'}}>
+          <button
+            ref={reference}
+            className="MacSelect-button"
+            {...getReferenceProps({
+              onTouchStart() {
+                setTouch(true);
+              },
+              onPointerMove({pointerType}) {
+                if (pointerType === 'mouse') {
+                  setTouch(false);
+                }
+              },
+            })}
+          >
+            <span aria-hidden="true">{emoji}</span>
+            <span>{text}</span>
+          </button>
+          {open && (
+            <FloatingOverlay lockScroll={!touch} style={{zIndex: 1}}>
+              <FloatingFocusManager context={context} preventTabbing>
+                <div
+                  ref={floating}
+                  className="MacSelect"
+                  style={{
+                    position: strategy,
+                    top: y ?? 0,
+                    left: x ?? 0,
+                  }}
+                  {...getFloatingProps({
+                    onScroll({currentTarget}) {
+                      // In React 18, the ScrollArrows need to synchronously
+                      // know this value to prevent painting at the wrong
+                      // time.
+                      flushSync(() => setScrollTop(currentTarget.scrollTop));
+                    },
+                    onKeyDown() {
+                      setControlledScrolling(true);
+                    },
+                    onPointerMove() {
+                      setControlledScrolling(false);
+                    },
+                    onContextMenu(e) {
+                      e.preventDefault();
+                    },
+                  })}
+                >
+                  {fruits.map((fruit, i) => {
+                    const {emoji, text} = getParts(fruit);
+                    return (
+                      <button
+                        // Prevent immediate selection on touch devices when
+                        // pressing the ScrollArrows
+                        disabled={blockSelection}
+                        aria-selected={selectedIndex === i}
+                        role="option"
+                        style={{
+                          background:
+                            activeIndex === i
+                              ? 'rgba(0,200,255,0.2)'
+                              : i === selectedIndex
+                              ? 'rgba(0,0,50,0.05)'
+                              : 'transparent',
+                          fontWeight: i === selectedIndex ? 'bold' : '',
+                        }}
+                        ref={(node) => {
+                          listRef.current[i] = node;
+                          listContentRef.current[i] = text;
+                        }}
+                        {...getItemProps({
+                          onTouchStart() {
+                            allowSelectRef.current = true;
+                            allowMouseUpRef.current = false;
+                          },
+                          onKeyDown() {
+                            allowSelectRef.current = true;
+                          },
+                          onClick() {
+                            if (allowSelectRef.current) {
+                              setSelectedIndex(i);
+                              setOpen(false);
+                            }
+                          },
+                          onMouseUp() {
+                            if (!allowMouseUpRef.current) {
+                              return;
+                            }
+
+                            if (allowSelectRef.current) {
+                              setSelectedIndex(i);
+                              setOpen(false);
+                            }
+
+                            // On touch devices, prevent the element from
+                            // immediately closing `onClick` by deferring it
+                            clearTimeout(selectTimeoutRef.current);
+                            selectTimeoutRef.current = setTimeout(() => {
+                              allowSelectRef.current = true;
+                            });
+                          },
+                        })}
+                      >
+                        <span aria-hidden="true">{emoji}</span>
+                        <span>{text}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </FloatingFocusManager>
+              {(['up', 'down'] as Array<'up' | 'down'>).map((dir) => (
+                <ScrollArrow
+                  key={dir}
+                  dir={dir}
+                  scrollTop={scrollTop}
+                  arrowRef={dir === 'up' ? upArrowRef : downArrowRef}
+                  floatingRef={refs.floating}
+                  open={open}
+                  onScroll={handleArrowScroll}
+                  onHide={handleArrowHide}
+                />
+              ))}
+            </FloatingOverlay>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/react-dom-interactions/test/visual/index.tsx
+++ b/packages/react-dom-interactions/test/visual/index.tsx
@@ -12,6 +12,7 @@ import './index.css';
 import {Main as Tooltip} from './components/Tooltip';
 import {Main as Popover} from './components/Popover';
 import {Main as Menu} from './components/Menu';
+import {Main as MacSelect} from './components/MacSelect';
 
 import {New} from './utils/New';
 
@@ -19,6 +20,7 @@ const ROUTES = [
   {path: 'tooltip', component: Tooltip},
   {path: 'popover', component: Popover},
   {path: 'menu', component: Menu},
+  {path: 'mac-select', component: MacSelect},
 ];
 
 function App() {


### PR DESCRIPTION
Closes #1580

This adds a generic abstraction required to create a macOS-style `<select>` where an item inside of the floating element is anchored to the reference element (upon opening, the item sits on top of it). 

It's not as simple as using the `offset` middleware and calculating the `.offsetTop` of the inner item. This is because if the select menu is moderately large, it will overflow the boundary. It needs to limit its height on the top and bottom but also expand the maxHeight when scrolling in case the reference element is near the boundary, the small "viewport" caused by the initial alignment results in suboptimal UX otherwise. 

All of this requires pretty complex logic and an interaction hook. It's also not really possible to make it agnostic to the DOM, so for this it's only available for `@floating-ui/react-dom-interactions`.

As this uses detectOverflow logic, it's far less hacky and better customizable/easier to use than the CodeSandbox experiment.