### PR TITLE
fix(react-dom-interactions): various tweaks

### DIFF
--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -229,6 +229,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
   ]);
 
   React.useEffect(() => {
+    // Retain `returnFocus` behavior for root nodes
     if (preventTabbing && !root) {
       return;
     }
@@ -237,10 +238,12 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     const floating = refs.floating.current;
     const previouslyFocusedElement = activeElement(getDocument(floating));
 
-    if (typeof initialFocus === 'number') {
-      focus(getTabbableElements()[initialFocus] ?? floating);
-    } else if (isHTMLElement(initialFocus?.current)) {
-      focus(initialFocus.current ?? floating);
+    if (!preventTabbing) {
+      if (typeof initialFocus === 'number') {
+        focus(getTabbableElements()[initialFocus] ?? floating);
+      } else if (isHTMLElement(initialFocus?.current)) {
+        focus(initialFocus.current ?? floating);
+      }
     }
 
     // Dismissing via outside `pointerdown` should always ignore `returnFocus`

--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -241,10 +241,9 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     }
 
     // Dismissing via outside `pointerdown` should always ignore `returnFocus`
-    // to prevent unwanted scrolling. The `esc` key will continue to focus the
-    // reference.
-    function onDismiss() {
-      returnFocusValue = false;
+    // to prevent unwanted scrolling.
+    function onDismiss(allowReturnFocus = false) {
+      returnFocusValue = allowReturnFocus;
     }
 
     events.on('dismiss', onDismiss);

--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -72,6 +72,9 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
   const onOpenChangeRef = useLatestRef(onOpenChange);
   const tree = useFloatingTree();
 
+  const root =
+    tree?.nodesRef.current.find((node) => node.id === nodeId)?.parentId == null;
+
   const getTabbableElements = React.useCallback(() => {
     return orderRef.current
       .map((type) => {
@@ -226,7 +229,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
   ]);
 
   React.useEffect(() => {
-    if (preventTabbing) {
+    if (preventTabbing && !root) {
       return;
     }
 
@@ -262,6 +265,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     returnFocus,
     refs,
     events,
+    root,
   ]);
 
   const isTypeableCombobox = () =>

--- a/packages/react-dom-interactions/src/hooks/useClick.ts
+++ b/packages/react-dom-interactions/src/hooks/useClick.ts
@@ -39,13 +39,14 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
   return {
     reference: {
       onPointerDown(event) {
+        pointerTypeRef.current = event.pointerType;
+      },
+      onMouseDown(event) {
         // Ignore all buttons except for the "main" button.
         // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
         if (event.button !== 0) {
           return;
         }
-
-        pointerTypeRef.current = event.pointerType;
 
         if (pointerTypeRef.current === 'mouse' && ignoreMouse) {
           return;

--- a/packages/react-dom-interactions/src/hooks/useClick.ts
+++ b/packages/react-dom-interactions/src/hooks/useClick.ts
@@ -60,7 +60,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
           if (
             toggle &&
             (dataRef.current.openEvent
-              ? dataRef.current.openEvent.type === 'pointerdown'
+              ? dataRef.current.openEvent.type === 'mousedown'
               : true)
           ) {
             onOpenChange(false);

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -5,7 +5,7 @@ import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import {activeElement} from '../utils/activeElement';
 import {getChildren} from '../utils/getChildren';
 import {getDocument} from '../utils/getDocument';
-import {isElement, isHTMLElement} from '../utils/is';
+import {isElement} from '../utils/is';
 import {isEventTargetWithin} from '../utils/isEventTargetWithin';
 import {useLatestRef} from '../utils/useLatestRef';
 
@@ -53,12 +53,8 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
           return;
         }
 
-        events.emit('dismiss');
+        events.emit('dismiss', true);
         onOpenChangeRef.current(false);
-
-        if (isHTMLElement(refs.domReference.current)) {
-          refs.domReference.current.focus();
-        }
       }
     }
 
@@ -91,10 +87,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
 
     const doc = getDocument(refs.floating.current);
     escapeKey && doc.addEventListener('keydown', onKeyDown);
-    // Use `mousedown` instead of `pointerdown` as it acts more like a click
-    // on touch devices than a `touchstart` (which can result in accidental
-    // dismissals too easily.)
-    outsidePointerDown && doc.addEventListener('mousedown', onPointerDown);
+    outsidePointerDown && doc.addEventListener('pointerdown', onPointerDown);
 
     const ancestors = (
       ancestorScroll
@@ -118,7 +111,8 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
 
     return () => {
       escapeKey && doc.removeEventListener('keydown', onKeyDown);
-      outsidePointerDown && doc.removeEventListener('mousedown', onPointerDown);
+      outsidePointerDown &&
+        doc.removeEventListener('pointerdown', onPointerDown);
       ancestors.forEach((ancestor) =>
         ancestor.removeEventListener('scroll', onScroll)
       );

--- a/packages/react-dom-interactions/src/hooks/useListNavigation.ts
+++ b/packages/react-dom-interactions/src/hooks/useListNavigation.ts
@@ -320,23 +320,6 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
     disabledIndicesRef,
   ]);
 
-  // Return focus to the reference element when `selectedIndex` is a number and
-  // the floating element closes.
-  useLayoutEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
-    if (
-      !open &&
-      previousOpen &&
-      selectedIndex != null &&
-      isHTMLElement(refs.domReference.current)
-    ) {
-      refs.domReference.current.focus();
-    }
-  }, [refs, selectedIndex, open, previousOpen, enabled]);
-
   // Ensure the parent floating element has focus when a nested child closes
   // to allow arrow key navigation to work after the pointer leaves the child.
   useLayoutEffect(() => {
@@ -553,7 +536,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
             }
           }
         },
-        onMouseLeave() {
+        onPointerLeave() {
           if (!blockPointerLeaveRef.current) {
             indexRef.current = -1;
             focusItem(listRef, indexRef);

--- a/packages/react-dom-interactions/test/unit/useListNavigation.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useListNavigation.test.tsx
@@ -317,7 +317,7 @@ describe('focusOnHover', () => {
     fireEvent.click(screen.getByRole('button'));
     fireEvent.mouseMove(screen.getByTestId('item-1'));
     expect(screen.getByTestId('item-1')).toHaveFocus();
-    fireEvent.mouseLeave(screen.getByTestId('item-1'));
+    fireEvent.pointerLeave(screen.getByTestId('item-1'));
     expect(screen.getByRole('menu')).toHaveFocus();
     expect(spy).toHaveBeenCalledWith(1);
     cleanup();


### PR DESCRIPTION
Working on #1758 trying to create the select that worked well on touch + mouse, these issues arose

- All return focus to reference calls are now exclusively handled by `FloatingFocusManager` to bypass isuses with unmounting animations tested with `framer-motion`. Previously pressing `esc` meant the user could open the floating element while it was still transitioning out and this caused the focus trap to fail. Now it waits for the animation to finish so the bug is gone.
- `lockScroll` on iOS and touch in general is poor for non fullscreen modal/dialogs, and the `mousedown` event used in `useDismiss` is now `pointerdown` to instantly dismiss the floating element while attempting to scroll.
- Conversely, the `pointerdown` event in `useClick` is now `mousedown` because it was 1) too easy to open the floating element by touching the screen unintentionally, and 2) caused issues with focus being moved to items unexpectedly.
- `onPointerLeave` instead of `onMouseLeave` in `useListNavigation` also works better on touch devices