### PR TITLE
feat: configure events

### DIFF
--- a/packages/react-dom-interactions/package.json
+++ b/packages/react-dom-interactions/package.json
@@ -4,8 +4,8 @@
   "@rollingversions": {
     "baseVersion": [
       0,
-      1,
-      0
+      10,
+      1
     ]
   },
   "description": "Floating UI Interactions for React DOM",

--- a/packages/react-dom-interactions/src/FloatingFocusManager.tsx
+++ b/packages/react-dom-interactions/src/FloatingFocusManager.tsx
@@ -13,7 +13,7 @@ import {stopEvent} from './utils/stopEvent';
 import {useLatestRef} from './utils/useLatestRef';
 
 function focus(el: HTMLElement | undefined, preventScroll = false) {
-  // `pointerDown` clicks occur before `focus`, so the button will steal the
+  // `mousedown` clicks occur before `focus`, so the button will steal the
   // focus unless we wait a frame.
   requestAnimationFrame(() => {
     el?.focus({preventScroll});
@@ -268,8 +268,8 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
       }
     }
 
-    // Dismissing via outside `pointerdown` should always ignore `returnFocus`
-    // to prevent unwanted scrolling.
+    // Dismissing via outside press should always ignore `returnFocus` to
+    // prevent unwanted scrolling.
     function onDismiss(
       allowReturnFocus: boolean | {preventScroll: boolean} = false
     ) {

--- a/packages/react-dom-interactions/src/hooks/useClick.ts
+++ b/packages/react-dom-interactions/src/hooks/useClick.ts
@@ -9,7 +9,7 @@ function isButtonTarget(event: React.KeyboardEvent<Element>) {
 
 export interface Props {
   enabled?: boolean;
-  pointerDown?: boolean;
+  event?: 'click' | 'mousedown';
   toggle?: boolean;
   ignoreMouse?: boolean;
   keyboardHandlers?: boolean;
@@ -23,7 +23,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
   {open, onOpenChange, dataRef, refs}: FloatingContext<RT>,
   {
     enabled = true,
-    pointerDown = false,
+    event: eventOption = 'click',
     toggle = true,
     ignoreMouse = false,
     keyboardHandlers = true,
@@ -55,7 +55,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
           return;
         }
 
-        if (!pointerDown) {
+        if (eventOption === 'click') {
           return;
         }
 
@@ -75,7 +75,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
         dataRef.current.openEvent = event.nativeEvent;
       },
       onClick(event) {
-        if (pointerDown && pointerTypeRef.current) {
+        if (eventOption === 'mousedown' && pointerTypeRef.current) {
           pointerTypeRef.current = undefined;
           return;
         }

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -8,6 +8,18 @@ import {getTarget} from '../utils/getTarget';
 import {isElement} from '../utils/is';
 import {isEventTargetWithin} from '../utils/isEventTargetWithin';
 
+const bubbleHandlerKeys = {
+  pointerdown: 'onPointerDown',
+  mousedown: 'onMouseDown',
+  mouseup: 'onMouseUp',
+};
+
+const captureHandlerKeys = {
+  pointerdown: 'onPointerDownCapture',
+  mousedown: 'onMouseDownCapture',
+  mouseup: 'onMouseUpCapture',
+};
+
 export interface Props {
   enabled?: boolean;
   escapeKey?: boolean;
@@ -179,21 +191,9 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     return {};
   }
 
-  const referencePropKey = {
-    pointerdown: 'onPointerDown',
-    mousedown: 'onMouseDown',
-    mouseup: 'onMouseUp',
-  }[referencePressEvent];
-
-  const floatingPropKey = {
-    pointerdown: 'onPointerDownCapture',
-    mousedown: 'onMouseDownCapture',
-    mouseup: 'onMouseUpCapture',
-  }[outsidePressEvent];
-
   return {
     reference: {
-      [referencePropKey]: () => {
+      [bubbleHandlerKeys[referencePressEvent]]: () => {
         if (referencePress) {
           events.emit('dismiss');
           onOpenChange(false);
@@ -201,7 +201,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
       },
     },
     floating: {
-      [floatingPropKey]: () => {
+      [captureHandlerKeys[outsidePressEvent]]: () => {
         insideReactTreeRef.current = true;
       },
     },

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -11,22 +11,22 @@ import {isEventTargetWithin} from '../utils/isEventTargetWithin';
 const bubbleHandlerKeys = {
   pointerdown: 'onPointerDown',
   mousedown: 'onMouseDown',
-  mouseup: 'onMouseUp',
+  click: 'onClick',
 };
 
 const captureHandlerKeys = {
   pointerdown: 'onPointerDownCapture',
   mousedown: 'onMouseDownCapture',
-  mouseup: 'onMouseUpCapture',
+  click: 'onClickCapture',
 };
 
 export interface Props {
   enabled?: boolean;
   escapeKey?: boolean;
   referencePress?: boolean;
-  referencePressEvent?: 'pointerdown' | 'mousedown' | 'mouseup';
+  referencePressEvent?: 'pointerdown' | 'mousedown' | 'click';
   outsidePress?: boolean;
-  outsidePressEvent?: 'pointerdown' | 'mousedown' | 'mouseup';
+  outsidePressEvent?: 'pointerdown' | 'mousedown' | 'click';
   ancestorScroll?: boolean;
   bubbles?: boolean;
 }

--- a/packages/react-dom-interactions/src/hooks/useListNavigation.ts
+++ b/packages/react-dom-interactions/src/hooks/useListNavigation.ts
@@ -232,7 +232,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
       listRef: React.MutableRefObject<Array<HTMLElement | null>>,
       indexRef: React.MutableRefObject<number>
     ) => {
-      // `pointerDown` clicks occur before `focus`, so the button will steal the
+      // `mousedown` clicks occur before `focus`, so the button will steal the
       // focus unless we wait a frame.
       frameRef.current = requestAnimationFrame(() => {
         if (virtual) {

--- a/packages/react-dom-interactions/test/unit/useClick.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useClick.test.tsx
@@ -57,7 +57,7 @@ describe('default', () => {
 
 describe('`pointerDown` prop', () => {
   test('changes `open` state to `true` after click', () => {
-    render(<App pointerDown />);
+    render(<App event="mousedown" />);
     const button = screen.getByRole('button');
 
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
@@ -70,7 +70,7 @@ describe('`pointerDown` prop', () => {
   });
 
   test('changes `open` state to `false` after two clicks', () => {
-    render(<App pointerDown />);
+    render(<App event="mousedown" />);
     const button = screen.getByRole('button');
 
     fireEvent.click(button);
@@ -109,7 +109,7 @@ describe('`toggle` prop', () => {
   });
 
   test('`open` state remains `true` after two clicks (`pointerDown`)', () => {
-    render(<App toggle={false} pointerDown />);
+    render(<App toggle={false} event="mousedown" />);
     const button = screen.getByRole('button');
 
     fireEvent.click(button);

--- a/packages/react-dom-interactions/test/unit/useClick.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useClick.test.tsx
@@ -55,7 +55,7 @@ describe('default', () => {
   });
 });
 
-describe('`pointerDown` prop', () => {
+describe('mousedown `event` prop', () => {
   test('changes `open` state to `true` after click', () => {
     render(<App event="mousedown" />);
     const button = screen.getByRole('button');
@@ -108,7 +108,7 @@ describe('`toggle` prop', () => {
     cleanup();
   });
 
-  test('`open` state remains `true` after two clicks (`pointerDown`)', () => {
+  test('`open` state remains `true` after two clicks with `mousedown`', () => {
     render(<App toggle={false} event="mousedown" />);
     const button = screen.getByRole('button');
 

--- a/packages/react-dom-interactions/test/unit/useDismiss.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useDismiss.test.tsx
@@ -35,14 +35,14 @@ describe('true', () => {
     cleanup();
   });
 
-  test('dismisses with outside pointer down', async () => {
+  test('dismisses with outside pointer press', async () => {
     render(<App />);
     await userEvent.click(document.body);
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     cleanup();
   });
 
-  test('dismisses with reference pointer down', async () => {
+  test('dismisses with reference press', async () => {
     render(<App referencePress />);
     await userEvent.click(screen.getByRole('button'));
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
@@ -65,7 +65,7 @@ describe('false', () => {
     cleanup();
   });
 
-  test('dismisses with outside pointer down', async () => {
+  test('dismisses with outside press', async () => {
     render(<App outsidePress={false} />);
     await userEvent.click(document.body);
     expect(screen.queryByRole('tooltip')).toBeInTheDocument();

--- a/packages/react-dom-interactions/test/unit/useDismiss.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useDismiss.test.tsx
@@ -43,7 +43,7 @@ describe('true', () => {
   });
 
   test('dismisses with reference pointer down', async () => {
-    render(<App referencePointerDown />);
+    render(<App referencePress />);
     await userEvent.click(screen.getByRole('button'));
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     cleanup();
@@ -66,14 +66,14 @@ describe('false', () => {
   });
 
   test('dismisses with outside pointer down', async () => {
-    render(<App outsidePointerDown={false} />);
+    render(<App outsidePress={false} />);
     await userEvent.click(document.body);
     expect(screen.queryByRole('tooltip')).toBeInTheDocument();
     cleanup();
   });
 
   test('dismisses with reference pointer down', async () => {
-    render(<App referencePointerDown={false} />);
+    render(<App referencePress={false} />);
     await userEvent.click(screen.getByRole('button'));
     expect(screen.queryByRole('tooltip')).toBeInTheDocument();
     cleanup();

--- a/packages/react-dom-interactions/test/unit/useFocus.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useFocus.test.tsx
@@ -19,7 +19,7 @@ function App(props: Props & {dismiss?: boolean; hover?: boolean}) {
   });
   const {getReferenceProps, getFloatingProps} = useInteractions([
     useFocus(context, props),
-    useDismiss(context, {enabled: !!props.dismiss, referencePointerDown: true}),
+    useDismiss(context, {enabled: !!props.dismiss, referencePress: true}),
     useHover(context, {enabled: !!props.hover}),
   ]);
 

--- a/packages/react-dom-interactions/test/visual/components/MacSelect.tsx
+++ b/packages/react-dom-interactions/test/visual/components/MacSelect.tsx
@@ -244,8 +244,8 @@ export function Main() {
   });
 
   const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
-    useClick(context, {pointerDown: true}),
-    useDismiss(context, {outsidePointerDown: false}),
+    useClick(context, {event: 'mousedown'}),
+    useDismiss(context, {outsidePress: false}),
     useRole(context, {role: 'listbox'}),
     useInnerOffset(context, {
       enabled: !fallback,

--- a/packages/react-dom-interactions/test/visual/components/Menu.tsx
+++ b/packages/react-dom-interactions/test/visual/components/Menu.tsx
@@ -116,11 +116,11 @@ export const MenuComponent = forwardRef<
     }),
     useClick(context, {
       toggle: !nested,
-      pointerDown: true,
+      event: 'mousedown',
       ignoreMouse: nested,
     }),
     useRole(context, {role: 'menu'}),
-    useDismiss(context),
+    useDismiss(context, {outsidePressEvent: 'mouseup'}),
     useListNavigation(context, {
       listRef: listItemsRef,
       activeIndex,

--- a/packages/react-dom-interactions/test/visual/components/Menu.tsx
+++ b/packages/react-dom-interactions/test/visual/components/Menu.tsx
@@ -120,7 +120,7 @@ export const MenuComponent = forwardRef<
       ignoreMouse: nested,
     }),
     useRole(context, {role: 'menu'}),
-    useDismiss(context, {outsidePressEvent: 'mouseup'}),
+    useDismiss(context),
     useListNavigation(context, {
       listRef: listItemsRef,
       activeIndex,


### PR DESCRIPTION
This allows the user to configure the events for `useClick` and `useDismiss` and avoids the `pointerDown` terminology

Closes #1879 

## useDismiss

- `outsidePointerDown` => `outsidePress`
- `outsidePressEvent: string`
- `referencePointerDown` => `referencePress`
- `referencePressEvent: string`

`pointerdown` (default)

When you want to dismiss on both mouse/touch **eagerly**

`mousedown`

When you want to dismiss eagerly with mouse but lazily with touch

`click`

When you want to dismiss on both mouse/touch **lazily**

## useClick

After discovering it's poor UX to use `pointerdown` instead of `mousedown` on touch devices this was changed. So now the option doesn't match what it is doing.

`pointerDown` => `event: 'click' | 'mousedown'`
