### PR TITLE
Fix link color of "open collective" on website index page 

### DIFF
--- a/website/pages/index.js
+++ b/website/pages/index.js
@@ -683,6 +683,7 @@ function HomePage() {
             proudly sponsored by the following organizations,
             consider joining them on{' '}
             <a
+              className="text-blue-300 hover:text-blue-100 decoration-blue-400/60 hover:decoration-blue-200 decoration-2"
               href="https://opencollective.com/floating-ui"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34198573/203975317-c6db3834-a52b-4883-a457-f135acbe8866.png)

instead of

![image](https://user-images.githubusercontent.com/34198573/203975400-6408343c-6cf3-4778-9119-aa54b68970cd.png)
