### PR TITLE
feat(safePolygon): add `blockPointerEvents` option

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -12,6 +12,19 @@ import {isElement} from '../utils/is';
 import {useLatestRef} from '../utils/useLatestRef';
 import {usePrevious} from '../utils/usePrevious';
 
+interface HandleCloseFn<RT extends ReferenceType = ReferenceType> {
+  (
+    context: FloatingContext<RT> & {
+      onClose: () => void;
+      tree?: FloatingTreeType<RT> | null;
+      leave?: boolean;
+    }
+  ): (event: PointerEvent) => void;
+  __options: {
+    blockPointerEvents: boolean;
+  };
+}
+
 export function getDelay(
   value: Props['delay'],
   prop: 'open' | 'close',
@@ -30,15 +43,7 @@ export function getDelay(
 
 export interface Props<RT extends ReferenceType = ReferenceType> {
   enabled?: boolean;
-  handleClose?:
-    | null
-    | ((
-        context: FloatingContext<RT> & {
-          onClose: () => void;
-          tree?: FloatingTreeType<RT> | null;
-          leave?: boolean;
-        }
-      ) => (event: PointerEvent) => void);
+  handleClose?: HandleCloseFn<RT> | null;
   restMs?: number;
   delay?: number | Partial<{open: number; close: number}>;
   mouseOnly?: boolean;
@@ -294,7 +299,12 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       return;
     }
 
-    if (open && handleCloseRef.current && isHoverOpen()) {
+    if (
+      open &&
+      handleCloseRef.current &&
+      handleCloseRef.current.__options.blockPointerEvents &&
+      isHoverOpen()
+    ) {
       getDocument(refs.floating.current).body.style.pointerEvents = 'none';
       performedPointerEventsMutationRef.current = true;
       const reference = refs.domReference.current;

--- a/packages/react-dom-interactions/src/safePolygon.ts
+++ b/packages/react-dom-interactions/src/safePolygon.ts
@@ -24,16 +24,18 @@ function isPointInPolygon(point: Point, polygon: Polygon) {
 export function safePolygon<RT extends ReferenceType = ReferenceType>({
   restMs = 0,
   buffer = 0.5,
+  blockPointerEvents = true,
   debug = null,
 }: Partial<{
   restMs: number;
   buffer: number;
+  blockPointerEvents: boolean;
   debug: null | ((points?: string | null) => void);
 }> = {}) {
   let timeoutId: NodeJS.Timeout;
   let polygonIsDestroyed = false;
 
-  return ({
+  const fn = ({
     x,
     y,
     placement,
@@ -345,4 +347,10 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
       }
     };
   };
+
+  fn.__options = {
+    blockPointerEvents,
+  };
+
+  return fn;
 }


### PR DESCRIPTION
Since #1811 is stalled, and maybe doesn't have a good fix, this option is much cleaner for disabling the `pointer-events` blocking behavior without needing the useLayoutEffect workaround. 