### PR TITLE
fix(useHover): switch to mousemove event

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -18,7 +18,7 @@ interface HandleCloseFn<RT extends ReferenceType = ReferenceType> {
       tree?: FloatingTreeType<RT> | null;
       leave?: boolean;
     }
-  ): (event: PointerEvent) => void;
+  ): (event: MouseEvent) => void;
   __options: {
     blockPointerEvents: boolean;
   };
@@ -73,7 +73,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
 
   const pointerTypeRef = React.useRef<string>();
   const timeoutRef = React.useRef<any>();
-  const handlerRef = React.useRef<(event: PointerEvent) => void>();
+  const handlerRef = React.useRef<(event: MouseEvent) => void>();
   const restTimeoutRef = React.useRef<any>();
   const blockMouseMoveRef = React.useRef(true);
   const performedPointerEventsMutationRef = React.useRef(false);
@@ -138,10 +138,10 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     [delayRef, onOpenChange]
   );
 
-  const cleanupPointerMoveHandler = React.useCallback(() => {
+  const cleanupMouseMoveHandler = React.useCallback(() => {
     if (handlerRef.current) {
       getDocument(refs.floating.current).removeEventListener(
-        'pointermove',
+        'mousemove',
         handlerRef.current
       );
       handlerRef.current = undefined;
@@ -207,7 +207,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         clearTimeout(timeoutRef.current);
 
         handlerRef.current &&
-          doc.removeEventListener('pointermove', handlerRef.current);
+          doc.removeEventListener('mousemove', handlerRef.current);
 
         handlerRef.current = handleCloseRef.current({
           ...context,
@@ -216,12 +216,12 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
           y: event.clientY,
           onClose() {
             clearPointerEvents();
-            cleanupPointerMoveHandler();
+            cleanupMouseMoveHandler();
             closeWithDelay();
           },
         });
 
-        doc.addEventListener('pointermove', handlerRef.current);
+        doc.addEventListener('mousemove', handlerRef.current);
         return;
       }
 
@@ -244,10 +244,10 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         leave: true,
         onClose() {
           clearPointerEvents();
-          cleanupPointerMoveHandler();
+          cleanupMouseMoveHandler();
           closeWithDelay();
         },
-      })(event as PointerEvent);
+      })(event);
     }
 
     const floating = refs.floating.current;
@@ -278,7 +278,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     restMs,
     move,
     closeWithDelay,
-    cleanupPointerMoveHandler,
+    cleanupMouseMoveHandler,
     clearPointerEvents,
     onOpenChange,
     open,
@@ -341,17 +341,17 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
   useLayoutEffect(() => {
     if (!open) {
       pointerTypeRef.current = undefined;
-      cleanupPointerMoveHandler();
+      cleanupMouseMoveHandler();
 
       if (performedPointerEventsMutationRef.current) {
         clearPointerEvents();
       }
     }
-  }, [open, cleanupPointerMoveHandler, clearPointerEvents]);
+  }, [open, cleanupMouseMoveHandler, clearPointerEvents]);
 
   React.useEffect(() => {
     return () => {
-      cleanupPointerMoveHandler();
+      cleanupMouseMoveHandler();
       clearTimeout(timeoutRef.current);
       clearTimeout(restTimeoutRef.current);
 
@@ -359,7 +359,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         clearPointerEvents();
       }
     };
-  }, [enabled, cleanupPointerMoveHandler, clearPointerEvents]);
+  }, [enabled, cleanupMouseMoveHandler, clearPointerEvents]);
 
   return React.useMemo(() => {
     if (!enabled) {

--- a/packages/react-dom-interactions/src/safePolygon.ts
+++ b/packages/react-dom-interactions/src/safePolygon.ts
@@ -2,6 +2,7 @@ import type {Side} from '@floating-ui/core';
 import type {FloatingContext, FloatingTreeType, ReferenceType} from './types';
 import {contains} from './utils/contains';
 import {getChildren} from './utils/getChildren';
+import {getTarget} from './utils/getTarget';
 import {isElement} from './utils/is';
 
 type Point = [number, number];
@@ -51,7 +52,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
     tree?: FloatingTreeType<RT> | null;
     leave?: boolean;
   }) => {
-    return function onPointerMove(event: PointerEvent) {
+    return function onMouseMove(event: MouseEvent) {
       clearTimeout(timeoutId);
 
       function close() {
@@ -59,21 +60,13 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
         onClose();
       }
 
-      if (event.pointerType && event.pointerType !== 'mouse') {
-        return;
-      }
-
       const {clientX, clientY} = event;
-      const target =
-        'composedPath' in event
-          ? event.composedPath()[0]
-          : (event as Event).target;
-      const targetNode = target as Element | null;
+      const target = getTarget(event) as Element | null;
 
       // If the pointer is over the reference, there is no need to run the logic
       if (
-        event.type === 'pointermove' &&
-        contains(refs.domReference.current, targetNode)
+        event.type === 'mousemove' &&
+        contains(refs.domReference.current, target)
       ) {
         return;
       }
@@ -99,7 +92,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
       }
 
       // The cursor landed, so we destroy the polygon logic
-      if (contains(refs.floating.current, targetNode) && !leave) {
+      if (contains(refs.floating.current, target) && !leave) {
         polygonIsDestroyed = true;
         return;
       }


### PR DESCRIPTION
Firefox seemed a bit flakey in certain cases with this event while `mousemove` works flawlessly.