### PR TITLE
fix(dom): calc position correctly with css transform()

### DIFF
--- a/packages/dom/src/utils/getBoundingClientRect.ts
+++ b/packages/dom/src/utils/getBoundingClientRect.ts
@@ -27,14 +27,13 @@ export function getBoundingClientRect(
   const win = isElement(element) ? getWindow(element) : window;
   const addVisualOffsets = !isLayoutViewport() && isFixedStrategy;
 
-  const x =
-    (clientRect.left +
-      (addVisualOffsets ? win.visualViewport?.offsetLeft ?? 0 : 0)) /
-    scaleX;
-  const y =
-    (clientRect.top +
-      (addVisualOffsets ? win.visualViewport?.offsetTop ?? 0 : 0)) /
-    scaleY;
+  const x0 = clientRect.left +
+    (addVisualOffsets ? win.visualViewport?.offsetLeft ?? 0 : 0);
+  const y0 = clientRect.top +
+    (addVisualOffsets ? win.visualViewport?.offsetTop ?? 0 : 0);
+
+  const x = scaleX < 1 ? x0 * scaleX : x0 / scaleX;
+  const y = scaleY < 1 ? y0 * scaleY : y0 / scaleY;
   const width = clientRect.width / scaleX;
   const height = clientRect.height / scaleY;
 

--- a/packages/dom/src/utils/getClippingRect.ts
+++ b/packages/dom/src/utils/getClippingRect.ts
@@ -24,7 +24,7 @@ function getInnerBoundingClientRect(
 ): ClientRectObject {
   const clientRect = getBoundingClientRect(
     element,
-    false,
+    true,
     strategy === 'fixed'
   );
   const top = clientRect.top + element.clientTop;


### PR DESCRIPTION
This PR should fix the positioning of elements when applying `transform: scale()` to any element or any of its parents.

it's based on https://github.com/floating-ui/floating-ui/issues/1594#issuecomment-1086821366  but instead of passing the scale as a parameter I'm using it always. The scale formula is taken from https://github.com/rfrey-rbx/popper.js/commit/add166ea75be347081990674f346031575b3dac3

before (with `scale(0.5)` applied to the container of the app):

<img width="360" alt="Schermata 2022-06-30 alle 12 41 20" src="https://user-images.githubusercontent.com/6401008/176658871-37c53c8b-d7fd-480d-b0f0-65cf3c33986c.png">

after:

<img width="357" alt="Schermata 2022-06-30 alle 12 41 36" src="https://user-images.githubusercontent.com/6401008/176658966-975f1e06-08fb-4f3f-b1e3-f18d5694f48c.png">

