### PR TITLE
[v2] use `ComputedPlacement` type in returned `State`

### DIFF
--- a/src/createPopper.js
+++ b/src/createPopper.js
@@ -19,7 +19,7 @@ import getBasePlacement from './utils/getBasePlacement';
 import mergeByName from './utils/mergeByName';
 import detectOverflow from './utils/detectOverflow';
 import { isElement } from './dom-utils/instanceOf';
-import { auto } from './enums';
+import { auto, type Placement, type ComputedPlacement } from './enums';
 
 const INVALID_ELEMENT_ERROR =
   'Popper: Invalid reference or popper argument provided. They must be either a DOM element or virtual element.';
@@ -55,7 +55,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
     popper: HTMLElement,
     options: $Shape<OptionsGeneric<TModifier>> = defaultOptions
   ): Instance {
-    let state: $Shape<State> = {
+    let state: $Shape<State<Placement>> = {
       placement: 'bottom',
       orderedModifiers: [],
       options: { ...DEFAULT_OPTIONS, ...defaultOptions },
@@ -239,11 +239,11 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
 
       // Async and optimistically optimized update – it will not be executed if
       // not necessary (debounced to run at most once-per-tick)
-      update: debounce<$Shape<State>>(
+      update: debounce<$Shape<State<ComputedPlacement>>>(
         () =>
-          new Promise<$Shape<State>>((resolve) => {
+          new Promise<$Shape<State<ComputedPlacement>>>((resolve) => {
             instance.forceUpdate();
-            resolve(state);
+            resolve((state: any));
           })
       ),
 

--- a/src/enums.js
+++ b/src/enums.js
@@ -35,6 +35,7 @@ export type VariationPlacement =
   | 'left-end';
 export type AutoPlacement = 'auto' | 'auto-start' | 'auto-end';
 export type ComputedPlacement = VariationPlacement | BasePlacement;
+export type ResolvedPlacement = ComputedPlacement | BasePlacement;
 export type Placement = AutoPlacement | BasePlacement | VariationPlacement;
 
 export const variationPlacements: Array<VariationPlacement> = basePlacements.reduce(

--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,6 @@
 // @flow
 /* eslint-disable import/no-unused-modules */
-import type { Placement, ModifierPhases } from './enums';
+import type { Placement, ComputedPlacement, ModifierPhases } from './enums';
 
 import type { PopperOffsetsModifier } from './modifiers/popperOffsets';
 import type { FlipModifier } from './modifiers/flip';
@@ -73,14 +73,14 @@ export type StateOffsets = {|
 
 type OffsetData = { [Placement]: Offsets };
 
-export type State = {|
+export type State<TPlacement = Placement> = {|
   elements: {|
     reference: Element | VirtualElement,
     popper: HTMLElement,
     arrow?: HTMLElement,
   |},
   options: OptionsGeneric<any>,
-  placement: Placement,
+  placement: TPlacement,
   strategy: PositioningStrategy,
   orderedModifiers: Array<Modifier<any, any>>,
   rects: StateRects,
@@ -117,17 +117,17 @@ export type State = {|
 type SetAction<S> = S | ((prev: S) => S);
 
 export type Instance = {|
-  state: State,
+  state: State<Placement>,
   destroy: () => void,
   forceUpdate: () => void,
-  update: () => Promise<$Shape<State>>,
+  update: () => Promise<$Shape<State<ComputedPlacement>>>,
   setOptions: (
     setOptionsAction: SetAction<$Shape<OptionsGeneric<any>>>
-  ) => Promise<$Shape<State>>,
+  ) => Promise<$Shape<State<ComputedPlacement>>>,
 |};
 
 export type ModifierArguments<Options: Obj> = {
-  state: State,
+  state: State<Placement>,
   instance: Instance,
   options: $Shape<Options>,
   name: string,
@@ -138,7 +138,7 @@ export type Modifier<Name, Options: Obj> = {|
   phase: ModifierPhases,
   requires?: Array<string>,
   requiresIfExists?: Array<string>,
-  fn: (ModifierArguments<Options>) => State | void,
+  fn: (ModifierArguments<Options>) => State<Placement> | void,
   effect?: (ModifierArguments<Options>) => (() => void) | void,
   options?: $Shape<Options>,
   data?: Obj,
@@ -161,17 +161,17 @@ export type Options = {|
   placement: Placement,
   modifiers: Array<$Shape<Modifier<any, any>>>,
   strategy: PositioningStrategy,
-  onFirstUpdate?: ($Shape<State>) => void,
+  onFirstUpdate?: ($Shape<State<ComputedPlacement>>) => void,
 |};
 
 export type OptionsGeneric<TModifier> = {|
   placement: Placement,
   modifiers: Array<TModifier>,
   strategy: PositioningStrategy,
-  onFirstUpdate?: ($Shape<State>) => void,
+  onFirstUpdate?: ($Shape<State<ComputedPlacement>>) => void,
 |};
 
-export type UpdateCallback = (State) => void;
+export type UpdateCallback = (State<Placement>) => void;
 
 export type ClientRectObject = {|
   x: number,

--- a/src/utils/computeAutoPlacement.js
+++ b/src/utils/computeAutoPlacement.js
@@ -27,7 +27,7 @@ type Options = {
 type OverflowsMap = { [ComputedPlacement]: number };
 
 export default function computeAutoPlacement(
-  state: $Shape<State>,
+  state: $Shape<State<Placement>>,
   options: Options = {}
 ): Array<ComputedPlacement> {
   const {

--- a/src/utils/detectOverflow.js
+++ b/src/utils/detectOverflow.js
@@ -32,7 +32,7 @@ export type Options = {
 };
 
 export default function detectOverflow(
-  state: State,
+  state: State<Placement>,
   options: $Shape<Options> = {}
 ): SideObject {
   const {


### PR DESCRIPTION
I don't think it's possible for `placement` to be `auto` in the returned state, so this updates the types to make that the case. This will make the types slightly nicer in a project we have that uses this

If this is accepted I'll open up a followup PR to update https://github.com/floating-ui/react-popper/blob/beac280d61082852c4efc302be902911ce2d424c/src/usePopper.js#L35