### PR TITLE
docs: switch cdns to jsdelivr

### DIFF
--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -83,18 +83,14 @@ Floating UI can be loaded via CDN using ESM or UMD format.
 ### ESM
 
 ```js
-// development
-import {computePosition} from 'https://cdn.skypack.dev/@floating-ui/dom@__DOM_VERSION__';
-
-// production
-import {computePosition} from 'https://cdn.skypack.dev/@floating-ui/dom@__DOM_VERSION__?min';
+import {computePosition} from 'https://cdn.jsdelivr.net/npm/@floating-ui/dom@__DOM_VERSION__/+esm';
 ```
 
 ### UMD
 
 ```html
-<script src="https://unpkg.com/@floating-ui/core@__CORE_VERSION__"></script>
-<script src="https://unpkg.com/@floating-ui/dom@__DOM_VERSION__"></script>
+<script src="https://cdn.jsdelivr.net/npm/@floating-ui/core@__CORE_VERSION__"></script>
+<script src="https://cdn.jsdelivr.net/npm/@floating-ui/dom@__DOM_VERSION__"></script>
 ```
 
 All exports will be available on `window.FloatingUIDOM{:js}`.

--- a/website/pages/index.js
+++ b/website/pages/index.js
@@ -758,7 +758,7 @@ function HomePage() {
             <div className="border-gray-200 border-2 text-gray-100 rounded-lg py-8 px-12">
               <h3 className="text-2xl font-bold mb-4">CDN</h3>
               <p className="text-lg">
-                Install with the unpkg CDN.
+                Install with the jsDelivr CDN.
               </p>
               <Link href="/docs/getting-started#cdn">
                 <a


### PR DESCRIPTION
unpkg is unmaintained and [full of issues](https://github.com/mjackson/unpkg/issues). I switched the documentation over to [jsDelivr](https://www.jsdelivr.com/) since it's actively maintained and is much more reliable due to its [fallback system](https://www.jsdelivr.com/network/infographic) using multiple CDNs.

Likewise, Skypack is also [unmaintained](https://github.com/skypackjs/skypack-cdn/issues), so that was switched over to [esm.run](https://www.jsdelivr.com/esm), which is still part of the jsDelivr network.

Let me know if there are any concerns!