### PR TITLE
fix(useInteractions): props starting with `on`

### DIFF
--- a/packages/react-dom-interactions/src/useInteractions.ts
+++ b/packages/react-dom-interactions/src/useInteractions.ts
@@ -27,11 +27,11 @@ function mergeProps(
 
             if (typeof value === 'function') {
               map.get(key)?.push(value);
-            }
 
-            acc[key] = (...args: unknown[]) => {
-              map.get(key)?.forEach((fn) => fn(...args));
-            };
+              acc[key] = (...args: unknown[]) => {
+                map.get(key)?.forEach((fn) => fn(...args));
+              };
+            }
           } else {
             acc[key] = value;
           }

--- a/packages/react-dom-interactions/test/unit/useInteractions.test.ts
+++ b/packages/react-dom-interactions/test/unit/useInteractions.test.ts
@@ -47,3 +47,14 @@ test('does not error with undefined user supplied functions', () => {
     getReferenceProps({onClick: undefined}).onClick()
   ).not.toThrowError();
 });
+
+test('does not break props that start with `on`', () => {
+  const {getReferenceProps} = useInteractions([]);
+
+  const props = getReferenceProps({
+    // @ts-expect-error
+    onlyShowVotes: true,
+  });
+
+  expect(typeof props.onlyShowVotes).toBe('boolean');
+});

--- a/packages/react-dom-interactions/test/unit/useInteractions.test.ts
+++ b/packages/react-dom-interactions/test/unit/useInteractions.test.ts
@@ -54,7 +54,9 @@ test('does not break props that start with `on`', () => {
   const props = getReferenceProps({
     // @ts-expect-error
     onlyShowVotes: true,
+    onyx: () => {},
   });
 
-  expect(typeof props.onlyShowVotes).toBe('boolean');
+  expect(props.onlyShowVotes).toBe(true);
+  expect(typeof props.onyx).toBe('function');
 });


### PR DESCRIPTION
TS forbids passing custom props through `get{X}Props` but plain JS doesn't know this

Closes #1860