### PR TITLE
fix(limitShift): always apply offset regardless of the axis and the side

### DIFF
--- a/packages/core/src/middleware/shift.ts
+++ b/packages/core/src/middleware/shift.ts
@@ -199,12 +199,12 @@ export const limitShift = (
       const limitMin =
         rects.reference[crossAxis] -
         rects.floating[len] +
-        (isOriginSide ? middlewareData.offset?.[crossAxis] ?? 0 : 0) +
+        (middlewareData.offset?.[crossAxis] ?? 0) +
         (isOriginSide ? 0 : computedOffset.crossAxis);
       const limitMax =
         rects.reference[crossAxis] +
         rects.reference[len] +
-        (isOriginSide ? 0 : middlewareData.offset?.[crossAxis] ?? 0) -
+        (middlewareData.offset?.[crossAxis] ?? 0) -
         (isOriginSide ? computedOffset.crossAxis : 0);
 
       if (crossAxisCoord < limitMin) {

--- a/packages/core/src/middleware/shift.ts
+++ b/packages/core/src/middleware/shift.ts
@@ -178,11 +178,13 @@ export const limitShift = (
       const limitMin =
         rects.reference[mainAxis] -
         rects.floating[len] +
-        computedOffset.mainAxis;
+        computedOffset.mainAxis +
+        (middlewareData.offset?.[mainAxis] ?? 0);
       const limitMax =
         rects.reference[mainAxis] +
         rects.reference[len] -
-        computedOffset.mainAxis;
+        computedOffset.mainAxis +
+        (middlewareData.offset?.[mainAxis] ?? 0);
 
       if (mainAxisCoord < limitMin) {
         mainAxisCoord = limitMin;


### PR DESCRIPTION
Fixes #1859 

This PR changes the `limitShift` function from the `shift` middleware so that it always applies the `middlewareData.offset` when computing mix/max limits for both the main and the cross axis, regardless of the side (origin or not).

See https://github.com/floating-ui/floating-ui/issues/1859 and https://github.com/WordPress/gutenberg/pull/42950 for extra context