### PR TITLE
fix: useHover + useClick toggle behavior

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -148,6 +148,12 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       return;
     }
 
+    function isClickLikeOpenEvent() {
+      return dataRef.current.openEvent
+        ? ['click', 'mousedown'].includes(dataRef.current.openEvent.type)
+        : false;
+    }
+
     function onMouseEnter(event: MouseEvent) {
       clearTimeout(timeoutRef.current);
       blockMouseMoveRef.current = false;
@@ -174,10 +180,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     }
 
     function onMouseLeave(event: MouseEvent) {
-      if (
-        dataRef.current.openEvent?.type === 'click' ||
-        dataRef.current.openEvent?.type === 'mousedown'
-      ) {
+      if (isClickLikeOpenEvent()) {
         return;
       }
 
@@ -212,6 +215,10 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     // did not move.
     // https://github.com/floating-ui/floating-ui/discussions/1692
     function onScrollMouseLeave(event: MouseEvent) {
+      if (isClickLikeOpenEvent()) {
+        return;
+      }
+
       handleCloseRef.current?.({
         ...context,
         tree,


### PR DESCRIPTION
Using both hooks in conjunction was no longer working as described in the docs