### PR TITLE
fix(react-native): avoid queuing update if already queued

### DIFF
--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -68,7 +68,7 @@ export const useFloating = ({
   const floating = useRef<any>();
   const offsetParent = useRef<any>();
 
-  const isUpdateQueued = useRef(false);
+  const isUpdateQueuedRef = useRef(false);
 
   const [data, setData] = useState<Data>({
     x: null,
@@ -116,7 +116,7 @@ export const useFloating = ({
       }
     });
 
-    isUpdateQueued.current = false;
+    isUpdateQueuedRef.current = false;
   }, [latestMiddleware, platform, placement]);
 
   useLayoutEffect(() => {
@@ -131,8 +131,8 @@ export const useFloating = ({
   const setReference: UseFloatingReturn['reference'] = useCallback(
     (node) => {
       reference.current = node;
-      if (!isUpdateQueued.current) animationFrames.current.push(requestAnimationFrame(update));
-      isUpdateQueued.current = true;
+      if (!isUpdateQueuedRef.current) animationFrames.current.push(requestAnimationFrame(update));
+      isUpdateQueuedRef.current = true;
     },
     [update]
   );
@@ -140,8 +140,8 @@ export const useFloating = ({
   const setFloating: UseFloatingReturn['floating'] = useCallback(
     (node) => {
       floating.current = node;
-      if (!isUpdateQueued.current) animationFrames.current.push(requestAnimationFrame(update));
-      isUpdateQueued.current = true;
+      if (!isUpdateQueuedRef.current) animationFrames.current.push(requestAnimationFrame(update));
+      isUpdateQueuedRef.current = true;
     },
     [update]
   );
@@ -149,8 +149,8 @@ export const useFloating = ({
   const setOffsetParent: UseFloatingReturn['offsetParent'] = useCallback(
     (node) => {
       offsetParent.current = node;
-      if (!isUpdateQueued.current) animationFrames.current.push(requestAnimationFrame(update));
-      isUpdateQueued.current = true;
+      if (!isUpdateQueuedRef.current) animationFrames.current.push(requestAnimationFrame(update));
+      isUpdateQueuedRef.current = true;
     },
     [update]
   );

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -68,6 +68,8 @@ export const useFloating = ({
   const floating = useRef<any>();
   const offsetParent = useRef<any>();
 
+  const isUpdateQueued = useRef(false);
+
   const [data, setData] = useState<Data>({
     x: null,
     y: null,
@@ -113,6 +115,8 @@ export const useFloating = ({
         setData(data);
       }
     });
+
+    isUpdateQueued.current = false;
   }, [latestMiddleware, platform, placement]);
 
   useLayoutEffect(() => {
@@ -127,7 +131,8 @@ export const useFloating = ({
   const setReference: UseFloatingReturn['reference'] = useCallback(
     (node) => {
       reference.current = node;
-      animationFrames.current.push(requestAnimationFrame(update));
+      if (!isUpdateQueued.current) animationFrames.current.push(requestAnimationFrame(update));
+      isUpdateQueued.current = true;
     },
     [update]
   );
@@ -135,7 +140,8 @@ export const useFloating = ({
   const setFloating: UseFloatingReturn['floating'] = useCallback(
     (node) => {
       floating.current = node;
-      animationFrames.current.push(requestAnimationFrame(update));
+      if (!isUpdateQueued.current) animationFrames.current.push(requestAnimationFrame(update));
+      isUpdateQueued.current = true;
     },
     [update]
   );
@@ -143,7 +149,8 @@ export const useFloating = ({
   const setOffsetParent: UseFloatingReturn['offsetParent'] = useCallback(
     (node) => {
       offsetParent.current = node;
-      animationFrames.current.push(requestAnimationFrame(update));
+      if (!isUpdateQueued.current) animationFrames.current.push(requestAnimationFrame(update));
+      isUpdateQueued.current = true;
     },
     [update]
   );


### PR DESCRIPTION
This PR avoids some cases where using `useFloating` causing `Please report: Excessive number of pending callbacks: 501.` in some cases.