### PR TITLE
fix(useTypeahead): scoping and capslock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6697,9 +6697,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.1.1.tgz",
-      "integrity": "sha512-XrjH/iEUqNl9lF2HX9YhPNV7Amntkcnpw0Bo1KkRzowNDcgSN9i0nm4Q8Oi5wupgdfPaJNMAWa61A+voD6Kmwg==",
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
       "dev": true,
       "engines": {
         "node": ">=12",
@@ -13622,7 +13622,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -14355,6 +14356,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -16665,6 +16667,7 @@
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
       "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -19158,6 +19161,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
       "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "dev": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       },
@@ -19644,8 +19648,7 @@
       "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^0.4.2",
-        "use-isomorphic-layout-effect": "^1.1.1"
+        "@floating-ui/dom": "^0.4.2"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -19664,7 +19667,8 @@
         "react-dom": "^18.0.0",
         "rollup": "^2.60.1",
         "rollup-plugin-terser": "^7.0.2",
-        "ts-jest": "^27.0.7"
+        "ts-jest": "^27.0.7",
+        "use-isomorphic-layout-effect": "^1.1.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -19677,8 +19681,7 @@
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^0.6.1",
-        "aria-hidden": "^1.1.3",
-        "use-isomorphic-layout-effect": "^1.1.1"
+        "aria-hidden": "^1.1.3"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -19691,7 +19694,7 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.1.1",
         "@testing-library/react-hooks": "^7.0.2",
-        "@testing-library/user-event": "^14.1.1",
+        "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^27.0.3",
         "@types/react": "^18.0.1",
         "babel-plugin-annotate-pure-calls": "^0.4.0",
@@ -19703,7 +19706,8 @@
         "react-router-dom": "^6.3.0",
         "rollup": "^2.60.1",
         "rollup-plugin-terser": "^7.0.2",
-        "ts-jest": "^27.0.7"
+        "ts-jest": "^27.0.7",
+        "use-isomorphic-layout-effect": "^1.1.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -21216,7 +21220,7 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.1.1",
         "@testing-library/react-hooks": "^7.0.2",
-        "@testing-library/user-event": "^14.1.1",
+        "@testing-library/user-event": "14.4.3",
         "@types/jest": "^27.0.3",
         "@types/react": "^18.0.1",
         "aria-hidden": "^1.1.3",
@@ -24597,9 +24601,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.1.1.tgz",
-      "integrity": "sha512-XrjH/iEUqNl9lF2HX9YhPNV7Amntkcnpw0Bo1KkRzowNDcgSN9i0nm4Q8Oi5wupgdfPaJNMAWa61A+voD6Kmwg==",
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
       "dev": true,
       "requires": {}
     },
@@ -29849,7 +29853,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -30427,6 +30432,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -32274,6 +32280,7 @@
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
       "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -34249,6 +34256,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
       "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "dev": true,
       "requires": {}
     },
     "use-subscription": {

--- a/packages/react-dom-interactions/package.json
+++ b/packages/react-dom-interactions/package.json
@@ -75,7 +75,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/react-hooks": "^7.0.2",
-    "@testing-library/user-event": "^14.1.1",
+    "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^27.0.3",
     "@types/react": "^18.0.1",
     "babel-plugin-annotate-pure-calls": "^0.4.0",

--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -6,6 +6,7 @@ import {activeElement} from './utils/activeElement';
 import {getAncestors} from './utils/getAncestors';
 import {getChildren} from './utils/getChildren';
 import {getDocument} from './utils/getDocument';
+import {getTarget} from './utils/getTarget';
 import {isElement, isHTMLElement} from './utils/is';
 import {isTypeableElement, TYPEABLE_SELECTOR} from './utils/isTypeableElement';
 import {stopEvent} from './utils/stopEvent';
@@ -126,13 +127,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
         }
 
         const els = getTabbableElements();
