### PR TITLE
fix(useClick) ensure correct handling of events for wrapped buttons

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useClick.ts
+++ b/packages/react-dom-interactions/src/hooks/useClick.ts
@@ -2,8 +2,8 @@ import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import * as React from 'react';
 import {isTypeableElement} from '../utils/isTypeableElement';
 
-function isButtonTarget(event) {
-  return event.target && event.target.tagName === 'BUTTON';
+function isButtonTarget(event: React.KeyboardEvent<Element>) {
+  return event.target && event.target instanceof HTMLElement && event.target.tagName === 'BUTTON';
 }
 
 export interface Props {

--- a/packages/react-dom-interactions/src/hooks/useClick.ts
+++ b/packages/react-dom-interactions/src/hooks/useClick.ts
@@ -1,9 +1,10 @@
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import * as React from 'react';
 import {isTypeableElement} from '../utils/isTypeableElement';
+import {isHTMLElement} from '../utils/is';
 
 function isButtonTarget(event: React.KeyboardEvent<Element>) {
-  return event.target && event.target instanceof HTMLElement && event.target.tagName === 'BUTTON';
+  return isHTMLElement(event.target) && event.target.tagName === 'BUTTON';
 }
 
 export interface Props {

--- a/packages/react-dom-interactions/src/hooks/useClick.ts
+++ b/packages/react-dom-interactions/src/hooks/useClick.ts
@@ -2,6 +2,10 @@ import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import * as React from 'react';
 import {isTypeableElement} from '../utils/isTypeableElement';
 
+function isButtonTarget(event) {
+  return event.target && event.target.tagName === 'BUTTON';
+}
+
 export interface Props {
   enabled?: boolean;
   pointerDown?: boolean;
@@ -23,10 +27,6 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
   }: Props = {}
 ): ElementProps => {
   const pointerTypeRef = React.useRef<'mouse' | 'pen' | 'touch'>();
-
-  function isButton() {
-    return refs.domReference.current?.tagName === 'BUTTON';
-  }
 
   function isSpaceIgnored() {
     return isTypeableElement(refs.domReference.current);
@@ -99,7 +99,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
       onKeyDown(event) {
         pointerTypeRef.current = undefined;
 
-        if (isButton()) {
+        if (isButtonTarget(event)) {
           return;
         }
 
@@ -119,7 +119,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
         }
       },
       onKeyUp(event) {
-        if (isButton() || isSpaceIgnored()) {
+        if (isButtonTarget(event) || isSpaceIgnored()) {
           return;
         }
 


### PR DESCRIPTION
The current implementation of `useClick` bails on keyDown/Up handlers on button targets to avoid redundant handling of float state because pressing ENTER/SPACE on buttons trigger a click event. However, checking if the reference element is a button causes it to incorrectly bail on the wrong element type when an event is triggered by an element that is not the reference element. 

Instead, one possible solution is to check if the target that triggered the event is a button regardless of the type of the wrapping reference.

[Here](https://codesandbox.io/s/serene-noether-bqk39m?file=/src/App.tsx)'s a reproduction of the issue.