### PR TITLE
Floating UI v1

### DIFF
--- a/packages/core/src/middleware/arrow.ts
+++ b/packages/core/src/middleware/arrow.ts
@@ -79,12 +79,14 @@ export const arrow = (options: Options): Middleware => ({
     const offset = within(min, center, max);
 
     // Make sure that arrow points at the reference
-    const alignmentPadding = alignment === 'start' ? paddingObject[minProp] : paddingObject[maxProp];
-    const shouldAddOffset = alignmentPadding > 0
-      && center !== offset
-      && rects.reference[length] <= rects.floating[length];
-    const alignmentOffset = shouldAddOffset ?
-      center < min
+    const alignmentPadding =
+      alignment === 'start' ? paddingObject[minProp] : paddingObject[maxProp];
+    const shouldAddOffset =
+      alignmentPadding > 0 &&
+      center !== offset &&
+      rects.reference[length] <= rects.floating[length];
+    const alignmentOffset = shouldAddOffset
+      ? center < min
         ? min - center
         : max - center
       : 0;

--- a/packages/core/src/middleware/shift.ts
+++ b/packages/core/src/middleware/shift.ts
@@ -1,10 +1,4 @@
-import type {
-  Middleware,
-  Rect,
-  Placement,
-  MiddlewareArguments,
-  Coords,
-} from '../types';
+import type {Middleware, MiddlewareArguments, Coords} from '../types';
 import {getSide} from '../utils/getSide';
 import {getMainAxisFromPlacement} from '../utils/getMainAxisFromPlacement';
 import {getCrossAxis} from '../utils/getCrossAxis';
@@ -100,7 +94,7 @@ export const shift = (
 });
 
 type LimitShiftOffset =
-  | ((args: {placement: Placement; floating: Rect; reference: Rect}) =>
+  | ((args: MiddlewareArguments) =>
       | number
       | {
           /**
@@ -173,7 +167,7 @@ export const limitShift = (
     let crossAxisCoord = coords[crossAxis];
 
     const rawOffset =
-      typeof offset === 'function' ? offset({...rects, placement}) : offset;
+      typeof offset === 'function' ? offset(middlewareArguments) : offset;
     const computedOffset =
       typeof rawOffset === 'number'
         ? {mainAxis: rawOffset, crossAxis: 0}

--- a/packages/core/src/middleware/size.ts
+++ b/packages/core/src/middleware/size.ts
@@ -18,7 +18,7 @@ export interface Options {
       availableWidth: number;
       availableHeight: number;
     }
-  ): void;
+  ): void | Promise<void>;
 }
 
 /**
@@ -34,7 +34,7 @@ export const size = (
   options,
   async fn(middlewareArguments) {
     const {placement, rects, platform, elements} = middlewareArguments;
-    const {apply, ...detectOverflowOptions} = options;
+    const {apply = () => {}, ...detectOverflowOptions} = options;
 
     const overflow = await detectOverflow(
       middlewareArguments,
@@ -82,18 +82,13 @@ export const size = (
           : overflow[widthSide]),
     };
 
-    const prevDimensions = await platform.getDimensions(elements.floating);
-
-    apply?.({
-      ...middlewareArguments,
-      ...dimensions,
-    });
+    await apply({...middlewareArguments, ...dimensions});
 
     const nextDimensions = await platform.getDimensions(elements.floating);
 
     if (
-      prevDimensions.width !== nextDimensions.width ||
-      prevDimensions.height !== nextDimensions.height
+      rects.floating.width !== nextDimensions.width ||
+      rects.floating.height !== nextDimensions.height
     ) {
       return {
         reset: {

--- a/packages/dom/test/visual/spec/Shift.tsx
+++ b/packages/dom/test/visual/spec/Shift.tsx
@@ -21,9 +21,9 @@ const LIMIT_SHIFT_OFFSET: Array<{
   {offset: -50, name: '-50'},
   {offset: {mainAxis: 50}, name: 'mA: 50'},
   {offset: {crossAxis: 50}, name: 'cA: 50'},
-  {offset: ({reference}) => reference.width / 2, name: 'fn => r.width/2'},
+  {offset: ({rects}) => rects.reference.width / 2, name: 'fn => r.width/2'},
   {
-    offset: ({reference}) => ({crossAxis: reference.width}),
+    offset: ({rects}) => ({crossAxis: rects.reference.width}),
     name: 'fn => cA: f.width/2',
   },
 ];

--- a/packages/react-dom-interactions/package.json
+++ b/packages/react-dom-interactions/package.json
@@ -12,16 +12,16 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "./dist/floating-ui.react-dom-interactions.js",
+  "main": "./dist/floating-ui.react-dom-interactions.umd.js",
   "module": "./dist/floating-ui.react-dom-interactions.esm.js",
-  "unpkg": "./dist/floating-ui.react-dom-interactions.min.js",
+  "unpkg": "./dist/floating-ui.react-dom-interactions.umd.min.js",
   "types": "./index.d.ts",
   "exports": {
     ".": {
       "types": "./index.d.ts",
       "module": "./dist/floating-ui.react-dom-interactions.esm.js",
       "import": "./dist/floating-ui.react-dom-interactions.mjs",
-      "default": "./dist/floating-ui.react-dom-interactions.js"
+      "default": "./dist/floating-ui.react-dom-interactions.umd.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/react-dom-interactions/package.json
+++ b/packages/react-dom-interactions/package.json
@@ -62,8 +62,7 @@
   },
   "dependencies": {
     "@floating-ui/react-dom": "^0.6.1",
-    "aria-hidden": "^1.1.3",
-    "use-isomorphic-layout-effect": "^1.1.1"
+    "aria-hidden": "^1.1.3"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.4",
@@ -88,6 +87,7 @@
     "react-router-dom": "^6.3.0",
     "rollup": "^2.60.1",
     "rollup-plugin-terser": "^7.0.2",
-    "ts-jest": "^27.0.7"
+    "ts-jest": "^27.0.7",
+    "use-isomorphic-layout-effect": "^1.1.1"
   }
 }

--- a/packages/react-dom-interactions/rollup.config.js
+++ b/packages/react-dom-interactions/rollup.config.js
@@ -32,7 +32,10 @@ const bundles = [
     input,
     output: {
       name: 'FloatingUIReactDOM',
-      file: path.join(__dirname, 'dist/floating-ui.react-dom-interactions.js'),
+      file: path.join(
+        __dirname,
+        'dist/floating-ui.react-dom-interactions.umd.js'
+      ),
       format: 'umd',
       globals: {
         react: 'React',
@@ -50,7 +53,7 @@ const bundles = [
       name: 'FloatingUIReactDOM',
       file: path.join(
         __dirname,
-        'dist/floating-ui.react-dom-interactions.min.js'
+        'dist/floating-ui.react-dom-interactions.umd.min.js'
       ),
       format: 'umd',
       globals: {

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -60,8 +60,7 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
-    "@floating-ui/dom": "^0.4.2",
-    "use-isomorphic-layout-effect": "^1.1.1"
+    "@floating-ui/dom": "^0.4.2"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.4",
@@ -80,6 +79,7 @@
     "react-dom": "^18.0.0",
     "rollup": "^2.60.1",
     "rollup-plugin-terser": "^7.0.2",
-    "ts-jest": "^27.0.7"
+    "ts-jest": "^27.0.7",
+    "use-isomorphic-layout-effect": "^1.1.1"
   }
 }

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -12,16 +12,16 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "./dist/floating-ui.react-dom.js",
+  "main": "./dist/floating-ui.react-dom.umd.js",
   "module": "./dist/floating-ui.react-dom.esm.js",
-  "unpkg": "./dist/floating-ui.react-dom.min.js",
+  "unpkg": "./dist/floating-ui.react-dom.umd.min.js",
   "types": "./index.d.ts",
   "exports": {
     ".": {
       "types": "./index.d.ts",
       "module": "./dist/floating-ui.react-dom.esm.js",
       "import": "./dist/floating-ui.react-dom.mjs",
-      "default": "./dist/floating-ui.react-dom.js"
+      "default": "./dist/floating-ui.react-dom.umd.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/react-dom/rollup.config.js
+++ b/packages/react-dom/rollup.config.js
@@ -26,7 +26,7 @@ const bundles = [
     input,
     output: {
       name: 'FloatingUIReactDOM',
-      file: path.join(__dirname, 'dist/floating-ui.react-dom.js'),
+      file: path.join(__dirname, 'dist/floating-ui.react-dom.umd.js'),
       format: 'umd',
       globals: {
         react: 'React',
@@ -40,7 +40,7 @@ const bundles = [
     input,
     output: {
       name: 'FloatingUIReactDOM',
-      file: path.join(__dirname, 'dist/floating-ui.react-dom.min.js'),
+      file: path.join(__dirname, 'dist/floating-ui.react-dom.umd.min.js'),
       format: 'umd',
       globals: {
         react: 'React',

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -33,6 +33,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
     middlewareData: {},
   });
 
+  const dataRef = useLatestRef(data);
   const [latestMiddleware, setLatestMiddleware] = React.useState(middleware);
 
   if (
@@ -53,14 +54,14 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       middleware: latestMiddleware,
       placement,
       strategy,
-    }).then((data) => {
-      if (isMountedRef.current) {
+    }).then((latestData) => {
+      if (isMountedRef.current && !deepEqual(dataRef.current, latestData)) {
         ReactDOM.flushSync(() => {
-          setData(data);
+          setData(latestData);
         });
       }
     });
-  }, [latestMiddleware, placement, strategy]);
+  }, [dataRef, latestMiddleware, placement, strategy]);
 
   useLayoutEffect(() => {
     // Skip first update

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -87,8 +87,8 @@ export const useFloating = ({
 
   if (
     !deepEqual(
-      latestMiddleware?.map(({options}) => options),
-      middleware?.map(({options}) => options)
+      latestMiddleware?.map(({name, options}) => ({name, options})),
+      middleware?.map(({name, options}) => ({name, options}))
     )
   ) {
     setLatestMiddleware(middleware);


### PR DESCRIPTION
Closes #1538

This will bump the following packages to v1:

- `core`
- `dom`
- `react-dom`

Following will remain v0 (but will use these packages):

- `react-native`
- `react-dom-interactions`

## Non-breaking

- [Core] `arrow.ts` file just didn't have Prettier applied properly
- [Core] `size()` `apply` has `await` before it (closes #1766)
- [React DOM] allow unstable inline ref callbacks (found a solution to this)
- [React] Add `name` check for middleware comparisons
- [React] Remove `use-isomorphic-layout-effect` from installed deps (as it's bundled in and tiny, anyway)

## Breaking

- [Core] `limitShift()` `offset` option gets passed `MiddlewareArguments` signature to be consistent with other APIs
- [React] Add `.umd` to UMD package files
