### PR TITLE
refactor: `useEvent` hook

### DIFF
--- a/packages/react-dom-interactions/src/FloatingDelayGroup.tsx
+++ b/packages/react-dom-interactions/src/FloatingDelayGroup.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {getDelay} from './hooks/useHover';
 import type {FloatingContext} from './types';
-import {useLatestRef} from './utils/useLatestRef';
 
 type Delay = number | Partial<{open: number; close: number}>;
 
@@ -75,25 +74,24 @@ export const useDelayGroup = (
   {id}: UseGroupOptions
 ) => {
   const {currentId, initialDelay, setState} = useDelayGroupContext();
-  const onOpenChangeRef = useLatestRef(onOpenChange);
 
   React.useEffect(() => {
-    if (currentId && onOpenChangeRef.current) {
+    if (currentId) {
       setState((state) => ({
         ...state,
         delay: {open: 1, close: getDelay(initialDelay, 'close')},
       }));
 
       if (currentId !== id) {
-        onOpenChangeRef.current(false);
+        onOpenChange(false);
       }
     }
-  }, [id, onOpenChangeRef, setState, currentId, initialDelay]);
+  }, [id, onOpenChange, setState, currentId, initialDelay]);
 
   React.useEffect(() => {
-    if (!open && currentId === id && onOpenChangeRef.current) {
-      onOpenChangeRef.current(false);
+    if (!open && currentId === id) {
+      onOpenChange(false);
       setState((state) => ({...state, delay: initialDelay, currentId: null}));
     }
-  }, [open, setState, currentId, id, onOpenChangeRef, initialDelay]);
+  }, [open, setState, currentId, id, onOpenChange, initialDelay]);
 };

--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -69,7 +69,6 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
   modal = true,
 }: Props<RT>): JSX.Element {
   const orderRef = useLatestRef(order);
-  const onOpenChangeRef = useLatestRef(onOpenChange);
   const tree = useFloatingTree();
 
   const root =
@@ -191,7 +190,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
         !isChildOpen &&
         !isParentRelated
       ) {
-        onOpenChangeRef.current(false);
+        onOpenChange(false);
       }
     }
 
@@ -221,7 +220,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     nodeId,
     tree,
     modal,
-    onOpenChangeRef,
+    onOpenChange,
     orderRef,
     dataRef,
     getTabbableElements,

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -6,7 +6,6 @@ import {getChildren} from '../utils/getChildren';
 import {getDocument} from '../utils/getDocument';
 import {isElement} from '../utils/is';
 import {isEventTargetWithin} from '../utils/isEventTargetWithin';
-import {useLatestRef} from '../utils/useLatestRef';
 
 export interface Props {
   enabled?: boolean;
@@ -33,7 +32,6 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
   }: Props = {}
 ): ElementProps => {
   const tree = useFloatingTree();
-  const onOpenChangeRef = useLatestRef(onOpenChange);
   const nested = useFloatingParentNodeId() != null;
 
   React.useEffect(() => {
@@ -52,7 +50,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
         }
 
         events.emit('dismiss', {preventScroll: false});
-        onOpenChangeRef.current(false);
+        onOpenChange(false);
       }
     }
 
@@ -111,11 +109,11 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
       }
 
       events.emit('dismiss', nested ? {preventScroll: true} : false);
-      onOpenChangeRef.current(false);
+      onOpenChange(false);
     }
 
     function onScroll() {
-      onOpenChangeRef.current(false);
+      onOpenChange(false);
     }
 
     const doc = getDocument(refs.floating.current);
@@ -157,7 +155,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     tree,
     nodeId,
     open,
-    onOpenChangeRef,
+    onOpenChange,
     ancestorScroll,
     enabled,
     bubbles,

--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -64,7 +64,6 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
 
   const tree = useFloatingTree<RT>();
   const parentId = useFloatingParentNodeId();
-  const onOpenChangeRef = useLatestRef(onOpenChange);
   const handleCloseRef = useLatestRef(handleClose);
   const delayRef = useLatestRef(delay);
   const previousOpen = usePrevious(open);
@@ -105,7 +104,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
 
     function onLeave() {
       if (isHoverOpen()) {
-        onOpenChangeRef.current(false);
+        onOpenChange(false);
       }
     }
 
@@ -114,7 +113,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     return () => {
       html.removeEventListener('mouseleave', onLeave);
     };
-  }, [refs, onOpenChangeRef, enabled, handleCloseRef, dataRef, isHoverOpen]);
+  }, [refs, onOpenChange, enabled, handleCloseRef, dataRef, isHoverOpen]);
 
   const closeWithDelay = React.useCallback(
     (runElseBranch = true) => {
@@ -125,16 +124,13 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       );
       if (closeDelay && !handlerRef.current) {
         clearTimeout(timeoutRef.current);
-        timeoutRef.current = setTimeout(
-          () => onOpenChangeRef.current(false),
-          closeDelay
-        );
+        timeoutRef.current = setTimeout(() => onOpenChange(false), closeDelay);
       } else if (runElseBranch) {
         clearTimeout(timeoutRef.current);
-        onOpenChangeRef.current(false);
+        onOpenChange(false);
       }
     },
