### PR TITLE
perf: revert offsetParent polyfill

### DIFF
--- a/packages/dom/index.test-d.ts
+++ b/packages/dom/index.test-d.ts
@@ -10,6 +10,7 @@ import {
   arrow,
   detectOverflow,
   Middleware,
+  platform,
 } from '.';
 
 // @ts-expect-error
@@ -218,4 +219,12 @@ const middlewareWDetectOverflow: Middleware = {
 
 computePosition(document.body, document.body, {
   middleware: [middlewareWithoutName, middleware, middlewareWDetectOverflow],
+});
+
+computePosition(document.body, document.body, {
+  platform: {
+    ...platform,
+    getOffsetParent: (element) =>
+      Promise.resolve((element as HTMLElement).offsetParent || window),
+  },
 });

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -33,3 +33,5 @@ export {
 export {autoUpdate} from './autoUpdate';
 
 export {getOverflowAncestors} from './utils/getOverflowAncestors';
+
+export {platform} from './platform';

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -79,9 +79,10 @@ export type SizeOptions = Omit<CoreSizeOptions, 'apply'> & {
 
 export type ComputePositionConfig = Omit<
   CoreComputePositionConfig,
-  'middleware'
+  'middleware' | 'platform'
 > & {
   middleware?: Middleware[];
+  platform?: Platform;
 };
 
 /**
@@ -205,3 +206,4 @@ export {computePosition} from './';
 export {autoUpdate, Options as AutoUpdateOptions} from './autoUpdate';
 
 export {getOverflowAncestors} from './utils/getOverflowAncestors';
+export {platform} from './platform';

--- a/packages/dom/src/utils/getOffsetParent.ts
+++ b/packages/dom/src/utils/getOffsetParent.ts
@@ -17,51 +17,7 @@ function getTrueOffsetParent(element: Element): Element | null {
     return null;
   }
 
-  return composedOffsetParent(element);
-}
-
-/**
- * Polyfills the old offsetParent behavior from before the spec was changed:
- * https://github.com/w3c/csswg-drafts/issues/159
- */
-function composedOffsetParent(element: HTMLElement): Element | null {
-  let {offsetParent} = element;
-
-  let ancestor: Element = element;
-  let foundInsideSlot = false;
-
-  while (ancestor && ancestor !== offsetParent) {
-    const {assignedSlot} = ancestor;
-
-    if (assignedSlot) {
-      let newOffsetParent = assignedSlot.offsetParent;
-
-      if (getComputedStyle(assignedSlot).display === 'contents') {
-        const hadStyleAttribute = assignedSlot.hasAttribute('style');
-        const oldDisplay = assignedSlot.style.display;
-        assignedSlot.style.display = getComputedStyle(ancestor).display;
-
-        newOffsetParent = assignedSlot.offsetParent;
-
-        assignedSlot.style.display = oldDisplay;
-        if (!hadStyleAttribute) {
-          assignedSlot.removeAttribute('style');
-        }
-      }
-
-      ancestor = assignedSlot;
-      if (offsetParent !== newOffsetParent) {
-        offsetParent = newOffsetParent;
-        foundInsideSlot = true;
-      }
-    } else if (isShadowRoot(ancestor) && ancestor.host && foundInsideSlot) {
-      break;
-    }
-    ancestor = ((isShadowRoot(ancestor) && ancestor.host) ||
-      ancestor.parentNode) as Element;
-  }
-
-  return offsetParent;
+  return element.offsetParent;
 }
 
 function getContainingBlock(element: Element) {


### PR DESCRIPTION
Kinda felt this was going to happen, this is causing poor performance as noted in here: https://github.com/shoelace-style/shoelace/discussions/902#discussioncomment-3607642

Going to revert this for now, unfortunately there's no fast native `composedOffsetParent()` to use and this polyfill is slow.

Users will have to:

- Simply avoid using the DOM layout that causes issues, or;
- This PR exports `platform` from the `dom` package, so they can spread in the other methods and only rewrite `getOffsetParent` to include this polyfill themselves without needing `patch-package`. If this is necessary for React DOM it can also be added