### PR TITLE
fix(useHover): remove open check

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -171,7 +171,6 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       blockMouseMoveRef.current = false;
 
       if (
-        open ||
         (mouseOnly && pointerTypeRef.current !== 'mouse') ||
         (restMs > 0 && getDelay(delayRef.current, 'open') === 0)
       ) {


### PR DESCRIPTION
When `move: false`, Firefox seems to have an issue on the first open for whatever reason