-    [delayRef, onOpenChangeRef]
+    [delayRef, onOpenChange]
   );
 
   const cleanupPointerMoveHandler = React.useCallback(() => {
@@ -187,10 +183,10 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
 
       if (openDelay) {
         timeoutRef.current = setTimeout(() => {
-          onOpenChangeRef.current(true);
+          onOpenChange(true);
         }, openDelay);
       } else {
-        onOpenChangeRef.current(true);
+        onOpenChange(true);
       }
     }
 
@@ -276,13 +272,13 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     closeWithDelay,
     cleanupPointerMoveHandler,
     clearPointerEvents,
+    onOpenChange,
     open,
     tree,
     refs,
     delayRef,
     handleCloseRef,
     dataRef,
-    onOpenChangeRef,
   ]);
 
   // Block pointer-events of every element other than the reference and floating

--- a/packages/react-dom-interactions/src/useFloating.ts
+++ b/packages/react-dom-interactions/src/useFloating.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {useFloating as usePositionalFloating} from '@floating-ui/react-dom';
+import {useFloating as usePosition} from '@floating-ui/react-dom';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
 import type {
   FloatingContext,
@@ -11,10 +11,11 @@ import type {
 import {createPubSub} from './createPubSub';
 import {useFloatingTree} from './FloatingTree';
 import {isElement} from './utils/is';
+import {useEvent} from './utils/useEvent';
 
 export function useFloating<RT extends ReferenceType = ReferenceType>({
   open = false,
-  onOpenChange = () => {},
+  onOpenChange: unstable_onOpenChange,
   whileElementsMounted,
   placement,
   middleware,
@@ -25,24 +26,26 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
   const domReferenceRef = React.useRef<Element | null>(null);
   const dataRef = React.useRef<ContextData>({});
   const events = React.useState(() => createPubSub())[0];
-  const floating = usePositionalFloating<RT>({
+  const position = usePosition<RT>({
     placement,
     middleware,
     strategy,
     whileElementsMounted,
   });
 
+  const onOpenChange = useEvent(unstable_onOpenChange);
+
   const refs = React.useMemo(
     () => ({
-      ...floating.refs,
+      ...position.refs,
       domReference: domReferenceRef,
     }),
-    [floating.refs]
+    [position.refs]
   );
 
   const context = React.useMemo<FloatingContext<RT>>(
     () => ({
-      ...floating,
+      ...position,
       refs,
       dataRef,
       nodeId,
@@ -50,7 +53,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       open,
       onOpenChange,
     }),
-    [floating, nodeId, events, open, onOpenChange, refs]
+    [position, nodeId, events, open, onOpenChange, refs]
   );
 
   useLayoutEffect(() => {
@@ -60,7 +63,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
     }
   });
 
-  const {reference} = floating;
+  const {reference} = position;
   const setReference: UseFloatingReturn<RT>['reference'] = React.useCallback(
     (node) => {
       if (isElement(node) || node === null) {
@@ -74,11 +77,11 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
 
   return React.useMemo(
     () => ({
-      ...floating,
+      ...position,
       context,
       refs,
       reference: setReference,
     }),
-    [floating, refs, context, setReference]
+    [position, refs, context, setReference]
   );
 }

--- a/packages/react-dom-interactions/src/utils/useEvent.ts
+++ b/packages/react-dom-interactions/src/utils/useEvent.ts
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import {useInsertionEffect as _useInsertionEffect} from 'react';
-
-const useInsertionEffect =
-  typeof _useInsertionEffect === 'function' ? _useInsertionEffect : undefined;
 
 type AnyFunction = (...args: any[]) => any;
+
+// `toString()` prevents bundlers from trying to `import { useInsertionEffect } from 'react'`
+const useInsertionEffect = (React as any)['useInsertionEffect'.toString()] as
+  | AnyFunction
+  | undefined;
 
 export function useEvent<T extends AnyFunction>(callback?: T) {
   const ref = React.useRef<AnyFunction | undefined>(() => {

--- a/packages/react-dom-interactions/src/utils/useEvent.ts
+++ b/packages/react-dom-interactions/src/utils/useEvent.ts
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import {useInsertionEffect as _useInsertionEffect} from 'react';
+
+const useInsertionEffect =
+  typeof _useInsertionEffect === 'function' ? _useInsertionEffect : undefined;
+
+type AnyFunction = (...args: any[]) => any;
+
+export function useEvent<T extends AnyFunction>(callback?: T) {
+  const ref = React.useRef<AnyFunction | undefined>(() => {
+    if (__DEV__) {
+      throw new Error('Cannot call an event handler while rendering.');
+    }
+  });
+
+  if (useInsertionEffect) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useInsertionEffect(() => {
+      ref.current = callback;
+    });
+  } else {
+    ref.current = callback;
+  }
+
+  return React.useCallback<AnyFunction>(
+    (...args) => ref.current?.(...args),
+    []
+  ) as T;
+}


### PR DESCRIPTION
Internal polyfill for proposed `useEvent` hook, adapted from Ariakit. Far nicer for functions compared to `useLatestRef`

Plus, now users can pass an unstable `onOpenChange` callback without breaking the memoization of the returned object from `useFloating()`.