### PR TITLE
Treat 'pen' pointerType like 'mouse' in useHover hook

### DIFF
--- a/packages/react-dom-interactions/src/hooks/useHover.ts
+++ b/packages/react-dom-interactions/src/hooks/useHover.ts
@@ -24,12 +24,14 @@ interface HandleCloseFn<RT extends ReferenceType = ReferenceType> {
   };
 }
 
+const mouseLikePointerTypes = ['mouse', 'pen'];
+
 export function getDelay(
   value: Props['delay'],
   prop: 'open' | 'close',
   pointerType?: PointerEvent['pointerType']
 ) {
-  if (pointerType && pointerType !== 'mouse') {
+  if (pointerType && !mouseLinkPointerTypes.includes(pointerType)) {
     return 0;
   }
 
@@ -172,7 +174,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       blockMouseMoveRef.current = false;
 
       if (
-        (mouseOnly && pointerTypeRef.current !== 'mouse') ||
+        (mouseOnly && !mouseLikePointerTypes.includes(pointerTypeRef.current)) ||
         (restMs > 0 && getDelay(delayRef.current, 'open') === 0)
       ) {
         return;


### PR DESCRIPTION
I made these changes in the github.dev editor, so apologies if any linter requirement might not be met.

I made these changes to the `dist/floating-ui.react-dom-interactions.esm.js` locally, tested them, and then copied the changes to the source file - so there's an exceedingly small chance there was a transcription error on my part - but I believe this code to be functional and ready to go.

@atomiks