### PR TITLE
fix: export ExtendedRefs type

### DIFF
--- a/packages/react-dom-interactions/src/types.ts
+++ b/packages/react-dom-interactions/src/types.ts
@@ -14,7 +14,7 @@ export * from './';
 
 export {arrow} from '@floating-ui/react-dom';
 
-interface ExtendedRefs<RT extends ReferenceType = ReferenceType> {
+export interface ExtendedRefs<RT extends ReferenceType = ReferenceType> {
   reference: React.MutableRefObject<RT | null>;
   floating: React.MutableRefObject<HTMLElement | null>;
   domReference: React.MutableRefObject<Element | null>;


### PR DESCRIPTION
I'm attempting to create a hook similarly to [the official Popover example](https://codesandbox.io/s/distracted-swirles-jo1pvu?file=/src/Popover.tsx:1684-1933) and passing the return type of that to be the context type. Building such a lib with TS (through rollup in my case) fails with an error:

> [!] (plugin typescript) Error: @rollup/plugin-typescript TS4023: Exported variable 'useDrawer' has or is using name 'ExtendedRefs' from external module "node_modules/@floating-ui/react-dom-interactions/src/types" but cannot be named.

I think it needs to translate that `typeof useDrawer` type to something real, since consuming applications don't have that information, so it needs to access the actual type. Hacking in node_modules and adding the export helped my build, I guess this is fairly safe to do anyway.