### PR TITLE
feat: support non-React tree hierarchy for outside presses

### DIFF
--- a/packages/react-dom-interactions/src/FloatingTree.tsx
+++ b/packages/react-dom-interactions/src/FloatingTree.tsx
@@ -17,10 +17,11 @@ export const useFloatingTree = <
 /**
  * Registers a node into the floating tree, returning its id.
  */
-export const useFloatingNodeId = (): string => {
+export const useFloatingNodeId = (customParentId?: string): string => {
   const id = useId();
   const tree = useFloatingTree();
-  const parentId = useFloatingParentNodeId();
+  const reactParentId = useFloatingParentNodeId();
+  const parentId = customParentId || reactParentId;
 
   useLayoutEffect(() => {
     const node = {id, parentId};

--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -25,7 +25,7 @@ export interface Props {
   escapeKey?: boolean;
   referencePress?: boolean;
   referencePressEvent?: 'pointerdown' | 'mousedown' | 'click';
-  outsidePress?: boolean;
+  outsidePress?: boolean | ((event: MouseEvent) => boolean);
   outsidePressEvent?: 'pointerdown' | 'mousedown' | 'click';
   ancestorScroll?: boolean;
   bubbles?: boolean;
@@ -79,6 +79,10 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
       insideReactTreeRef.current = false;
 
       if (insideReactTree) {
+        return;
+      }
+
+      if (typeof outsidePress === 'function' && !outsidePress(event)) {
         return;
       }
 

--- a/packages/react-dom-interactions/test/unit/useDismiss.test.tsx
+++ b/packages/react-dom-interactions/test/unit/useDismiss.test.tsx
@@ -55,6 +55,13 @@ describe('true', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     cleanup();
   });
+
+  test('outsidePress function guard', async () => {
+    render(<App outsidePress={() => false} />);
+    await userEvent.click(document.body);
+    expect(screen.queryByRole('tooltip')).toBeInTheDocument();
+    cleanup();
+  });
 });
 
 describe('false', () => {
@@ -120,6 +127,13 @@ describe('false', () => {
 
     expect(screen.queryByTestId('portaled-button')).toBeInTheDocument();
 
+    cleanup();
+  });
+
+  test('outsidePress function guard', async () => {
+    render(<App outsidePress={() => true} />);
+    await userEvent.click(document.body);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     cleanup();
   });
 });


### PR DESCRIPTION
Closes #1982  @hornta

This provides two mechanisms for allowing "outside press" to be ignored with certain floating tree structures, the most common being toasts that are rendered on top of a floating element, outside of its React tree.

When the toast is rendered over the top of the modal and it is pressed, we don't want the modal to close:

```jsx
<Modal />
<Toast />
```

Option 1 is adding an attribute, or any selector/identifier to the toast:

```js
<div className="toast" />
```

Then in `useDismiss`, enable the option, but with a guard that cancels the outsidePress dismissal when pressing a toast:

```js
useDismiss(context, {
  outsidePress: (event) => !event.target.closest('.toast'),
});
```

Second option is the ability to specify a custom parentId when registering a nodeId, bypassing the `FloatingNode` lookup since it requires a direct parent-child React tree relationship. This enables FloatingTree-required things like the `bubbles` option to also work.

```js
<FloatingTree>
  <Modal />
  <Toast />
</FloatingTree>
```

```js
function Toast({parentNodeId}) {
  const nodeId = useFloatingNodeId(parentNodeId);
}

function Modal() {
  const nodeId = useFloatingNodeId();

  function onClick() {
    // The ToastProvider sets the state and passes it to the <Toast /> component
    createToast({
      message: 'hello',
      parentNodeId: nodeId,
    });
  }
}
```