### PR TITLE
fix(platform): `getElementRects` decoupling

### DIFF
--- a/packages/dom/src/platform.ts
+++ b/packages/dom/src/platform.ts
@@ -16,7 +16,7 @@ export const platform: Platform = {
   getOffsetParent,
   getDocumentElement,
   async getElementRects({reference, floating, strategy}) {
-    const getOffsetParentFn = this.getOffsetParent ?? getOffsetParent;
+    const getOffsetParentFn = this.getOffsetParent || getOffsetParent;
     const getDimensionsFn = this.getDimensions;
     return {
       reference: getRectRelativeToOffsetParent(

--- a/packages/dom/src/platform.ts
+++ b/packages/dom/src/platform.ts
@@ -15,14 +15,18 @@ export const platform: Platform = {
   getDimensions,
   getOffsetParent,
   getDocumentElement,
-  getElementRects: ({reference, floating, strategy}) => ({
-    reference: getRectRelativeToOffsetParent(
-      reference,
-      getOffsetParent(floating),
-      strategy
-    ),
-    floating: {...getDimensions(floating), x: 0, y: 0},
-  }),
+  async getElementRects({reference, floating, strategy}) {
+    const getOffsetParentFn = this.getOffsetParent ?? getOffsetParent;
+    const getDimensionsFn = this.getDimensions;
+    return {
+      reference: getRectRelativeToOffsetParent(
+        reference,
+        await getOffsetParentFn(floating),
+        strategy
+      ),
+      floating: {x: 0, y: 0, ...(await getDimensionsFn(floating))},
+    };
+  },
   getClientRects: (element) => Array.from(element.getClientRects()),
   isRTL: (element) => getComputedStyle(element).direction === 'rtl',
 };


### PR DESCRIPTION
Forgot about how useful `this` keyword could be...

Closes #1962 