### PR TITLE
Fix error with user-agent brand not being an array

### DIFF
--- a/src/utils/userAgent.js
+++ b/src/utils/userAgent.js
@@ -10,7 +10,7 @@ interface NavigatorUAData {
 export default function getUAString(): string {
   const uaData = (navigator: Navigator).userAgentData;
 
-  if (uaData?.brands) {
+  if (uaData?.brands && Array.isArray(uaData.brands)) {
     return uaData.brands
       .map((item) => `${item.brand}/${item.version}`)
       .join(' ');


### PR DESCRIPTION
We have thousands of errors a day caused by `navigator.userAgentData.brands` not being an array. This PR aims to fix that.