### PR TITLE
feat(useRole): allow `alertdialog`

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useRole.ts
+++ b/packages/react-dom-interactions/src/hooks/useRole.ts
@@ -3,7 +3,14 @@ import {useId} from './useId';
 
 export interface Props {
   enabled?: boolean;
-  role?: 'tooltip' | 'dialog' | 'menu' | 'listbox' | 'grid' | 'tree';
+  role?:
+    | 'tooltip'
+    | 'dialog'
+    | 'alertdialog'
+    | 'menu'
+    | 'listbox'
+    | 'grid'
+    | 'tree';
 }
 
 /**
@@ -34,7 +41,7 @@ export const useRole = <RT extends ReferenceType = ReferenceType>(
   return {
     reference: {
       'aria-expanded': open ? 'true' : 'false',
-      'aria-haspopup': role,
+      'aria-haspopup': role === 'alertdialog' ? 'dialog' : role,
       'aria-controls': open ? rootId : undefined,
       ...(role === 'listbox' && {
         role: 'combobox',


### PR DESCRIPTION
`aria-haspopup` doesn't include this in the types, but can be replaced by `dialog` as the popup, and the role will still be `alertdialog` on the floating element.