### PR TITLE
refactor: remove `preventTabbing` prop

### DIFF
--- a/packages/react-dom-interactions/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react-dom-interactions/test/unit/FloatingFocusManager.test.tsx
@@ -248,30 +248,6 @@ describe('endGuard', () => {
   });
 });
 
-describe('preventTabbing', () => {
-  test('true', async () => {
-    render(<App preventTabbing={true} />);
-
-    const prevEl = document.activeElement;
-    fireEvent.click(screen.getByTestId('reference'));
-
-    await userEvent.tab();
-
-    expect(prevEl).toBe(document.activeElement);
-  });
-
-  test('false', async () => {
-    render(<App preventTabbing={false} />);
-
-    const prevEl = document.activeElement;
-    fireEvent.click(screen.getByTestId('reference'));
-
-    await userEvent.tab();
-
-    expect(prevEl).not.toBe(document.activeElement);
-  });
-});
-
 describe('modal', () => {
   test('true', async () => {
     render(<App modal={true} />);

--- a/packages/react-dom-interactions/test/visual/components/MacSelect.tsx
+++ b/packages/react-dom-interactions/test/visual/components/MacSelect.tsx
@@ -390,7 +390,7 @@ export function Main() {
           </button>
           {open && (
             <FloatingOverlay lockScroll={!touch} style={{zIndex: 1}}>
-              <FloatingFocusManager context={context} preventTabbing>
+              <FloatingFocusManager context={context}>
                 <div
                   ref={floating}
                   className="MacSelect"
@@ -426,6 +426,7 @@ export function Main() {
                         // pressing the ScrollArrows
                         disabled={blockSelection}
                         aria-selected={selectedIndex === i}
+                        tabIndex={-1}
                         role="option"
                         style={{
                           background:

--- a/packages/react-dom-interactions/test/visual/components/Menu.tsx
+++ b/packages/react-dom-interactions/test/visual/components/Menu.tsx
@@ -139,10 +139,6 @@ export const MenuComponent = forwardRef<
   useEffect(() => {
     function onTreeClick() {
       setOpen(false);
-
-      if (parentId === null) {
-        refs.reference.current?.focus();
-      }
     }
 
     tree?.events.on('click', onTreeClick);
@@ -210,8 +206,8 @@ export const MenuComponent = forwardRef<
           <FloatingFocusManager
             context={context}
             modal={!nested}
-            order={['reference', 'content']}
             returnFocus={!nested}
+            order={['reference', 'content']}
           >
             <div
               {...getFloatingProps({

--- a/packages/react-dom-interactions/test/visual/components/Menu.tsx
+++ b/packages/react-dom-interactions/test/visual/components/Menu.tsx
@@ -209,9 +209,9 @@ export const MenuComponent = forwardRef<
         {open && (
           <FloatingFocusManager
             context={context}
-            preventTabbing
             modal={!nested}
             order={['reference', 'content']}
+            returnFocus={!nested}
           >
             <div
               {...getFloatingProps({
@@ -231,6 +231,7 @@ export const MenuComponent = forwardRef<
                   cloneElement(
                     child,
                     getItemProps({
+                      tabIndex: -1,
                       role: 'menuitem',
                       className: 'MenuItem',
                       ref(node: HTMLButtonElement) {


### PR DESCRIPTION
This prop has confused users and is better replaced with the following technique:

- Use `tabIndex={-1}` on all focusable/tabbable items when using a modal FocusManager. `useListNavigation()` will handle the focus management, instead of the `Tab` key.
- For nested menus, set `returnFocus={!nested}`, so focus only returns to the root reference, preventing unwanted focus when using mouse input.