### PR TITLE
fix(useHover): `pointer-events` clearing

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -200,6 +200,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
           x: event.clientX,
           y: event.clientY,
           onClose() {
+            clearPointerEvents();
             cleanupPointerMoveHandler();
             closeWithDelay();
           },
@@ -227,6 +228,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         y: event.clientY,
         leave: true,
         onClose() {
+          clearPointerEvents();
           cleanupPointerMoveHandler();
           closeWithDelay();
         },
@@ -263,6 +265,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     tree,
     restMs,
     cleanupPointerMoveHandler,
+    clearPointerEvents,
     refs,
   ]);
 
@@ -319,7 +322,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         clearPointerEvents();
       }
     };
-  }, [cleanupPointerMoveHandler, clearPointerEvents]);
+  }, [enabled, cleanupPointerMoveHandler, clearPointerEvents]);
 
   if (!enabled) {
     return {};

--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -73,6 +73,11 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
   const blockMouseMoveRef = React.useRef(true);
   const performedPointerEventsMutationRef = React.useRef(false);
 
+  const isHoverOpen = React.useCallback(() => {
+    const type = dataRef.current.openEvent?.type;
+    return type?.includes('mouse') && type !== 'mousedown';
+  }, [dataRef]);
+
   React.useEffect(() => {
     if (!enabled) {
       return;
@@ -96,8 +101,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     }
 
     function onLeave() {
-      const type = dataRef.current.openEvent?.type;
-      if (type?.includes('mouse') && type !== 'mousedown') {
+      if (isHoverOpen()) {
         onOpenChangeRef.current(false);
       }
     }
@@ -107,7 +111,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     return () => {
       html.removeEventListener('mouseleave', onLeave);
     };
-  }, [refs, onOpenChangeRef, enabled, handleCloseRef, dataRef]);
+  }, [refs, onOpenChangeRef, enabled, handleCloseRef, dataRef, isHoverOpen]);
 
   const closeWithDelay = React.useCallback(
     (runElseBranch = true) => {
@@ -278,7 +282,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       return;
     }
 
-    if (open && handleCloseRef.current) {
+    if (open && handleCloseRef.current && isHoverOpen()) {
       getDocument(refs.floating.current).body.style.pointerEvents = 'none';
       performedPointerEventsMutationRef.current = true;
       const reference = refs.domReference.current;
@@ -302,7 +306,16 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         };
       }
     }
-  }, [enabled, open, parentId, refs, tree, handleCloseRef, dataRef]);
+  }, [
+    enabled,
+    open,
+    parentId,
+    refs,
+    tree,
+    handleCloseRef,
+    dataRef,
+    isHoverOpen,
+  ]);
 
   useLayoutEffect(() => {
     if (previousOpen && !open) {


### PR DESCRIPTION
`pointer-events` should be cleared:

- When the cursor leaves the polygon (and floating element)
- When the `enabled` state changes

Closes #1807, #1806 

@mihkeleidast 