### PR TITLE
feat(useListNavigation): Grid navigation

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useListNavigation.ts
+++ b/packages/react-dom-interactions/src/hooks/useListNavigation.ts
@@ -14,6 +14,10 @@ const ARROW_DOWN = 'ArrowDown';
 const ARROW_LEFT = 'ArrowLeft';
 const ARROW_RIGHT = 'ArrowRight';
 
+function isDifferentRow(index: number, cols: number, prevRow: number) {
+  return Math.floor(index / cols) !== prevRow;
+}
+
 function isIndexOutOfBounds(
   listRef: React.MutableRefObject<Array<HTMLElement | null>>,
   index: number
@@ -27,17 +31,19 @@ function findNonDisabledIndex(
     startingIndex = -1,
     decrement = false,
     disabledIndices,
+    amount = 1,
   }: {
     startingIndex?: number;
     decrement?: boolean;
     disabledIndices?: Array<number>;
+    amount?: number;
   } = {}
 ): number {
   const list = listRef.current;
 
   let index = startingIndex;
   do {
-    index = index + (decrement ? -1 : 1);
+    index = index + (decrement ? -amount : amount);
   } while (
     index >= 0 &&
     index <= list.length - 1 &&
@@ -128,7 +134,7 @@ function getMaxIndex(
 export interface Props {
   listRef: React.MutableRefObject<Array<HTMLElement | null>>;
   activeIndex: number | null;
-  onNavigate: (index: number | null) => void;
+  onNavigate?: (index: number | null) => void;
   enabled?: boolean;
   selectedIndex?: number | null;
   focusItemOnOpen?: boolean | 'auto';
@@ -141,6 +147,7 @@ export interface Props {
   rtl?: boolean;
   virtual?: boolean;
   orientation?: 'vertical' | 'horizontal' | 'both';
+  cols?: number;
 }
 
 /**
@@ -153,7 +160,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
   {
     listRef,
     activeIndex,
-    onNavigate,
+    onNavigate = () => {},
     enabled = true,
     selectedIndex = null,
     allowEscape = false,
@@ -166,6 +173,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
     openOnArrowKeyDown = true,
     disabledIndices = openOnArrowKeyDown ? undefined : [],
     orientation = 'vertical',
+    cols = 1,
   }: Props = {
     listRef: {current: []},
     activeIndex: null,
@@ -371,6 +379,153 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
     if (event.key === 'End') {
       indexRef.current = maxIndex;
       onNavigate(indexRef.current);
+    }
+
+    // Grid navigation
+    if (cols > 1) {
+      const prevIndex = indexRef.current;
+
+      if (event.key === ARROW_UP) {
+        stopEvent(event);
+
+        if (prevIndex === -1) {
+          indexRef.current = maxIndex;
+        } else {
+          indexRef.current = findNonDisabledIndex(listRef, {
+            startingIndex: prevIndex,
+            amount: cols,
+            decrement: true,
+            disabledIndices,
+          });
+
+          if (loop && (prevIndex - cols < minIndex || indexRef.current < 0)) {
+            const col = prevIndex % cols;
+            const maxCol = maxIndex % cols;
+            const offset = maxIndex - (maxCol - col);
+
+            if (maxCol === col) {
+              indexRef.current = maxIndex;
+            } else {
+              indexRef.current = maxCol > col ? offset : offset - cols;
+            }
+          }
+        }
+
+        if (isIndexOutOfBounds(listRef, indexRef.current)) {
+          indexRef.current = prevIndex;
+        }
+
+        onNavigate(indexRef.current);
+      }
+
+      if (event.key === ARROW_DOWN) {
+        stopEvent(event);
+
+        if (prevIndex === -1) {
+          indexRef.current = minIndex;
+        } else {
+          indexRef.current = findNonDisabledIndex(listRef, {
+            startingIndex: prevIndex,
+            amount: cols,
+            disabledIndices,
+          });
+
+          if (loop && prevIndex + cols > maxIndex) {
+            indexRef.current = findNonDisabledIndex(listRef, {
+              startingIndex: (prevIndex % cols) - cols,
+              amount: cols,
+              disabledIndices,
+            });
+          }
+        }
+
+        if (isIndexOutOfBounds(listRef, indexRef.current)) {
+          indexRef.current = prevIndex;
+        }
+
+        onNavigate(indexRef.current);
+      }
+
+      // Remains on the same row/column
+      if (orientation === 'both') {
+        const prevRow = Math.floor(prevIndex / cols);
+
+        if (event.key === ARROW_RIGHT) {
+          stopEvent(event);
+
+          if (prevIndex % cols !== cols - 1) {
+            indexRef.current = findNonDisabledIndex(listRef, {
+              startingIndex: prevIndex,
+              disabledIndices,
+            });
+
+            if (loop && isDifferentRow(indexRef.current, cols, prevRow)) {
+              indexRef.current = findNonDisabledIndex(listRef, {
+                startingIndex: prevIndex - (prevIndex % cols) - 1,
+                disabledIndices,
+              });
+            }
+          } else if (loop) {
+            indexRef.current = findNonDisabledIndex(listRef, {
+              startingIndex: prevIndex - (prevIndex % cols) - 1,
+              disabledIndices,
+            });
+          }
+
+          if (isDifferentRow(indexRef.current, cols, prevRow)) {
+            indexRef.current = prevIndex;
+          }
+        }
+
+        if (event.key === ARROW_LEFT) {
+          stopEvent(event);
+
+          if (prevIndex % cols !== 0) {
+            indexRef.current = findNonDisabledIndex(listRef, {
+              startingIndex: prevIndex,
+              disabledIndices,
+              decrement: true,
+            });
+
+            if (loop && isDifferentRow(indexRef.current, cols, prevRow)) {
+              indexRef.current = findNonDisabledIndex(listRef, {
+                startingIndex: prevIndex + (cols - (prevIndex % cols)),
+                decrement: true,
+                disabledIndices,
+              });
+            }
+          } else if (loop) {
+            indexRef.current = findNonDisabledIndex(listRef, {
+              startingIndex: prevIndex + (cols - (prevIndex % cols)),
+              decrement: true,
+              disabledIndices,
+            });
+          }
+
+          if (isDifferentRow(indexRef.current, cols, prevRow)) {
+            indexRef.current = prevIndex;
+          }
+        }
+
+        const lastRow = Math.floor(maxIndex / cols) === prevRow;
+
+        if (isIndexOutOfBounds(listRef, indexRef.current)) {
+          if (loop && lastRow) {
+            indexRef.current =
+              event.key === ARROW_LEFT
+                ? maxIndex
+                : findNonDisabledIndex(listRef, {
+                    startingIndex: prevIndex - (prevIndex % cols) - 1,
+                    disabledIndices,
+                  });
+          } else {
+            indexRef.current = prevIndex;
+          }
+        }
+
+        onNavigate(indexRef.current);
+        return;
+      }
     }
 
     if (isMainOrientationKey(event.key, orientation)) {

--- a/packages/react-dom-interactions/src/hooks/useListNavigation.ts
+++ b/packages/react-dom-interactions/src/hooks/useListNavigation.ts
@@ -171,7 +171,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
     focusItemOnOpen = 'auto',
     focusItemOnHover = true,
     openOnArrowKeyDown = true,
-    disabledIndices = openOnArrowKeyDown ? undefined : [],
+    disabledIndices = undefined,
     orientation = 'vertical',
     cols = 1,
   }: Props = {

--- a/packages/react-dom-interactions/src/hooks/useListNavigation.ts
+++ b/packages/react-dom-interactions/src/hooks/useListNavigation.ts
@@ -204,8 +204,8 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
     if (orientation === 'vertical' && cols > 1) {
       console.warn(
         [
-          'Floating UI: In grid mode (`cols` > 1), the `orientation` should be',
-          'either "horizontal" or "both".',
+          'Floating UI: In grid list navigation mode (`cols` > 1), the',
+          '`orientation` should be either "horizontal" or "both".',
         ].join(' ')
       );
     }

--- a/packages/react-dom-interactions/src/hooks/useListNavigation.ts
+++ b/packages/react-dom-interactions/src/hooks/useListNavigation.ts
@@ -200,6 +200,15 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
         );
       }
     }
+
+    if (orientation === 'vertical' && cols > 1) {
+      console.warn(
+        [
+          'Floating UI: In grid mode (`cols` > 1), the `orientation` should be',
+          'either "horizontal" or "both".',
+        ].join(' ')
+      );
+    }
   }
 
   const parentId = useFloatingParentNodeId();

--- a/packages/react-dom-interactions/test/unit/useListNavigation.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useListNavigation.test.tsx
@@ -1,4 +1,4 @@
-import {fireEvent, render, screen, cleanup} from '@testing-library/react';
+import {fireEvent, render, screen, cleanup, act} from '@testing-library/react';
 import {useRef, useState} from 'react';
 import {
   useListNavigation,
@@ -7,6 +7,7 @@ import {
   useClick,
 } from '../../src';
 import type {Props} from '../../src/hooks/useListNavigation';
+import {Main as Grid} from '../visual/components/Grid';
 
 function App(props: Omit<Partial<Props>, 'listRef'>) {
   const [open, setOpen] = useState(false);
@@ -330,6 +331,171 @@ describe('focusOnHover', () => {
     fireEvent.mouseMove(screen.getByTestId('item-1'));
     expect(screen.getByTestId('item-1')).not.toHaveFocus();
     expect(spy).toHaveBeenCalledTimes(0);
+    cleanup();
+  });
+});
+
+describe('grid navigation', () => {
+  test('focuses first non-disabled item in grid', () => {
+    render(<Grid />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter'});
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getAllByRole('option')[8]).toHaveFocus();
+    cleanup();
+  });
+
+  test('focuses next item using ArrowRight key, skipping disabled items', () => {
+    render(<Grid />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter'});
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowRight'});
+    expect(screen.getAllByRole('option')[9]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowRight'});
+    expect(screen.getAllByRole('option')[11]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowRight'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowRight'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowRight'});
+    expect(screen.getAllByRole('option')[14]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowRight'});
+    expect(screen.getAllByRole('option')[16]).toHaveFocus();
+    cleanup();
+  });
+
+  test('focuses previous item using ArrowLeft key, skipping disabled items', () => {
+    render(<Grid />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter'});
+    fireEvent.click(screen.getByRole('button'));
+
+    act(() => screen.getAllByRole('option')[47].focus());
+
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowLeft'});
+    expect(screen.getAllByRole('option')[46]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowLeft'});
+    expect(screen.getAllByRole('option')[44]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowLeft'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowLeft'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowLeft'});
+    expect(screen.getAllByRole('option')[41]).toHaveFocus();
+    cleanup();
+  });
+
+  test('skips row and remains on same column when pressing ArrowDown', () => {
+    render(<Grid />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter'});
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+    expect(screen.getAllByRole('option')[13]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+    expect(screen.getAllByRole('option')[18]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+    expect(screen.getAllByRole('option')[23]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+    expect(screen.getAllByRole('option')[28]).toHaveFocus();
+
+    cleanup();
+  });
+
+  test('skips row and remains on same column when pressing ArrowUp', () => {
+    render(<Grid />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter'});
+    fireEvent.click(screen.getByRole('button'));
+
+    act(() => screen.getAllByRole('option')[47].focus());
+
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowUp'});
+    expect(screen.getAllByRole('option')[42]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowUp'});
+    expect(screen.getAllByRole('option')[37]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowUp'});
+    expect(screen.getAllByRole('option')[32]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowUp'});
+    expect(screen.getAllByRole('option')[27]).toHaveFocus();
+
+    cleanup();
+  });
+
+  test('loops on the same column with ArrowDown', () => {
+    render(<Grid loop />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter'});
+    fireEvent.click(screen.getByRole('button'));
+
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+
+    expect(screen.getAllByRole('option')[8]).toHaveFocus();
+
+    cleanup();
+  });
+
+  test('loops on the same column with ArrowUp', () => {
+    render(<Grid loop />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter'});
+    fireEvent.click(screen.getByRole('button'));
+
+    act(() => screen.getAllByRole('option')[43].focus());
+
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowUp'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowUp'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowUp'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowUp'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowUp'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowUp'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowUp'});
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowUp'});
+
+    expect(screen.getAllByRole('option')[43]).toHaveFocus();
+
+    cleanup();
+  });
+
+  test('does not leave row with "both" orientation while looping', () => {
+    render(<Grid orientation="both" loop />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter'});
+    fireEvent.click(screen.getByRole('button'));
+
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowRight'});
+    expect(screen.getAllByRole('option')[9]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowRight'});
+    expect(screen.getAllByRole('option')[8]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowLeft'});
+    expect(screen.getAllByRole('option')[9]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowLeft'});
+    expect(screen.getAllByRole('option')[8]).toHaveFocus();
+
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowDown'});
+    expect(screen.getAllByRole('option')[13]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowRight'});
+    expect(screen.getAllByRole('option')[14]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowRight'});
+    expect(screen.getAllByRole('option')[11]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowLeft'});
+    expect(screen.getAllByRole('option')[14]).toHaveFocus();
+
+    cleanup();
+  });
+
+  test('looping works on last row', () => {
+    render(<Grid orientation="both" loop />);
+    fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter'});
+    fireEvent.click(screen.getByRole('button'));
+
+    act(() => screen.getAllByRole('option')[46].focus());
+
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowRight'});
+    expect(screen.getAllByRole('option')[47]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowRight'});
+    expect(screen.getAllByRole('option')[46]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowLeft'});
+    expect(screen.getAllByRole('option')[47]).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId('floating'), {key: 'ArrowLeft'});
+    expect(screen.getAllByRole('option')[46]).toHaveFocus();
+
     cleanup();
   });
 });

--- a/packages/react-dom-interactions/test/visual/components/EmojiPicker.css
+++ b/packages/react-dom-interactions/test/visual/components/EmojiPicker.css
@@ -1,0 +1,64 @@
+.EmojiPicker {
+  box-shadow: rgb(0 0 0 / 50%) 0px 0px 1px, rgb(0 0 0 / 3%) 0px 100px 80px,
+    rgb(0 0 0 / 2%) 0px 41.7776px 33.4221px,
+    rgb(0 0 0 / 2%) 0px 22.3363px 17.869px,
+    rgb(0 0 0 / 4%) 0px 12.5216px 10.0172px;
+  background: white;
+  border-radius: 8px;
+  padding: 10px 15px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.EmojiPicker-button {
+  background: white;
+  border: 1px solid rgba(0, 10, 20, 0.25);
+  border-radius: 50%;
+  padding: 6px 12px;
+  font-weight: 500;
+  font-size: 24px;
+}
+
+.EmojiPicker-search {
+  border: none;
+  padding: 4px 8px;
+  border: 1px solid rgba(0, 10, 20, 0.2);
+  border-radius: 4px;
+  width: 120px;
+}
+
+.EmojiPicker-search:focus {
+  outline: 0;
+  border-color: white;
+  box-shadow: 0 0 0 2px royalblue;
+}
+
+.EmojiPicker-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: 2px;
+  right: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 20px;
+  padding: 0;
+  vertical-align: middle;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  color: rgba(0, 10, 20, 0.8);
+  outline: 0;
+}
+
+.EmojiPicker-close:focus-visible {
+  box-shadow: 0 0 0 2px royalblue;
+}
+
+.EmojiPicker-no-results {
+  font-size: 14px;
+  margin: 0;
+}

--- a/packages/react-dom-interactions/test/visual/components/EmojiPicker.tsx
+++ b/packages/react-dom-interactions/test/visual/components/EmojiPicker.tsx
@@ -12,7 +12,10 @@ import {
   flip,
   autoUpdate,
   useId,
+  Placement,
 } from '@floating-ui/react-dom-interactions';
+
+import './EmojiPicker.css';
 
 const emojis = [
   {
@@ -68,21 +71,27 @@ const Option = forwardRef<HTMLButtonElement, OptionProps>(function Option(
   return (
     <button
       {...props}
-      type="button"
       ref={ref}
-      role="option"
       id={id}
+      role="option"
       aria-selected={selected}
       aria-label={name}
       tabIndex={-1}
       style={{
-        background: active ? 'cyan' : 'none',
+        background: active
+          ? 'rgba(0, 255, 255, 0.5)'
+          : selected
+          ? 'rgba(0, 10, 20, 0.1)'
+          : 'none',
+        border: active
+          ? '1px solid rgba(0, 225, 255, 1)'
+          : '1px solid transparent',
         borderRadius: 4,
-        border: 'none',
-        fontSize: 36,
+        fontSize: 30,
         textAlign: 'center',
         cursor: 'default',
         userSelect: 'none',
+        padding: 0,
       }}
     >
       {children}
@@ -95,14 +104,27 @@ export const Main = () => {
   const [search, setSearch] = useState('');
   const [selectedEmoji, setSelectedEmoji] = useState<string | null>(null);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [placement, setPlacement] = useState<Placement | null>(null);
 
   const listRef = useRef<Array<HTMLElement | null>>([]);
 
-  const {x, y, reference, floating, strategy, context} = useFloating({
-    placement: 'bottom-start',
+  const noResultsId = useId();
+
+  const {
+    x,
+    y,
+    reference,
+    floating,
+    strategy,
+    context,
+    placement: resultantPlacement,
+  } = useFloating({
+    placement: placement ?? 'bottom',
     open,
     onOpenChange: setOpen,
-    middleware: [offset(8), flip()],
+    // We don't want flipping to occur while searching, as the floating element
+    // will resize and cause disorientation.
+    middleware: [offset(4), ...(placement ? [] : [flip()])],
     whileElementsMounted: autoUpdate,
   });
 
@@ -134,11 +156,14 @@ export const Main = () => {
   ]);
 
   useEffect(() => {
-    if (!open) {
+    if (open) {
+      setPlacement(resultantPlacement);
+    } else {
       setSearch('');
       setActiveIndex(null);
+      setPlacement(null);
     }
-  }, [open]);
+  }, [open, resultantPlacement]);
 
   const handleEmojiClick = () => {
     if (activeIndex !== null) {
@@ -166,81 +191,110 @@ export const Main = () => {
     <>
       <h1>Emoji Picker</h1>
       <div className="container">
-        <div>
+        <div style={{textAlign: 'center'}}>
+          <button
+            ref={reference}
+            className="EmojiPicker-button"
+            aria-label="Choose emoji"
+            aria-describedby="emoji-label"
+            style={{
+              background: open ? 'rgba(0, 10, 20, 0.1)' : '',
+            }}
+            {...getReferenceProps()}
+          >
+            ☻
+          </button>
+          <br />
           {selectedEmoji && (
             <span id="emoji-label">
               <span
-                style={{fontSize: 36}}
+                style={{fontSize: 30}}
                 aria-label={
                   emojis.find(({emoji}) => emoji === selectedEmoji)?.name
                 }
               >
                 {selectedEmoji}
               </span>{' '}
-              is the selected emoji
+              selected
             </span>
           )}
-          <br />
-          <button
-            ref={reference}
-            aria-describedby="emoji-label"
-            {...getReferenceProps()}
-          >
-            Choose emoji
-          </button>
           <FloatingPortal>
             {open && (
               <FloatingFocusManager context={context}>
                 <div
                   ref={floating}
+                  className="EmojiPicker"
                   style={{
                     position: strategy,
                     left: x ?? 0,
                     top: y ?? 0,
-                    padding: 15,
-                    border: '1px solid black',
-                    background: 'white',
                   }}
                   {...getFloatingProps(getListFloatingProps())}
                 >
+                  <span
+                    style={{
+                      opacity: 0.4,
+                      fontSize: 12,
+                      textTransform: 'uppercase',
+                    }}
+                  >
+                    Emoji Picker
+                  </span>
                   <input
+                    className="EmojiPicker-search"
                     placeholder="Search emoji"
                     value={search}
+                    aria-controls={noResultsId}
                     {...getInputProps({
                       onChange: handleInputChange,
                       onKeyDown: handleKeyDown,
                     })}
                   />
                   <button
+                    className="EmojiPicker-close"
                     aria-label="Close picker"
                     onClick={() => setOpen(false)}
                   >
-                    X
+                    ×
                   </button>
-                  <div
-                    style={{
-                      display: 'grid',
-                      gridTemplateColumns: '50px 50px 50px',
-                    }}
-                    role="listbox"
-                  >
-                    {filteredEmojis.map(({name, emoji}, index) => (
-                      <Option
-                        key={name}
-                        name={name}
-                        ref={(node) => {
-                          listRef.current[index] = node;
-                        }}
-                        selected={selectedEmoji === emoji}
-                        active={activeIndex === index}
-                        {...getItemProps({
-                          onClick: handleEmojiClick,
-                        })}
-                      >
-                        {emoji}
-                      </Option>
-                    ))}
-                  </div>
+                  {filteredEmojis.length === 0 && (
+                    <p
+                      key={search}
+                      id={noResultsId}
+                      className="EmojiPicker-no-results"
+                      role="region"
+                      aria-atomic="true"
+                      aria-live="assertive"
+                    >
+                      No results.
+                    </p>
+                  )}
+                  {filteredEmojis.length > 0 && (
+                    <div
+                      style={{
+                        display: 'grid',
+                        gridTemplateColumns: '40px 40px 40px',
+                      }}
+                      role="listbox"
+                    >
+                      {filteredEmojis.map(({name, emoji}, index) => (
+                        <Option
+                          key={name}
+                          name={name}
+                          ref={(node) => {
+                            listRef.current[index] = node;
+                          }}
+                          selected={selectedEmoji === emoji}
+                          active={activeIndex === index}
+                          {...getItemProps({
+                            onClick: handleEmojiClick,
+                          })}
+                        >
+                          {emoji}
+                        </Option>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </FloatingFocusManager>
             )}

--- a/packages/react-dom-interactions/test/visual/components/EmojiPicker.tsx
+++ b/packages/react-dom-interactions/test/visual/components/EmojiPicker.tsx
@@ -53,11 +53,10 @@ const emojis = [
   },
 ];
 
-type OptionProps = React.HTMLProps<HTMLButtonElement> & {
+type OptionProps = React.HTMLAttributes<HTMLButtonElement> & {
   name: string;
   active: boolean;
   selected: boolean;
-  onClick: () => void;
   children: React.ReactNode;
 };
 
@@ -73,7 +72,6 @@ const Option = forwardRef<HTMLButtonElement, OptionProps>(function Option(
       ref={ref}
       role="option"
       id={id}
-      key={name}
       aria-selected={selected}
       aria-label={name}
       tabIndex={-1}
@@ -229,6 +227,7 @@ export const Main = () => {
                     {filteredEmojis.map(({name, emoji}, index) => (
                       <Option
                         key={name}
+                        name={name}
                         ref={(node) => {
                           listRef.current[index] = node;
                         }}

--- a/packages/react-dom-interactions/test/visual/components/EmojiPicker.tsx
+++ b/packages/react-dom-interactions/test/visual/components/EmojiPicker.tsx
@@ -1,0 +1,201 @@
+import {useState, useRef, useEffect} from 'react';
+import {
+  useFloating,
+  useInteractions,
+  useListNavigation,
+  useClick,
+  useDismiss,
+  FloatingFocusManager,
+  useRole,
+  offset,
+  flip,
+  autoUpdate,
+} from '@floating-ui/react-dom-interactions';
+
+const emojis = [
+  {
+    name: 'apple',
+    emoji: '🍎',
+  },
+  {
+    name: 'orange',
+    emoji: '🍊',
+  },
+  {
+    name: 'watermelon',
+    emoji: '🍉',
+  },
+  {
+    name: 'strawberry',
+    emoji: '🍓',
+  },
+  {
+    name: 'pear',
+    emoji: '🍐',
+  },
+  {
+    name: 'banana',
+    emoji: '🍌',
+  },
+  {
+    name: 'pineapple',
+    emoji: '🍍',
+  },
+  {
+    name: 'cherry',
+    emoji: '🍒',
+  },
+  {
+    name: 'peach',
+    emoji: '🍑',
+  },
+];
+
+export const Main = () => {
+  const [emoji, setEmoji] = useState('');
+  const [showPicker, setShowPicker] = useState(false);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [search, setSearch] = useState('');
+
+  const listRef = useRef<Array<HTMLElement | null>>([]);
+
+  const {x, y, reference, floating, strategy, context} = useFloating({
+    placement: 'bottom-start',
+    open: showPicker,
+    onOpenChange: setShowPicker,
+    middleware: [offset(8), flip()],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
+    useClick(context),
+    useDismiss(context),
+    useRole(context, {role: 'menu'}),
+    useListNavigation(context, {
+      listRef,
+      onNavigate: showPicker ? setActiveIndex : undefined,
+      activeIndex,
+      cols: 3,
+      orientation: 'horizontal',
+      loop: true,
+      openOnArrowKeyDown: false,
+      focusItemOnOpen: false,
+      virtual: true,
+      allowEscape: true,
+    }),
+  ]);
+
+  useEffect(() => {
+    if (!showPicker) {
+      setSearch('');
+      setActiveIndex(null);
+    }
+  }, [showPicker]);
+
+  const handleEmojiClick = () => {
+    if (activeIndex !== null) {
+      setEmoji(filteredEmojis[activeIndex].emoji);
+      setShowPicker(false);
+    }
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setActiveIndex(null);
+    setSearch(event.target.value);
+  };
+
+  const filteredEmojis = emojis.filter(({name}) =>
+    name.toLocaleLowerCase().includes(search.toLocaleLowerCase())
+  );
+
+  return (
+    <>
+      <h1>Emoji Picker</h1>
+      <div className="container">
+        <div>
+          {emoji && (
+            <span id="emoji-label">
+              <span style={{fontSize: 36}}>{emoji}</span> is the selected emoji
+            </span>
+          )}
+          <br />
+          <button
+            ref={reference}
+            aria-describedby="emoji-label"
+            {...getReferenceProps()}
+          >
+            Choose emoji
+          </button>
+          {showPicker && (
+            <FloatingFocusManager context={context}>
+              <div
+                ref={floating}
+                style={{
+                  position: strategy,
+                  left: x ?? 0,
+                  top: y ?? 0,
+                  padding: 15,
+                  border: '1px solid black',
+                  background: 'white',
+                }}
+                {...getFloatingProps()}
+              >
+                <input
+                  placeholder="Search emoji"
+                  value={search}
+                  onChange={handleInputChange}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      handleEmojiClick();
+                    }
+                  }}
+                  aria-activedescendant={
+                    activeIndex == null ? undefined : `option-${activeIndex}`
+                  }
+                />
+                <button
+                  aria-label="Close picker"
+                  onClick={() => setShowPicker(false)}
+                >
+                  X
+                </button>
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '50px 50px 50px',
+                  }}
+                  role="listbox"
+                >
+                  {filteredEmojis.map(({name, emoji: e}, index) => (
+                    <button
+                      role="option"
+                      id={`option-${index}`}
+                      key={name}
+                      aria-selected={emoji === e}
+                      aria-label={name}
+                      tabIndex={-1}
+                      ref={(node) => {
+                        listRef.current[index] = node;
+                      }}
+                      style={{
+                        background: activeIndex === index ? 'cyan' : 'none',
+                        borderRadius: 4,
+                        border: 'none',
+                        fontSize: 36,
+                      }}
+                      {...getItemProps({
+                        onClick: handleEmojiClick,
+                      })}
+                    >
+                      {e}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </FloatingFocusManager>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};

--- a/packages/react-dom-interactions/test/visual/components/Grid.tsx
+++ b/packages/react-dom-interactions/test/visual/components/Grid.tsx
@@ -1,0 +1,87 @@
+import {
+  useFloating,
+  useInteractions,
+  FloatingFocusManager,
+  useClick,
+  useDismiss,
+  useListNavigation,
+} from '@floating-ui/react-dom-interactions';
+import {useRef, useState} from 'react';
+
+interface Props {
+  orientation?: 'horizontal' | 'both';
+  loop?: boolean;
+}
+
+export const Main = ({orientation = 'horizontal', loop = false}: Props) => {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  const listRef = useRef<Array<HTMLElement | null>>([]);
+
+  const {x, y, reference, floating, strategy, context} = useFloating({
+    open,
+    onOpenChange: setOpen,
+    placement: 'bottom-start',
+  });
+
+  const disabledIndices = [0, 1, 2, 3, 4, 5, 6, 7, 10, 15, 45, 48];
+
+  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
+    useClick(context),
+    useListNavigation(context, {
+      listRef,
+      activeIndex,
+      onNavigate: open ? setActiveIndex : undefined,
+      cols: 5,
+      orientation,
+      loop,
+      openOnArrowKeyDown: false,
+      disabledIndices,
+    }),
+    useDismiss(context),
+  ]);
+
+  return (
+    <>
+      <h1>Grid</h1>
+      <div className="container">
+        <button ref={reference} {...getReferenceProps()}>
+          Reference
+        </button>
+        {open && (
+          <FloatingFocusManager context={context}>
+            <div
+              ref={floating}
+              data-testid="floating"
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '100px 100px 100px 100px 100px',
+                position: strategy,
+                left: x ?? 0,
+                top: y ?? 0,
+                zIndex: 999,
+              }}
+              {...getFloatingProps()}
+            >
+              {[...Array(49)].map((_, index) => (
+                <button
+                  role="option"
+                  key={index}
+                  tabIndex={-1}
+                  disabled={disabledIndices.includes(index)}
+                  ref={(node) => {
+                    listRef.current[index] = node;
+                  }}
+                  {...getItemProps()}
+                >
+                  Item {index}
+                </button>
+              ))}
+            </div>
+          </FloatingFocusManager>
+        )}
+      </div>
+    </>
+  );
+};

--- a/packages/react-dom-interactions/test/visual/index.tsx
+++ b/packages/react-dom-interactions/test/visual/index.tsx
@@ -13,6 +13,7 @@ import {Main as Tooltip} from './components/Tooltip';
 import {Main as Popover} from './components/Popover';
 import {Main as Menu} from './components/Menu';
 import {Main as MacSelect} from './components/MacSelect';
+import {Main as Grid} from './components/Grid';
 
 import {New} from './utils/New';
 
@@ -21,6 +22,7 @@ const ROUTES = [
   {path: 'popover', component: Popover},
   {path: 'menu', component: Menu},
   {path: 'mac-select', component: MacSelect},
+  {path: 'grid', component: Grid},
 ];
 
 function App() {

--- a/packages/react-dom-interactions/test/visual/index.tsx
+++ b/packages/react-dom-interactions/test/visual/index.tsx
@@ -15,7 +15,6 @@ import {Main as Menu} from './components/Menu';
 import {Main as MacSelect} from './components/MacSelect';
 import {Main as Grid} from './components/Grid';
 import {Main as EmojiPicker} from './components/EmojiPicker';
-import {Main as Autocomplete} from './components/Autocomplete';
 
 import {New} from './utils/New';
 
@@ -26,7 +25,6 @@ const ROUTES = [
   {path: 'mac-select', component: MacSelect},
   {path: 'grid', component: Grid},
   {path: 'emoji-picker', component: EmojiPicker},
-  {path: 'autocomplete', component: Autocomplete},
 ];
 
 function App() {

--- a/packages/react-dom-interactions/test/visual/index.tsx
+++ b/packages/react-dom-interactions/test/visual/index.tsx
@@ -14,6 +14,8 @@ import {Main as Popover} from './components/Popover';
 import {Main as Menu} from './components/Menu';
 import {Main as MacSelect} from './components/MacSelect';
 import {Main as Grid} from './components/Grid';
+import {Main as EmojiPicker} from './components/EmojiPicker';
+import {Main as Autocomplete} from './components/Autocomplete';
 
 import {New} from './utils/New';
 
@@ -23,6 +25,8 @@ const ROUTES = [
   {path: 'menu', component: Menu},
   {path: 'mac-select', component: MacSelect},
   {path: 'grid', component: Grid},
+  {path: 'emoji-picker', component: EmojiPicker},
+  {path: 'autocomplete', component: Autocomplete},
 ];
 
 function App() {


### PR DESCRIPTION
Closes #1695 

By specifying `cols` the navigation enters grid mode. Most common use is `horizontal` orientation, but with `both` orientation, it can lock itself to a row or column without moving to the next one.

- [x] Tests
- [x] Minor issue when `loop` is enabled with `both` mode and there are disabled indices on the row, it will not loop correctly