### PR TITLE
fix(useHover): allow conditionally rendered reference element

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -60,7 +60,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     move = true,
   }: Props<RT> = {}
 ): ElementProps => {
-  const {open, onOpenChange, dataRef, events, refs} = context;
+  const {open, onOpenChange, dataRef, events, refs, _} = context;
 
   const tree = useFloatingTree<RT>();
   const parentId = useFloatingParentNodeId();
@@ -268,6 +268,9 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       };
     }
   }, [
+    // Ensure the effect is re-run when the reference changes.
+    // https://github.com/floating-ui/floating-ui/issues/1833
+    _.domReference,
     enabled,
     context,
     mouseOnly,

--- a/packages/react-dom-interactions/src/types.ts
+++ b/packages/react-dom-interactions/src/types.ts
@@ -39,6 +39,9 @@ export interface FloatingContext<RT extends ReferenceType = ReferenceType>
   dataRef: React.MutableRefObject<ContextData>;
   nodeId: string | undefined;
   refs: ExtendedRefs<RT>;
+  _: {
+    domReference: Element | null;
+  };
 }
 
 export interface FloatingNodeType<RT extends ReferenceType = ReferenceType> {

--- a/packages/react-dom-interactions/src/useFloating.ts
+++ b/packages/react-dom-interactions/src/useFloating.ts
@@ -21,6 +21,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
   strategy,
   nodeId,
 }: Partial<UseFloatingProps> = {}): UseFloatingReturn<RT> {
+  const [domReference, setDomReference] = React.useState<Element | null>(null);
   const tree = useFloatingTree<RT>();
   const domReferenceRef = React.useRef<Element | null>(null);
   const dataRef = React.useRef<ContextData>({});
@@ -49,8 +50,9 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       events,
       open,
       onOpenChange,
+      _: {domReference},
     }),
-    [floating, nodeId, events, open, onOpenChange, refs]
+    [floating, nodeId, events, open, onOpenChange, refs, domReference]
   );
 
   useLayoutEffect(() => {
@@ -65,6 +67,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
     (node) => {
       if (isElement(node) || node === null) {
         context.refs.domReference.current = node;
+        setDomReference(node);
       }
 
       reference(node);

--- a/packages/react-dom-interactions/test/unit/useHover.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useHover.test.tsx
@@ -163,4 +163,6 @@ test('continues working after reference is conditionally rendered', () => {
   fireEvent.mouseEnter(screen.getByRole('button'));
 
   expect(screen.queryByRole('tooltip')).toBeInTheDocument();
+
+  cleanup();
 });

--- a/packages/react-dom-interactions/test/unit/useHover.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useHover.test.tsx
@@ -5,7 +5,10 @@ import type {Props} from '../../src/hooks/useHover';
 
 jest.useFakeTimers();
 
-function App(props: Props) {
+function App({
+  showReference = true,
+  ...props
+}: Props & {showReference?: boolean}) {
   const [open, setOpen] = useState(false);
   const {reference, floating, context} = useFloating({
     open,
@@ -17,7 +20,7 @@ function App(props: Props) {
 
   return (
     <>
-      <button {...getReferenceProps({ref: reference})} />
+      {showReference && <button {...getReferenceProps({ref: reference})} />}
       {open && <div role="tooltip" {...getFloatingProps({ref: floating})} />}
     </>
   );
@@ -151,4 +154,13 @@ test('restMs', async () => {
   expect(screen.queryByRole('tooltip')).toBeInTheDocument();
 
   cleanup();
+});
+
+test('continues working after reference is conditionally rendered', () => {
+  const {rerender} = render(<App showReference={false} />);
+  rerender(<App showReference />);
+
+  fireEvent.mouseEnter(screen.getByRole('button'));
+
+  expect(screen.queryByRole('tooltip')).toBeInTheDocument();
 });


### PR DESCRIPTION
Closes #1833. Unfortunately causes 1 more re-render due to the state change, but this effect needs to have it as a dependency. Other hooks are not affected as they use regular event handlers. It is just placed under a private `_` variable in the context