### PR TITLE
[dom] Do not treat elements with display: inline or display: contents as overflow ancestors

### DIFF
--- a/packages/dom/src/utils/is.ts
+++ b/packages/dom/src/utils/is.ts
@@ -36,8 +36,11 @@ export function isShadowRoot(node: Node): node is ShadowRoot {
 
 export function isOverflowElement(element: HTMLElement): boolean {
   // Firefox wants us to check `-x` and `-y` variations as well
-  const {overflow, overflowX, overflowY} = getComputedStyle(element);
-  return /auto|scroll|overlay|hidden/.test(overflow + overflowY + overflowX);
+  const {overflow, overflowX, overflowY, display} = getComputedStyle(element);
+  return (
+    /auto|scroll|overlay|hidden/.test(overflow + overflowY + overflowX) &&
+    !['inline', 'contents'].includes(display)
+  );
 }
 
 export function isTableElement(element: Element): boolean {

--- a/packages/dom/test/unit/getOverflowAncestors.test.ts
+++ b/packages/dom/test/unit/getOverflowAncestors.test.ts
@@ -16,3 +16,52 @@ test('returns all overflow ancestors', () => {
     window,
   ]);
 });
+
+test('does not treat display: inline elements as overflow ancestors', () => {
+  const overflowScroll = document.createElement('div');
+  overflowScroll.style.overflow = 'scroll';
+  overflowScroll.style.display = 'inline';
+  const overflowHidden = document.createElement('div');
+  overflowHidden.style.overflow = 'hidden';
+  overflowHidden.style.display = 'inline';
+  const test = document.createElement('div');
+
+  overflowScroll.append(overflowHidden);
+  overflowHidden.append(test);
+
+  expect(getOverflowAncestors(test)).toEqual([window]);
+});
+
+test('does not treat display: contents elements as overflow ancestors', () => {
+  const overflowScroll = document.createElement('div');
+  overflowScroll.style.overflow = 'scroll';
+  overflowScroll.style.display = 'contents';
+  const overflowHidden = document.createElement('div');
+  overflowHidden.style.overflow = 'hidden';
+  overflowHidden.style.display = 'contents';
+  const test = document.createElement('div');
+
+  overflowScroll.append(overflowHidden);
+  overflowHidden.append(test);
+
+  expect(getOverflowAncestors(test)).toEqual([window]);
+});
+
+test('does treat display: inline-block elements as overflow ancestors', () => {
+  const overflowScroll = document.createElement('div');
+  overflowScroll.style.overflow = 'scroll';
+  overflowScroll.style.display = 'inline-block';
+  const overflowHidden = document.createElement('div');
+  overflowHidden.style.overflow = 'hidden';
+  overflowHidden.style.display = 'inline-block';
+  const test = document.createElement('div');
+
+  overflowScroll.append(overflowHidden);
+  overflowHidden.append(test);
+
+  expect(getOverflowAncestors(test)).toEqual([
+    overflowHidden,
+    overflowScroll,
+    window,
+  ]);
+});


### PR DESCRIPTION
Fixes #1831 