### PR TITLE
fix(useDismiss): return focus to reference on outside pointerdown for nested elements

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -51,7 +51,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
           return;
         }
 
-        events.emit('dismiss', true);
+        events.emit('dismiss', {preventScroll: false});
         onOpenChangeRef.current(false);
       }
     }
@@ -79,7 +79,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
         return;
       }
 
-      events.emit('dismiss', nested);
+      events.emit('dismiss', nested ? {preventScroll: true} : false);
       onOpenChangeRef.current(false);
     }
 

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -2,7 +2,6 @@ import {getOverflowAncestors} from '@floating-ui/react-dom';
 import * as React from 'react';
 import {useFloatingParentNodeId, useFloatingTree} from '../FloatingTree';
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
-import {activeElement} from '../utils/activeElement';
 import {getChildren} from '../utils/getChildren';
 import {getDocument} from '../utils/getDocument';
 import {isElement} from '../utils/is';
@@ -37,12 +36,6 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
   const onOpenChangeRef = useLatestRef(onOpenChange);
   const nested = useFloatingParentNodeId() != null;
 
-  const isFocusInsideFloating = React.useCallback(() => {
-    return refs.floating.current?.contains(
-      activeElement(getDocument(refs.floating.current))
-    );
-  }, [refs]);
-
   React.useEffect(() => {
     if (!open || !enabled) {
       return;
@@ -50,7 +43,11 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
 
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
-        if (!bubbles && !isFocusInsideFloating()) {
+        if (
+          !bubbles &&
+          tree &&
+          getChildren(tree.nodesRef.current, nodeId).length > 0
+        ) {
           return;
         }
 
@@ -74,7 +71,11 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
         return;
       }
 
-      if (!bubbles && !isFocusInsideFloating()) {
+      if (
+        !bubbles &&
+        tree &&
+        getChildren(tree.nodesRef.current, nodeId).length > 0
+      ) {
         return;
       }
 
@@ -129,7 +130,6 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     ancestorScroll,
     enabled,
     bubbles,
-    isFocusInsideFloating,
     refs,
     nested,
   ]);

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -1,6 +1,6 @@
 import {getOverflowAncestors} from '@floating-ui/react-dom';
 import * as React from 'react';
-import {useFloatingTree} from '../FloatingTree';
+import {useFloatingParentNodeId, useFloatingTree} from '../FloatingTree';
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import {activeElement} from '../utils/activeElement';
 import {getChildren} from '../utils/getChildren';
@@ -35,6 +35,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
 ): ElementProps => {
   const tree = useFloatingTree();
   const onOpenChangeRef = useLatestRef(onOpenChange);
+  const nested = useFloatingParentNodeId() != null;
 
   const isFocusInsideFloating = React.useCallback(() => {
     return refs.floating.current?.contains(
@@ -77,7 +78,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
         return;
       }
 
-      events.emit('dismiss');
+      events.emit('dismiss', nested);
       onOpenChangeRef.current(false);
     }
 
@@ -130,6 +131,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     bubbles,
     isFocusInsideFloating,
     refs,
+    nested,
   ]);
 
   if (!enabled) {


### PR DESCRIPTION
Closes #1795 

The scrolling after focus problem isn't an issue for nested floating elements 