### PR TITLE
Add better cross-document support

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -127,6 +127,7 @@ export interface ElementRects {
  */
 export type VirtualElement = {
   getBoundingClientRect(): ClientRectObject;
+  ownerDocument?: Document;
   contextElement?: any;
 };
 export type ReferenceElement = any;

--- a/packages/dom/src/utils/getBoundingClientRect.ts
+++ b/packages/dom/src/utils/getBoundingClientRect.ts
@@ -27,14 +27,25 @@ export function getBoundingClientRect(
   const win = isElement(element) ? getWindow(element) : window;
   const addVisualOffsets = !isLayoutViewport() && isFixedStrategy;
 
+  const ownerDocOffset = {x: 0, y: 0};
+  if (win.frameElement) {
+    const iFrameBCR = win.frameElement.getBoundingClientRect();
+    ownerDocOffset.x = iFrameBCR.left;
+    ownerDocOffset.y = iFrameBCR.top;
+  }
+
   const x =
-    (clientRect.left +
-      (addVisualOffsets ? win.visualViewport?.offsetLeft ?? 0 : 0)) /
-    scaleX;
+    (
+      clientRect.left +
+      (addVisualOffsets ? win.visualViewport?.offsetLeft ?? 0 : 0) +
+      ownerDocOffset.x
+    ) / scaleX;
   const y =
-    (clientRect.top +
-      (addVisualOffsets ? win.visualViewport?.offsetTop ?? 0 : 0)) /
-    scaleY;
+    (
+      clientRect.top +
+      (addVisualOffsets ? win.visualViewport?.offsetTop ?? 0 : 0) +
+      ownerDocOffset.y
+    ) / scaleY;
   const width = clientRect.width / scaleX;
   const height = clientRect.height / scaleY;
 

--- a/packages/dom/src/utils/getBoundingClientRect.ts
+++ b/packages/dom/src/utils/getBoundingClientRect.ts
@@ -27,25 +27,14 @@ export function getBoundingClientRect(
   const win = isElement(element) ? getWindow(element) : window;
   const addVisualOffsets = !isLayoutViewport() && isFixedStrategy;
 
-  const ownerDocOffset = {x: 0, y: 0};
-  if (win.frameElement) {
-    const iFrameBCR = win.frameElement.getBoundingClientRect();
-    ownerDocOffset.x = iFrameBCR.left;
-    ownerDocOffset.y = iFrameBCR.top;
-  }
-
   const x =
-    (
-      clientRect.left +
-      (addVisualOffsets ? win.visualViewport?.offsetLeft ?? 0 : 0) +
-      ownerDocOffset.x
-    ) / scaleX;
+    (clientRect.left +
+      (addVisualOffsets ? win.visualViewport?.offsetLeft ?? 0 : 0)) /
+    scaleX;
   const y =
-    (
-      clientRect.top +
-      (addVisualOffsets ? win.visualViewport?.offsetTop ?? 0 : 0) +
-      ownerDocOffset.y
-    ) / scaleY;
+    (clientRect.top +
+      (addVisualOffsets ? win.visualViewport?.offsetTop ?? 0 : 0)) /
+    scaleY;
   const width = clientRect.width / scaleX;
   const height = clientRect.height / scaleY;
 

--- a/packages/dom/src/utils/getRectRelativeToOffsetParent.ts
+++ b/packages/dom/src/utils/getRectRelativeToOffsetParent.ts
@@ -52,19 +52,9 @@ export function getRectRelativeToOffsetParent(
     }
   }
 
-  const ownerDocOffset = {x: 0, y: 0};
-
-  // TODO: improve checks
-  if (element?.ownerDocument?.defaultView?.frameElement) {
-    const bcr =
-      element.ownerDocument.defaultView.frameElement.getBoundingClientRect();
-    ownerDocOffset.x = bcr.left;
-    ownerDocOffset.y = bcr.top;
-  }
-
   return {
-    x: rect.left + scroll.scrollLeft - offsets.x + ownerDocOffset.x,
-    y: rect.top + scroll.scrollTop - offsets.y + ownerDocOffset.y,
+    x: rect.left + scroll.scrollLeft - offsets.x,
+    y: rect.top + scroll.scrollTop - offsets.y,
     width: rect.width,
     height: rect.height,
   };

--- a/packages/dom/src/utils/getRectRelativeToOffsetParent.ts
+++ b/packages/dom/src/utils/getRectRelativeToOffsetParent.ts
@@ -52,9 +52,19 @@ export function getRectRelativeToOffsetParent(
     }
   }
 
+  const ownerDocOffset = {x: 0, y: 0};
+
+  // TODO: improve checks
+  if (element?.ownerDocument?.defaultView?.frameElement) {
+    const bcr =
+      element.ownerDocument.defaultView.frameElement.getBoundingClientRect();
+    ownerDocOffset.x = bcr.left;
+    ownerDocOffset.y = bcr.top;
+  }
+
   return {
-    x: rect.left + scroll.scrollLeft - offsets.x,
-    y: rect.top + scroll.scrollTop - offsets.y,
+    x: rect.left + scroll.scrollLeft - offsets.x + ownerDocOffset.x,
+    y: rect.top + scroll.scrollTop - offsets.y + ownerDocOffset.y,
     width: rect.width,
     height: rect.height,
   };

--- a/packages/dom/test/visual/index.css
+++ b/packages/dom/test/visual/index.css
@@ -10,6 +10,12 @@ body {
   padding-bottom: 200px;
 }
 
+iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
 nav {
   background: #edeff7;
   position: fixed;

--- a/packages/dom/test/visual/index.tsx
+++ b/packages/dom/test/visual/index.tsx
@@ -29,6 +29,7 @@ import {AutoUpdate} from './spec/AutoUpdate';
 import {Complex} from './spec/Complex';
 import {Inner} from './spec/Inner';
 import {ShadowDOM} from './spec/ShadowDOM';
+import {CrossDocument} from './spec/CrossDocument';
 
 import {New} from './utils/New';
 
@@ -53,6 +54,7 @@ const ROUTES = [
   {path: 'complex', component: Complex},
   {path: 'inner', component: Inner},
   {path: 'shadow-DOM', component: ShadowDOM},
+  {path: 'cross-document', component: CrossDocument},
 ];
 
 function App() {

--- a/packages/dom/test/visual/spec/CrossDocument.tsx
+++ b/packages/dom/test/visual/spec/CrossDocument.tsx
@@ -1,0 +1,150 @@
+import { useState, useLayoutEffect, useMemo, HTMLProps } from 'react';
+import { createPortal } from 'react-dom'
+
+import type { Placement } from '@floating-ui/core';
+import {useFloating} from '@floating-ui/react-dom';
+
+import { Controls } from '../utils/Controls';
+import { defineElements } from '../utils/shadowDOM';
+import { allPlacements } from '../utils/allPlacements';
+import {useScroll} from '../utils/useScroll';
+
+defineElements();
+
+export const IFrame = ({
+  children,
+  ...props
+}: HTMLProps<HTMLIFrameElement>) => {
+  const [contentRef, setContentRef] = useState<HTMLIFrameElement | null>(null)
+
+  const iFrameHead = contentRef?.contentWindow?.document?.head;
+  const iFrameRoot = contentRef?.contentWindow?.document?.body;
+
+
+  const headContent = useMemo(() => (<>
+    {/* Use the same styles as in the top-level document */}
+    {Array.from(contentRef?.ownerDocument.querySelectorAll('link') ?? []).map(
+      ({href}) => <link key={href} rel="stylesheet" href={href} />
+      )}
+    {/* Additional styles needed by the iframe's content */}
+    <style type='text/css'>{`
+      body {
+        /* necessary to override body styles from main stylesheet */
+        padding: 0;
+        /* Center reference inside the iframe */
+        display: grid;
+        place-items: center;
+      }
+    `}</style>
+  </>), [contentRef]);
+
+  return (
+    <iframe {...props} ref={setContentRef}>
+      {/* Add styles to the <head> */}
+      {iFrameHead && createPortal(headContent, iFrameHead)}
+      {/* Add content to the <body> */}
+      {iFrameRoot && createPortal(children, iFrameRoot)}
+    </iframe>
+  )
+}
+
+export function CrossDocument() {
+  const [placement, setPlacement] = useState<Placement>('top');
+
+  const {x, y, reference, floating, strategy, update, refs} = useFloating({
+    placement
+  });
+
+  useLayoutEffect(update, [
+    update,
+    placement,
+  ]);
+
+  useLayoutEffect(() => {
+    // Hack to force a re-render that also creates new values for
+    // `refs` and/or `update`, so that `useScroll` updates internally
+    // and scrolls the reference element into view.
+    setTimeout(() => setPlacement('bottom-start'));
+  }, []);
+
+  const {scrollRef, indicator} = useScroll({refs, update});
+
+  const referenceJsx = <div
+    ref={reference}
+    className="reference"
+  >
+    Reference
+  </div>;
+
+  const floatingJsx = <div
+    ref={floating}
+    className="floating"
+    style={{
+      position: strategy,
+      top: y ?? '',
+      left: x ?? '',
+    }}
+    >
+    Floating
+  </div>;
+
+  return (
+    <>
+      <h1>Cross document</h1>
+      <p>
+        The floating element should be positioned correctly when in a different <span style={{fontFamily: 'monospace'}}>ownerDocument</span> than its reference.
+      </p>
+      <div
+        className='container'
+        style={{
+          overflow: 'hidden',
+          position: 'relative'
+        }}
+      >
+        <IFrame>
+          <div
+            className="scroll"
+            data-x
+            style={{position: 'relative'}}
+            ref={scrollRef}
+            >
+            {indicator}
+            {referenceJsx}
+          </div>
+        </IFrame>
+        {floatingJsx}
+      </div>
+
+      {/* Controls / variations: */}
+      {/* Scenarios:
+          - reference inside iframe, floating in top document
+          - reference in top document, floating inside iframe
+          - reference and floating inside iframes
+       */}
+      {/* Resize iframe */}
+      {/* Scroll iframe */}
+
+      {/* placements */}
+      {/* positions */}
+      {/* arrow */}
+      {/* should the example allow scrolling for testing shift limiting? */}
+      {/* with autoupdate (incl rAF) */}
+
+      <h2>Placement</h2>
+      <Controls>
+        {allPlacements.map((localPlacement) => (
+          <button
+            key={localPlacement}
+            data-testid={`placement-${localPlacement}`}
+            onClick={() => setPlacement(localPlacement)}
+            style={{
+              backgroundColor: localPlacement === placement ? 'black' : '',
+            }}
+          >
+            {localPlacement}
+          </button>
+        ))}
+      </Controls>
+    </>
+  );
+}

--- a/packages/dom/test/visual/spec/CrossDocument.tsx
+++ b/packages/dom/test/visual/spec/CrossDocument.tsx
@@ -195,8 +195,11 @@ export function CrossDocument() {
         }}
       >
         {scenario === 'Reference in iframe' ? (
-          <>
-            <IFrame>
+          <><IFrame>
+            <IFrame style={{
+              maxWidth: '90%',
+              margin: '0 auto',
+            }}>
               <div
                 className="scroll"
                 style={{position: 'relative'}}
@@ -207,7 +210,8 @@ export function CrossDocument() {
                 {referenceJsx}
               </div>
             </IFrame>
-            {floatingJsx}
+          </IFrame>
+          {floatingJsx}
           </>
         // ) : scenario === 'Floating in iframe' ? (
         //   <>


### PR DESCRIPTION
Closes #1869

## What

This PR adds better support for cases where the reference and the floating elements are in two different documents — for example, if the reference is inside an `iframe`, while the floating element is rendered in the top-level document.

TODO:

 - [ ] make sure current approach doesn't introduce regressions (especially around clipping rect detection)
 - [ ] support scenarios:
   - [ ] reference inside iframe, floating in top document
   - [ ] reference in top document, floating inside iframe
   - [ ] reference and floating inside same iframe
   - [ ] nested iframes?
 - [ ] Add event listeners for the extra documents:
   - [ ] scroll
   - [ ] resize
   - [ ] mutation observer?
   - [ ] make sure it works when using the `animationFrame` autoupdate strategy
 - [ ] add tests
   - [ ] for each scenario highlighted above
   - [ ] for each placement
   - [ ] including arrow position
   - [ ] including shifting (with and without limiting)
   - [ ] including flipping
 - [ ] add documentation

## How

In particular, this PR:

- adds a new page to the Visual Playground
- adds a new optional prop on the `VirtualElement` type — `ownerDocument`. This prop is necessary to implement checks for cross-document support.
- improves the logic of the `getRectRelativeToOffsetParent` function in the `dom` package, taking into account (when needed) the offset of the reference's parent `iframe`