### PR TITLE
fix(useDismiss): ensure `outsidePress` referential stability

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useDismiss.ts
+++ b/packages/react-dom-interactions/src/hooks/useDismiss.ts
@@ -7,6 +7,7 @@ import {getDocument} from '../utils/getDocument';
 import {getTarget} from '../utils/getTarget';
 import {isElement, isVirtualClick, isVirtualPointerEvent} from '../utils/is';
 import {isEventTargetWithin} from '../utils/isEventTargetWithin';
+import {useLatestRef} from '../utils/useLatestRef';
 
 const bubbleHandlerKeys = {
   pointerdown: 'onPointerDown',
@@ -57,12 +58,15 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
 ): ElementProps => {
   const tree = useFloatingTree();
   const nested = useFloatingParentNodeId() != null;
+  const outsidePressRef = useLatestRef(outsidePress);
   const insideReactTreeRef = React.useRef(false);
 
   React.useEffect(() => {
     if (!open || !enabled) {
       return;
     }
+
+    const outsidePress = outsidePressRef.current;
 
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
@@ -214,7 +218,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     };
   }, [
     escapeKey,
-    outsidePress,
+    outsidePressRef,
     outsidePressEvent,
     events,
     tree,


### PR DESCRIPTION
Closes #2008 

- Small change in behavior: this makes `outsidePress` non-reactive, so if they change the value while the floating element is open it won't re-register the listeners. Doubt this matters.