### PR TITLE
[v2] remove unused `updateCallback` type

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -171,8 +171,6 @@ export type OptionsGeneric<TModifier> = {|
   onFirstUpdate?: ($Shape<State>) => void,
 |};
 
-export type UpdateCallback = (State) => void;
-
 export type ClientRectObject = {|
   x: number,
   y: number,


### PR DESCRIPTION
Looks like it was added in https://github.com/floating-ui/floating-ui/commit/2ac44d0d640f1732071c200ca8f3322e7fbedff7 by mistake? Don't think it's used anywhere?