### PR TITLE
feat: allow non-modal portalling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18566,6 +18566,11 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/tabbable": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.1.tgz",
+      "integrity": "sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA=="
+    },
     "node_modules/temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
@@ -19681,7 +19686,8 @@
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^0.6.1",
-        "aria-hidden": "^1.1.3"
+        "aria-hidden": "^1.1.3",
+        "tabbable": "^6.0.1"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -21233,6 +21239,7 @@
         "react-router-dom": "^6.3.0",
         "rollup": "^2.60.1",
         "rollup-plugin-terser": "^7.0.2",
+        "tabbable": "*",
         "ts-jest": "^27.0.7",
         "use-isomorphic-layout-effect": "^1.1.1"
       }
@@ -33808,6 +33815,11 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "tabbable": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.1.tgz",
+      "integrity": "sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA=="
     },
     "temp": {
       "version": "0.8.3",

--- a/packages/react-dom-interactions/package.json
+++ b/packages/react-dom-interactions/package.json
@@ -62,7 +62,8 @@
   },
   "dependencies": {
     "@floating-ui/react-dom": "^0.6.1",
-    "aria-hidden": "^1.1.3"
+    "aria-hidden": "^1.1.3",
+    "tabbable": "^6.0.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.4",

--- a/packages/react-dom-interactions/src/FloatingPortal.tsx
+++ b/packages/react-dom-interactions/src/FloatingPortal.tsx
@@ -10,6 +10,7 @@ type ManagerRef = null | {
 
 const PortalContext = React.createContext<null | {
   preserveTabOrder: boolean;
+  setModal: React.Dispatch<React.SetStateAction<boolean>>;
   beforeInsideRef: React.RefObject<HTMLSpanElement>;
   afterInsideRef: React.RefObject<HTMLSpanElement>;
   beforeOutsideRef: React.RefObject<HTMLSpanElement>;
@@ -59,7 +60,7 @@ export const FloatingPortal = ({
   children,
   id = DEFAULT_ID,
   root = null,
-  preserveTabOrder = false,
+  preserveTabOrder = true,
 }: {
   children?: React.ReactNode;
   id?: string;
@@ -67,6 +68,7 @@ export const FloatingPortal = ({
   preserveTabOrder?: boolean;
 }) => {
   const portalNode = useFloatingPortalNode({id, enabled: !root});
+  const [modal, setModal] = React.useState(true);
 
   const beforeOutsideRef = React.useRef<HTMLSpanElement>(null);
   const afterOutsideRef = React.useRef<HTMLSpanElement>(null);
@@ -74,7 +76,8 @@ export const FloatingPortal = ({
   const afterInsideRef = React.useRef<HTMLSpanElement>(null);
   const managerRef = React.useRef<ManagerRef>(null);
 
-  const renderGuards = !!children && !!(root || portalNode) && preserveTabOrder;
+  const renderGuards =
+    !!children && !!(root || portalNode) && preserveTabOrder && !modal;
 
   return (
     <PortalContext.Provider
@@ -86,6 +89,7 @@ export const FloatingPortal = ({
           beforeInsideRef,
           afterInsideRef,
           managerRef,
+          setModal,
         }),
         [preserveTabOrder]
       )}

--- a/packages/react-dom-interactions/src/FloatingPortal.tsx
+++ b/packages/react-dom-interactions/src/FloatingPortal.tsx
@@ -1,6 +1,21 @@
 import * as React from 'react';
 import {createPortal} from 'react-dom';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
+import {FocusGuard} from './utils/FocusGuard';
+
+type ManagerRef = null | {
+  handleBeforeOutside: () => void;
+  handleAfterOutside: () => void;
+};
+
+const PortalContext = React.createContext<null | {
+  preserveTabOrder: boolean;
+  beforeInsideRef: React.RefObject<HTMLSpanElement>;
+  afterInsideRef: React.RefObject<HTMLSpanElement>;
+  beforeOutsideRef: React.RefObject<HTMLSpanElement>;
+  afterOutsideRef: React.RefObject<HTMLSpanElement>;
+  managerRef: React.MutableRefObject<ManagerRef>;
+}>(null);
 
 const DEFAULT_ID = 'floating-ui-root';
 
@@ -44,20 +59,63 @@ export const FloatingPortal = ({
   children,
   id = DEFAULT_ID,
   root = null,
+  preserveTabOrder = false,
 }: {
   children?: React.ReactNode;
   id?: string;
   root?: HTMLElement | null;
-}): React.ReactPortal | null => {
+  preserveTabOrder?: boolean;
+}) => {
   const portalNode = useFloatingPortalNode({id, enabled: !root});
 
-  if (root) {
-    return createPortal(children, root);
-  }
+  const beforeOutsideRef = React.useRef<HTMLSpanElement>(null);
+  const afterOutsideRef = React.useRef<HTMLSpanElement>(null);
+  const beforeInsideRef = React.useRef<HTMLSpanElement>(null);
+  const afterInsideRef = React.useRef<HTMLSpanElement>(null);
+  const managerRef = React.useRef<ManagerRef>(null);
 
-  if (portalNode) {
-    return createPortal(children, portalNode);
-  }
+  const renderGuards = !!children && !!(root || portalNode) && preserveTabOrder;
 
-  return null;
+  return (
+    <PortalContext.Provider
+      value={React.useMemo(
+        () => ({
+          preserveTabOrder,
+          beforeOutsideRef,
+          afterOutsideRef,
+          beforeInsideRef,
+          afterInsideRef,
+          managerRef,
+        }),
+        [preserveTabOrder]
+      )}
+    >
+      {renderGuards && (
+        <FocusGuard
+          ref={beforeOutsideRef}
+          onFocus={() => {
+            managerRef.current?.handleBeforeOutside();
+          }}
+        />
+      )}
+      {renderGuards && (
+        <span aria-owns={portalNode?.id} style={{position: 'fixed'}} />
+      )}
+      {root
+        ? createPortal(children, root)
+        : portalNode
+        ? createPortal(children, portalNode)
+        : null}
+      {renderGuards && (
+        <FocusGuard
+          ref={afterOutsideRef}
+          onFocus={() => {
+            managerRef.current?.handleAfterOutside();
+          }}
+        />
+      )}
+    </PortalContext.Provider>
+  );
 };
+
+export const usePortalContext = () => React.useContext(PortalContext);

--- a/packages/react-dom-interactions/src/hooks/useListNavigation.ts
+++ b/packages/react-dom-interactions/src/hooks/useListNavigation.ts
@@ -686,6 +686,11 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
         onPointerMove() {
           blockPointerLeaveRef.current = false;
         },
+        onBlur(event) {
+          if (event.relatedTarget !== refs.domReference.current) {
+            onNavigate(null);
+          }
+        },
       },
       item: {
         onFocus({currentTarget}) {

--- a/packages/react-dom-interactions/src/hooks/useListNavigation.ts
+++ b/packages/react-dom-interactions/src/hooks/useListNavigation.ts
@@ -687,7 +687,13 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
           blockPointerLeaveRef.current = false;
         },
         onBlur(event) {
-          if (event.relatedTarget !== refs.domReference.current) {
+          const lostFocusToGuard =
+            event.relatedTarget?.getAttribute('data-floating-ui-focus-guard') !=
+            null;
+
+          // shift+tab back to the reference element should unset the
+          // `activeIndex`.
+          if (lostFocusToGuard) {
             onNavigate(null);
           }
         },

--- a/packages/react-dom-interactions/src/utils/FocusGuard.tsx
+++ b/packages/react-dom-interactions/src/utils/FocusGuard.tsx
@@ -1,10 +1,4 @@
 import * as React from 'react';
-import {TYPEABLE_SELECTOR} from './isTypeableElement';
-
-export const SELECTOR =
-  'select:not([disabled]),a[href],button:not([disabled]),[tabindex],' +
-  'iframe,object,embed,area[href],audio[controls],video[controls],' +
-  TYPEABLE_SELECTOR;
 
 export const FocusGuard = React.forwardRef<
   HTMLSpanElement,

--- a/packages/react-dom-interactions/src/utils/FocusGuard.tsx
+++ b/packages/react-dom-interactions/src/utils/FocusGuard.tsx
@@ -7,9 +7,10 @@ export const FocusGuard = React.forwardRef<
   return (
     <span
       {...props}
-      aria-hidden="true"
       ref={ref}
       tabIndex={0}
+      aria-hidden="true"
+      data-floating-ui-focus-guard=""
       style={{
         position: 'fixed',
         opacity: '0',

--- a/packages/react-dom-interactions/src/utils/FocusGuard.tsx
+++ b/packages/react-dom-interactions/src/utils/FocusGuard.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import {TYPEABLE_SELECTOR} from './isTypeableElement';
+
+export const SELECTOR =
+  'select:not([disabled]),a[href],button:not([disabled]),[tabindex],' +
+  'iframe,object,embed,area[href],audio[controls],video[controls],' +
+  TYPEABLE_SELECTOR;
+
+export const FocusGuard = React.forwardRef<
+  HTMLSpanElement,
+  React.HTMLProps<HTMLSpanElement>
+>(function FocusGuard(props, ref) {
+  return (
+    <span
+      {...props}
+      aria-hidden="true"
+      ref={ref}
+      tabIndex={0}
+      style={{
+        position: 'fixed',
+        opacity: '0',
+        pointerEvents: 'none',
+        outline: '0',
+      }}
+    />
+  );
+});

--- a/packages/react-dom-interactions/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react-dom-interactions/test/unit/FloatingFocusManager.test.tsx
@@ -453,3 +453,197 @@ describe('order', () => {
     cleanup();
   });
 });
+
+describe('non-modal + FloatingPortal', () => {
+  test('focuses inside element, tabbing out focuses last document element', async () => {
+    function App() {
+      const [open, setOpen] = useState(false);
+      const {reference, floating, context} = useFloating({
+        open,
+        onOpenChange: setOpen,
+      });
+
+      return (
+        <>
+          <span tabIndex={0} data-testid="first" />
+          <button
+            data-testid="reference"
+            ref={reference}
+            onClick={() => setOpen(true)}
+          />
+          <FloatingPortal>
+            {open && (
+              <FloatingFocusManager context={context} modal={false}>
+                <div data-testid="floating" ref={floating}>
+                  <span tabIndex={0} data-testid="inside" />
+                </div>
+              </FloatingFocusManager>
+            )}
+          </FloatingPortal>
+          <span tabIndex={0} data-testid="last" />
+        </>
+      );
+    }
+
+    render(<App />);
+
+    await userEvent.click(screen.getByTestId('reference'));
+
+    expect(screen.getByTestId('inside')).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
+    expect(screen.getByTestId('last')).toHaveFocus();
+
+    cleanup();
+  });
+
+  test('order: [reference, content] focuses reference, then inside, then, last document element', async () => {
+    function App() {
+      const [open, setOpen] = useState(false);
+      const {reference, floating, context} = useFloating({
+        open,
+        onOpenChange: setOpen,
+      });
+
+      return (
+        <>
+          <span tabIndex={0} data-testid="first" />
+          <button
+            data-testid="reference"
+            ref={reference}
+            onClick={() => setOpen(true)}
+          />
+          <FloatingPortal>
+            {open && (
+              <FloatingFocusManager
+                context={context}
+                modal={false}
+                order={['reference', 'content']}
+              >
+                <div data-testid="floating" ref={floating}>
+                  <span tabIndex={0} data-testid="inside" />
+                </div>
+              </FloatingFocusManager>
+            )}
+          </FloatingPortal>
+          <span tabIndex={0} data-testid="last" />
+        </>
+      );
+    }
+
+    render(<App />);
+
+    await userEvent.click(screen.getByTestId('reference'));
+
+    await userEvent.tab();
+
+    expect(screen.getByTestId('inside')).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
+    expect(screen.getByTestId('last')).toHaveFocus();
+
+    cleanup();
+  });
+
+  test('order: [reference, floating, content] focuses reference, then inside, then, last document element', async () => {
+    function App() {
+      const [open, setOpen] = useState(false);
+      const {reference, floating, context} = useFloating({
+        open,
+        onOpenChange: setOpen,
+      });
+
+      return (
+        <>
+          <span tabIndex={0} data-testid="first" />
+          <button
+            data-testid="reference"
+            ref={reference}
+            onClick={() => setOpen(true)}
+          />
+          <FloatingPortal>
+            {open && (
+              <FloatingFocusManager
+                context={context}
+                modal={false}
+                order={['reference', 'floating', 'content']}
+              >
+                <div data-testid="floating" ref={floating}>
+                  <span tabIndex={0} data-testid="inside" />
+                </div>
+              </FloatingFocusManager>
+            )}
+          </FloatingPortal>
+          <span tabIndex={0} data-testid="last" />
+        </>
+      );
+    }
+
+    render(<App />);
+
+    await userEvent.click(screen.getByTestId('reference'));
+
+    await userEvent.tab();
+
+    expect(screen.getByTestId('floating')).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(screen.getByTestId('inside')).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
+    expect(screen.getByTestId('last')).toHaveFocus();
+
+    cleanup();
+  });
+
+  test('shift+tab', async () => {
+    function App() {
+      const [open, setOpen] = useState(false);
+      const {reference, floating, context} = useFloating({
+        open,
+        onOpenChange: setOpen,
+      });
+
+      return (
+        <>
+          <span tabIndex={0} data-testid="first" />
+          <button
+            data-testid="reference"
+            ref={reference}
+            onClick={() => setOpen(true)}
+          />
+          <FloatingPortal>
+            {open && (
+              <FloatingFocusManager context={context} modal={false}>
+                <div data-testid="floating" ref={floating}>
+                  <span tabIndex={0} data-testid="inside" />
+                </div>
+              </FloatingFocusManager>
+            )}
+          </FloatingPortal>
+          <span tabIndex={0} data-testid="last" />
+        </>
+      );
+    }
+
+    render(<App />);
+
+    await userEvent.click(screen.getByTestId('reference'));
+    await userEvent.tab({shift: true});
+
+    expect(screen.queryByTestId('floating')).toBeInTheDocument();
+
+    await userEvent.tab({shift: true});
+
+    expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
+
+    cleanup();
+  });
+});

--- a/packages/react-dom-interactions/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react-dom-interactions/test/unit/FloatingFocusManager.test.tsx
@@ -196,9 +196,9 @@ describe('returnFocus', () => {
   });
 });
 
-describe('endGuard', () => {
+describe('guards', () => {
   test('true', async () => {
-    render(<App endGuard={true} />);
+    render(<App guards={true} />);
 
     fireEvent.click(screen.getByTestId('reference'));
 
@@ -210,33 +210,7 @@ describe('endGuard', () => {
   });
 
   test('false', async () => {
-    render(<App endGuard={false} />);
-
-    fireEvent.click(screen.getByTestId('reference'));
-
-    await userEvent.tab();
-    await userEvent.tab();
-    await userEvent.tab();
-
-    expect(document.body).toHaveFocus();
-  });
-});
-
-describe('endGuard', () => {
-  test('true', async () => {
-    render(<App endGuard={true} />);
-
-    fireEvent.click(screen.getByTestId('reference'));
-
-    await userEvent.tab();
-    await userEvent.tab();
-    await userEvent.tab();
-
-    expect(document.body).not.toHaveFocus();
-  });
-
-  test('false', async () => {
-    render(<App endGuard={false} />);
+    render(<App guards={false} />);
 
     fireEvent.click(screen.getByTestId('reference'));
 


### PR DESCRIPTION
WIP

Currently when using `modal={false}` in the `FloatingFocusManager`, you cannot also use `<FloatingPortal>` - this PR changes this to ensure DOM focus doesn't lose context despite the portal

Also changes:

- If `relatedTarget` is null, don't close the floating element (e.g. focusing DevTools or outside)
- Remove `endGuard` in favor of `guards` which allows the user to escape at the end or start like a native dialog, and it doesn't need to be at the end of the document
- `tabbable` library supports shadow DOM now and is more robust, switching to it