### PR TITLE
feat(react-dom): `open` option & `isPositioned` return value

### DIFF
--- a/packages/react-dom/index.test-d.tsx
+++ b/packages/react-dom/index.test-d.tsx
@@ -5,7 +5,7 @@ App;
 function App() {
   const arrowRef = useRef(null);
   useFloating();
-  const {reference, floating, update} = useFloating({
+  const {reference, floating, update, reset} = useFloating({
     placement: 'right',
     middleware: [
       shift(),
@@ -42,6 +42,7 @@ function App() {
   reference(null);
   floating(null);
   update();
+  reset();
   return <div ref={arrowRef} />;
 }
 

--- a/packages/react-dom/index.test-d.tsx
+++ b/packages/react-dom/index.test-d.tsx
@@ -5,7 +5,8 @@ App;
 function App() {
   const arrowRef = useRef(null);
   useFloating();
-  const {reference, floating, update, reset} = useFloating({
+  const {reference, floating, update} = useFloating({
+    open: true,
     placement: 'right',
     middleware: [
       shift(),
@@ -42,7 +43,6 @@ function App() {
   reference(null);
   floating(null);
   update();
-  reset();
   return <div ref={arrowRef} />;
 }
 

--- a/packages/react-dom/src/types.ts
+++ b/packages/react-dom/src/types.ts
@@ -20,6 +20,7 @@ export type ReferenceType = Element | VirtualElement;
 export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =
   UseFloatingData & {
     update: () => void;
+    reset: () => void;
     reference: (node: RT | null) => void;
     floating: (node: HTMLElement | null) => void;
     refs: {

--- a/packages/react-dom/src/types.ts
+++ b/packages/react-dom/src/types.ts
@@ -13,6 +13,7 @@ export {arrow} from './';
 export type UseFloatingData = Omit<ComputePositionReturn, 'x' | 'y'> & {
   x: number | null;
   y: number | null;
+  isReady: boolean;
 };
 
 export type ReferenceType = Element | VirtualElement;

--- a/packages/react-dom/src/types.ts
+++ b/packages/react-dom/src/types.ts
@@ -11,8 +11,8 @@ export {useFloating} from './';
 export {arrow} from './';
 
 export type UseFloatingData = Omit<ComputePositionReturn, 'x' | 'y'> & {
-  x: number | null;
-  y: number | null;
+  x: number;
+  y: number;
   isPositioned: boolean;
 };
 

--- a/packages/react-dom/src/types.ts
+++ b/packages/react-dom/src/types.ts
@@ -11,8 +11,8 @@ export {useFloating} from './';
 export {arrow} from './';
 
 export type UseFloatingData = Omit<ComputePositionReturn, 'x' | 'y'> & {
-  x: number;
-  y: number;
+  x: number | null;
+  y: number | null;
   isPositioned: boolean;
 };
 

--- a/packages/react-dom/src/types.ts
+++ b/packages/react-dom/src/types.ts
@@ -13,7 +13,7 @@ export {arrow} from './';
 export type UseFloatingData = Omit<ComputePositionReturn, 'x' | 'y'> & {
   x: number | null;
   y: number | null;
-  isReady: boolean;
+  isPositioned: boolean;
 };
 
 export type ReferenceType = Element | VirtualElement;
@@ -21,7 +21,6 @@ export type ReferenceType = Element | VirtualElement;
 export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =
   UseFloatingData & {
     update: () => void;
-    reset: () => void;
     reference: (node: RT | null) => void;
     floating: (node: HTMLElement | null) => void;
     refs: {
@@ -39,4 +38,5 @@ export type UseFloatingProps<RT extends ReferenceType = ReferenceType> = Omit<
     floating: HTMLElement,
     update: () => void
   ) => void | (() => void);
+  open?: boolean;
 };

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -17,15 +17,21 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
   strategy = 'absolute',
   whileElementsMounted,
 }: UseFloatingProps = {}): UseFloatingReturn<RT> {
-  const [data, setData] = React.useState<UseFloatingData>({
-    // Setting these to `null` will allow the consumer to determine if
-    // `computePosition()` has run yet
-    x: null,
-    y: null,
-    strategy,
-    placement,
-    middlewareData: {},
-  });
+  const initialData = React.useMemo(
+    () => ({
+      // Setting these to `null` will allow the consumer to determine if the
+      // floating element has been positioned yet, either due to async
+      // positioning or during SSR.
+      x: null,
+      y: null,
+      strategy,
+      placement,
+      middlewareData: {},
+    }),
+    [strategy, placement]
+  );
+
+  const [data, setData] = React.useState<UseFloatingData>(initialData);
 
   const [latestMiddleware, setLatestMiddleware] = React.useState(middleware);
 
@@ -111,6 +117,10 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
     [runElementMountCallback]
   );
 
+  const reset = React.useCallback(() => {
+    setData(initialData);
+  }, [initialData]);
+
   const refs = React.useMemo(() => ({reference, floating}), []);
 
   return React.useMemo(
@@ -118,9 +128,10 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       ...data,
       update,
       refs,
+      reset,
       reference: setReference,
       floating: setFloating,
     }),
-    [data, update, refs, setReference, setFloating]
+    [data, update, refs, reset, setReference, setFloating]
   );
 }

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -27,6 +27,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       strategy,
       placement,
       middlewareData: {},
+      isReady: false,
     }),
     [strategy, placement]
   );
@@ -57,9 +58,10 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       strategy,
     }).then((data) => {
       if (isMountedRef.current && !deepEqual(dataRef.current, data)) {
-        dataRef.current = data;
+        const value = {...data, isReady: true};
+        dataRef.current = value;
         ReactDOM.flushSync(() => {
-          setData(data);
+          setData(value);
         });
       }
     });

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -20,8 +20,8 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
 }: UseFloatingProps = {}): UseFloatingReturn<RT> {
   const initialData = React.useMemo(
     () => ({
-      x: 0,
-      y: 0,
+      x: null,
+      y: null,
       strategy,
       placement,
       middlewareData: {},
@@ -66,18 +66,10 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
   }, [latestMiddleware, placement, strategy]);
 
   useLayoutEffect(() => {
-    // Skip first update
-    if (isMountedRef.current && open === false) {
-      setData(initialData);
+    if (open === false && dataRef.current.isPositioned) {
+      setData((data) => ({...data, isPositioned: false}));
     }
-  }, [open, initialData]);
-
-  useLayoutEffect(() => {
-    // Skip first update
-    if (isMountedRef.current) {
-      update();
-    }
-  }, [update]);
+  }, [open]);
 
   const isMountedRef = React.useRef(false);
   useLayoutEffect(() => {

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -16,6 +16,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
   placement = 'bottom',
   strategy = 'absolute',
   whileElementsMounted,
+  open,
 }: UseFloatingProps = {}): UseFloatingReturn<RT> {
   const initialData = React.useMemo(
     () => ({
@@ -27,7 +28,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       strategy,
       placement,
       middlewareData: {},
-      isReady: false,
+      isPositioned: false,
     }),
     [strategy, placement]
   );
@@ -58,7 +59,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       strategy,
     }).then((data) => {
       if (isMountedRef.current && !deepEqual(dataRef.current, data)) {
-        const value = {...data, isReady: true};
+        const value = {...data, isPositioned: true};
         dataRef.current = value;
         ReactDOM.flushSync(() => {
           setData(value);
@@ -66,6 +67,13 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       }
     });
   }, [latestMiddleware, placement, strategy]);
+
+  useLayoutEffect(() => {
+    // Skip first update
+    if (isMountedRef.current) {
+      setData(initialData);
+    }
+  }, [open, initialData]);
 
   useLayoutEffect(() => {
     // Skip first update
@@ -119,10 +127,6 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
     [runElementMountCallback]
   );
 
-  const reset = React.useCallback(() => {
-    setData(initialData);
-  }, [initialData]);
-
   const refs = React.useMemo(() => ({reference, floating}), []);
 
   return React.useMemo(
@@ -130,10 +134,9 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       ...data,
       update,
       refs,
-      reset,
       reference: setReference,
       floating: setFloating,
     }),
-    [data, update, refs, reset, setReference, setFloating]
+    [data, update, refs, setReference, setFloating]
   );
 }

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -20,11 +20,8 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
 }: UseFloatingProps = {}): UseFloatingReturn<RT> {
   const initialData = React.useMemo(
     () => ({
-      // Setting these to `null` will allow the consumer to determine if the
-      // floating element has been positioned yet, either due to async
-      // positioning or during SSR.
-      x: null,
-      y: null,
+      x: 0,
+      y: 0,
       strategy,
       placement,
       middlewareData: {},

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -70,7 +70,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
 
   useLayoutEffect(() => {
     // Skip first update
-    if (isMountedRef.current && !open) {
+    if (isMountedRef.current && open === false) {
       setData(initialData);
     }
   }, [open, initialData]);

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -70,7 +70,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
 
   useLayoutEffect(() => {
     // Skip first update
-    if (isMountedRef.current) {
+    if (isMountedRef.current && !open) {
       setData(initialData);
     }
   }, [open, initialData]);

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -81,6 +81,7 @@ export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =
     floating: (node: HTMLElement | null) => void;
     context: FloatingContext<RT>;
     refs: ExtendedRefs<RT>;
+    isPositioned: boolean;
   };
 
 export interface UseFloatingProps<RT extends ReferenceType = ReferenceType> {

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -70,8 +70,8 @@ export interface ElementProps {
 export type ReferenceType = Element | VirtualElement;
 
 export type UseFloatingData = Omit<ComputePositionReturn, 'x' | 'y'> & {
-  x: number;
-  y: number;
+  x: number | null;
+  y: number | null;
 };
 
 export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -70,8 +70,8 @@ export interface ElementProps {
 export type ReferenceType = Element | VirtualElement;
 
 export type UseFloatingData = Omit<ComputePositionReturn, 'x' | 'y'> & {
-  x: number | null;
-  y: number | null;
+  x: number;
+  y: number;
 };
 
 export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -28,6 +28,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
   const dataRef = React.useRef<ContextData>({});
   const events = React.useState(() => createPubSub())[0];
   const position = usePosition<RT>({
+    open,
     placement,
     middleware,
     strategy,


### PR DESCRIPTION
Right now, the only fully reliable way to ensure the position is ready during an effect is to use `requestAnimationFrame` to prevent unwanted scrolling to the top/left of the document (due to the floating element's initial layout):

```js
useLayoutEffect(() => {
  open && requestAnimationFrame(() => el.focus());
}, [open]);
```

(I know `preventScroll` exists, but it's not very widely supported).

This feels kind of like a hack and can cause some issues, so I am proposing the following:

```js
const [open, setOpen] = useState(false);

const {isPositioned} = useFloating({
  // if false, resets the state
  open,
});

useLayoutEffect(() => {
  isPositioned && el.focus();
}, [isPositioned]);
```

The `open` option allows you to subscribe to resets, where `false` will cause a reset. This plays nicely with the main `react`/interactions package, because it already accepts an `open` option (and will default to this behavior), but also allows consumers of only the positioning library (`react-dom`, not `react`) to hook into resets declaratively.