### PR TITLE
fix: virtual contextElement ancestors overflow

### DIFF
--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -1,7 +1,7 @@
 import type {ReferenceElement, FloatingElement} from './types';
 import {getBoundingClientRect} from './utils/getBoundingClientRect';
 import {getOverflowAncestors} from './utils/getOverflowAncestors';
-import {isElement, isVirtualElement} from './utils/is';
+import {isElement} from './utils/is';
 
 export interface Options {
   /**
@@ -54,8 +54,9 @@ export function autoUpdate(
   const ancestors =
     ancestorScroll || ancestorResize
       ? [
-          ...(isElement(reference) ? getOverflowAncestors(reference) : []),
-          ...(isVirtualElement(reference) && reference.contextElement
+          ...(isElement(reference)
+            ? getOverflowAncestors(reference)
+            : reference.contextElement
             ? getOverflowAncestors(reference.contextElement)
             : []),
           ...getOverflowAncestors(floating),

--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -80,11 +80,7 @@ export function autoUpdate(
       initialUpdate = false;
     });
     isElement(reference) && !animationFrame && observer.observe(reference);
-    if (
-      !isElement(reference) &&
-      isElement(reference.contextElement) &&
-      !animationFrame
-    ) {
+    if (!isElement(reference) && reference.contextElement && !animationFrame) {
       observer.observe(reference.contextElement);
     }
     observer.observe(floating);

--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -80,6 +80,13 @@ export function autoUpdate(
       initialUpdate = false;
     });
     isElement(reference) && !animationFrame && observer.observe(reference);
+    if (
+      !isElement(reference) &&
+      isElement(reference.contextElement) &&
+      !animationFrame
+    ) {
+      observer.observe(reference.contextElement);
+    }
     observer.observe(floating);
   }
 

--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -1,7 +1,7 @@
 import type {ReferenceElement, FloatingElement} from './types';
 import {getBoundingClientRect} from './utils/getBoundingClientRect';
 import {getOverflowAncestors} from './utils/getOverflowAncestors';
-import {isElement} from './utils/is';
+import {isElement, isVirtualElement} from './utils/is';
 
 export interface Options {
   /**
@@ -55,6 +55,9 @@ export function autoUpdate(
     ancestorScroll || ancestorResize
       ? [
           ...(isElement(reference) ? getOverflowAncestors(reference) : []),
+          ...(isVirtualElement(reference) && reference.contextElement
+            ? getOverflowAncestors(reference.contextElement)
+            : []),
           ...getOverflowAncestors(floating),
         ]
       : [];

--- a/packages/dom/src/utils/is.ts
+++ b/packages/dom/src/utils/is.ts
@@ -2,6 +2,7 @@ import {getComputedStyle} from './getComputedStyle';
 import {getNodeName} from './getNodeName';
 import {getUAString} from './userAgent';
 import {getWindow} from './window';
+import {VirtualElement} from '../types';
 
 declare global {
   interface Window {
@@ -18,6 +19,10 @@ export function isHTMLElement(value: any): value is HTMLElement {
 
 export function isElement(value: any): value is Element {
   return value instanceof getWindow(value).Element;
+}
+
+export function isVirtualElement(value: any): value is VirtualElement {
+  return 'getBoundingClientRect' in value;
 }
 
 export function isNode(value: any): value is Node {

--- a/packages/dom/src/utils/is.ts
+++ b/packages/dom/src/utils/is.ts
@@ -2,7 +2,6 @@ import {getComputedStyle} from './getComputedStyle';
 import {getNodeName} from './getNodeName';
 import {getUAString} from './userAgent';
 import {getWindow} from './window';
-import {VirtualElement} from '../types';
 
 declare global {
   interface Window {
@@ -19,10 +18,6 @@ export function isHTMLElement(value: any): value is HTMLElement {
 
 export function isElement(value: any): value is Element {
   return value instanceof getWindow(value).Element;
-}
-
-export function isVirtualElement(value: any): value is VirtualElement {
-  return 'getBoundingClientRect' in value;
 }
 
 export function isNode(value: any): value is Node {


### PR DESCRIPTION
When using a [Virtual Elements](https://floating-ui.com/docs/virtual-elements) and `contextElement` property, event listeners are not added to its ansectors.