-
-        const target =
-          'composedPath' in event
-            ? event.composedPath()[0]
-            : // TS thinks `event` is of type never as it assumes all browsers
-              // support composedPath, but browsers without shadow dom don't
-              (event as Event).target;
+        const target = getTarget(event);
 
         if (
           orderRef.current[0] === 'reference' &&

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -4,6 +4,7 @@ import {useFloatingParentNodeId, useFloatingTree} from '../FloatingTree';
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import {getChildren} from '../utils/getChildren';
 import {getDocument} from '../utils/getDocument';
+import {getTarget} from '../utils/getTarget';
 import {isElement} from '../utils/is';
 import {isEventTargetWithin} from '../utils/isEventTargetWithin';
 import {useLatestRef} from '../utils/useLatestRef';
@@ -57,33 +58,29 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     }
 
     function onPointerDown(event: MouseEvent) {
-      // Check if the click occurred on the scrollbar
-      if (isElement(event.target) && refs.floating.current) {
-        const win = refs.floating.current.ownerDocument.defaultView ?? window;
-        const canScrollX = event.target.scrollWidth > event.target.clientWidth;
-        const canScrollY =
-          event.target.scrollHeight > event.target.clientHeight;
+      const target = getTarget(event);
 
-        let xCond = canScrollY && event.offsetX > event.target.clientWidth;
+      // Check if the click occurred on the scrollbar
+      if (isElement(target) && refs.floating.current) {
+        const win = refs.floating.current.ownerDocument.defaultView ?? window;
+        const canScrollX = target.scrollWidth > target.clientWidth;
+        const canScrollY = target.scrollHeight > target.clientHeight;
+
+        let xCond = canScrollY && event.offsetX > target.clientWidth;
 
         // In some browsers it is possible to change the <body> (or window)
         // scrollbar to the left side, but is very rare and is difficult to
         // check for. Plus, for modal dialogs with backdrops, it is more
         // important that the backdrop is checked but not so much the window.
         if (canScrollY) {
-          const isRTL = win.getComputedStyle(event.target).direction === 'rtl';
+          const isRTL = win.getComputedStyle(target).direction === 'rtl';
 
           if (isRTL) {
-            xCond =
-              event.offsetX <=
-              event.target.offsetWidth - event.target.clientWidth;
+            xCond = event.offsetX <= target.offsetWidth - target.clientWidth;
           }
         }
 
-        if (
-          xCond ||
-          (canScrollX && event.offsetY > event.target.clientHeight)
-        ) {
+        if (xCond || (canScrollX && event.offsetY > target.clientHeight)) {
           return;
         }
       }

--- a/packages/react-dom-interactions/src/hooks/useTypeahead.ts
+++ b/packages/react-dom-interactions/src/hooks/useTypeahead.ts
@@ -3,6 +3,7 @@ import useLayoutEffect from 'use-isomorphic-layout-effect';
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import {activeElement} from '../utils/activeElement';
 import {getDocument} from '../utils/getDocument';
+import {getTarget} from '../utils/getTarget';
 import {isElement} from '../utils/is';
 import {stopEvent} from '../utils/stopEvent';
 
@@ -69,10 +70,12 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
     // Correctly scope nested non-portalled floating elements. Since the nested
     // floating element is inside of the another, we find the closest role
     // that indicates the floating element scope.
+    const target = getTarget(event.nativeEvent);
+
     if (
-      isElement(event.target) &&
-      (activeElement(getDocument(event.target)) !== event.currentTarget
-        ? event.target.closest(
+      isElement(target) &&
+      (activeElement(getDocument(target)) !== event.currentTarget
+        ? target.closest(
             '[role="dialog"],[role="menu"],[role="listbox"],[role="tree"],[role="grid"]'
           ) !== event.currentTarget
         : false)

--- a/packages/react-dom-interactions/src/hooks/useTypeahead.ts
+++ b/packages/react-dom-interactions/src/hooks/useTypeahead.ts
@@ -66,7 +66,9 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
   }, [open, selectedIndex, activeIndex]);
 
   function onKeyDown(event: React.KeyboardEvent) {
-    // Correctly scope non-portalled floating elements
+    // Correctly scope nested non-portalled floating elements. Since the nested
+    // floating element is inside of the another, we find the closest role
+    // that indicates the floating element scope.
     if (
       isElement(event.target) &&
       (activeElement(getDocument(event.target)) !== event.currentTarget

--- a/packages/react-dom-interactions/src/hooks/useTypeahead.ts
+++ b/packages/react-dom-interactions/src/hooks/useTypeahead.ts
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
-import {activeElement} from '../utils/activeElement';
-import {getDocument} from '../utils/getDocument';
+import {isElement} from '../utils/is';
 import {stopEvent} from '../utils/stopEvent';
 
 export interface Props {
@@ -65,10 +64,12 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
   }, [open, selectedIndex, activeIndex]);
 
   function onKeyDown(event: React.KeyboardEvent) {
+    // Correctly scope non-portalled floating elements
     if (
-      !event.currentTarget.contains(
-        activeElement(getDocument(event.currentTarget as HTMLElement))
-      )
+      isElement(event.target) &&
+      event.target.closest(
+        '[role="dialog"],[role="menu"],[role="listbox"],[role="tree"],[role="grid"]'
+      ) !== event.currentTarget
     ) {
       return;
     }
@@ -129,7 +130,10 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
     const str = findMatch
       ? findMatch(orderedList, stringRef.current)
       : orderedList.find(
-          (text) => text?.toLocaleLowerCase().indexOf(stringRef.current) === 0
+          (text) =>
+            text
+              ?.toLocaleLowerCase()
+              .indexOf(stringRef.current.toLocaleLowerCase()) === 0
         );
 
     const index = str ? listContent.indexOf(str) : -1;

--- a/packages/react-dom-interactions/src/hooks/useTypeahead.ts
+++ b/packages/react-dom-interactions/src/hooks/useTypeahead.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
+import {activeElement} from '../utils/activeElement';
+import {getDocument} from '../utils/getDocument';
 import {isElement} from '../utils/is';
 import {stopEvent} from '../utils/stopEvent';
 
@@ -67,9 +69,11 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
     // Correctly scope non-portalled floating elements
     if (
       isElement(event.target) &&
-      event.target.closest(
-        '[role="dialog"],[role="menu"],[role="listbox"],[role="tree"],[role="grid"]'
-      ) !== event.currentTarget
+      (activeElement(getDocument(event.target)) !== event.currentTarget
+        ? event.target.closest(
+            '[role="dialog"],[role="menu"],[role="listbox"],[role="tree"],[role="grid"]'
+          ) !== event.currentTarget
+        : false)
     ) {
       return;
     }

--- a/packages/react-dom-interactions/src/utils/getTarget.ts
+++ b/packages/react-dom-interactions/src/utils/getTarget.ts
@@ -1,0 +1,9 @@
+export function getTarget(event: Event) {
+  if ('composedPath' in event) {
+    return event.composedPath()[0];
+  }
+
+  // TS thinks `event` is of type never as it assumes all browsers support
+  // `composedPath()`, but browsers without shadow DOM don't.
+  return (event as Event).target;
+}

--- a/packages/react-dom-interactions/test/unit/useTypeahead.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useTypeahead.test.tsx
@@ -5,6 +5,7 @@ import {useTypeahead, useFloating, useInteractions} from '../../src';
 import type {Props} from '../../src/hooks/useTypeahead';
 
 jest.useFakeTimers();
+const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
 
 function App(props: Pick<Props, 'onMatch'> & {list?: Array<string>}) {
   const [open, setOpen] = useState(true);
@@ -40,13 +41,13 @@ test('rapidly focuses list items when they start with the same letter', async ()
   const input = screen.getByRole('combobox');
   input.focus();
 
-  await userEvent.keyboard('t');
+  await user.keyboard('t');
   expect(spy).toHaveBeenCalledWith(1);
 
-  await userEvent.keyboard('t');
+  await user.keyboard('t');
   expect(spy).toHaveBeenCalledWith(2);
 
-  await userEvent.keyboard('t');
+  await user.keyboard('t');
   expect(spy).toHaveBeenCalledWith(1);
 
   cleanup();
@@ -59,10 +60,10 @@ test('bails out of rapid focus of first letter if the list contains a string tha
   const input = screen.getByRole('combobox');
   input.focus();
 
-  await userEvent.keyboard('a');
+  await user.keyboard('a');
   expect(spy).toHaveBeenCalledWith(0);
 
-  await userEvent.keyboard('a');
+  await user.keyboard('a');
   expect(spy).toHaveBeenCalledWith(0);
 
   cleanup();
@@ -77,38 +78,51 @@ test('starts from the current activeIndex and correctly loops', async () => {
   const input = screen.getByRole('combobox');
   input.focus();
 
-  await userEvent.keyboard('t');
-  await userEvent.keyboard('o');
-  await userEvent.keyboard('y');
+  await user.keyboard('t');
+  await user.keyboard('o');
+  await user.keyboard('y');
   expect(spy).toHaveBeenCalledWith(0);
 
   spy.mockReset();
 
-  await userEvent.keyboard('t');
-  await userEvent.keyboard('o');
-  await userEvent.keyboard('y');
+  await user.keyboard('t');
+  await user.keyboard('o');
+  await user.keyboard('y');
   expect(spy).not.toHaveBeenCalled();
 
   jest.advanceTimersByTime(1000);
 
-  await userEvent.keyboard('t');
-  await userEvent.keyboard('o');
-  await userEvent.keyboard('y');
+  await user.keyboard('t');
+  await user.keyboard('o');
+  await user.keyboard('y');
   expect(spy).toHaveBeenCalledWith(1);
 
   jest.advanceTimersByTime(1000);
 
-  await userEvent.keyboard('t');
-  await userEvent.keyboard('o');
-  await userEvent.keyboard('y');
+  await user.keyboard('t');
+  await user.keyboard('o');
+  await user.keyboard('y');
   expect(spy).toHaveBeenCalledWith(2);
 
   jest.advanceTimersByTime(1000);
 
-  await userEvent.keyboard('t');
-  await userEvent.keyboard('o');
-  await userEvent.keyboard('y');
+  await user.keyboard('t');
+  await user.keyboard('o');
+  await user.keyboard('y');
   expect(spy).toHaveBeenCalledWith(0);
+
+  cleanup();
+});
+
+test('capslock characters continue to match', async () => {
+  const spy = jest.fn();
+  render(<App onMatch={spy} />);
+
+  const input = screen.getByRole('combobox');
+  input.focus();
+
+  await user.keyboard('{CapsLock}t');
+  expect(spy).toHaveBeenCalledWith(1);
 
   cleanup();
 });


### PR DESCRIPTION
- If the capslock key is on, the default `findMatch` did not match correctly.
- If a nested floating element is not portalled, but focus is inside the nested floating element, it can still match parent items. This uses the `role` in order to scope, maybe there is a better way