### PR TITLE
Try out `esm-env`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10037,6 +10037,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esm-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
+      "integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA=="
+    },
     "node_modules/espree": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
@@ -19659,6 +19664,9 @@
       "name": "@floating-ui/core",
       "version": "0.6.1",
       "license": "MIT",
+      "dependencies": {
+        "esm-env": "^1.0.0"
+      },
       "devDependencies": {
         "@atomico/rollup-plugin-sizes": "^1.1.4",
         "@babel/preset-env": "^7.16.4",
@@ -19700,11 +19708,13 @@
       }
     },
     "packages/react": {
-      "version": "0.0.15",
+      "name": "@floating-ui/react",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^0.6.1",
         "aria-hidden": "^1.1.3",
+        "esm-env": "^1.0.0",
         "tabbable": "^6.0.1"
       },
       "devDependencies": {
@@ -21256,6 +21266,7 @@
         "@rollup/plugin-replace": "^3.0.0",
         "@types/jest": "^27.0.3",
         "babel-plugin-annotate-pure-calls": "^0.4.0",
+        "esm-env": "^1.0.0",
         "jest": "^27.3.1",
         "rollup": "^2.60.1",
         "rollup-plugin-terser": "^7.0.2",
@@ -21302,6 +21313,7 @@
         "@types/react": "^18.0.1",
         "aria-hidden": "^1.1.3",
         "babel-plugin-annotate-pure-calls": "^0.4.0",
+        "esm-env": "*",
         "framer-motion": "^6.2.8",
         "jest": "^27.3.1",
         "react": "^18.0.0",
@@ -27257,6 +27269,11 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
+    },
+    "esm-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
+      "integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA=="
     },
     "espree": {
       "version": "9.3.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,5 +73,8 @@
     "rollup": "^2.60.1",
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^27.0.7"
+  },
+  "dependencies": {
+    "esm-env": "^1.0.0"
   }
 }

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -41,6 +41,9 @@ const bundles = [
       name: 'FloatingUICore',
       file: path.join(__dirname, 'dist/floating-ui.core.umd.js'),
       format: 'umd',
+      globals: {
+        'esm-env': 'esmEnv',
+      },
     },
   },
   {
@@ -49,6 +52,9 @@ const bundles = [
       name: 'FloatingUICore',
       file: path.join(__dirname, 'dist/floating-ui.core.umd.min.js'),
       format: 'umd',
+      globals: {
+        'esm-env': 'esmEnv',
+      },
     },
   },
 ];
@@ -56,6 +62,7 @@ const bundles = [
 export default bundles.map(({input, output}) => ({
   input,
   output,
+  external: ['esm-env'],
   plugins: [
     nodeResolve({extensions: ['.ts']}),
     replace({

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -62,7 +62,7 @@ const bundles = [
 export default bundles.map(({input, output}) => ({
   input,
   output,
-  external: ['esm-env'],
+  external: output.format !== 'umd' ? ['esm-env'] : [],
   plugins: [
     nodeResolve({extensions: ['.ts']}),
     replace({

--- a/packages/core/src/_babel.d.ts
+++ b/packages/core/src/_babel.d.ts
@@ -1,1 +1,0 @@
-declare const __DEV__: boolean;

--- a/packages/core/src/computePosition.ts
+++ b/packages/core/src/computePosition.ts
@@ -1,3 +1,4 @@
+import {DEV} from 'esm-env';
 import type {
   ComputePosition,
   ComputePositionReturn,
@@ -28,7 +29,7 @@ export const computePosition: ComputePosition = async (
   const validMiddleware = middleware.filter(Boolean) as Middleware[];
   const rtl = await platform.isRTL?.(floating);
 
-  if (__DEV__) {
+  if (DEV) {
     if (platform == null) {
       console.error(
         [
@@ -102,7 +103,7 @@ export const computePosition: ComputePosition = async (
       },
     };
 
-    if (__DEV__) {
+    if (DEV) {
       if (resetCount > 50) {
         console.warn(
           [

--- a/packages/core/src/detectOverflow.ts
+++ b/packages/core/src/detectOverflow.ts
@@ -1,3 +1,4 @@
+import {DEV} from 'esm-env';
 import type {
   SideObject,
   Padding,
@@ -98,7 +99,7 @@ export async function detectOverflow(
       : rect
   );
 
-  if (__DEV__) {
+  if (DEV) {
     if (DEBUG_RECTS) {
       paintDebugRects(elementClientRect, clippingClientRect);
     }

--- a/packages/core/src/middleware/arrow.ts
+++ b/packages/core/src/middleware/arrow.ts
@@ -1,3 +1,4 @@
+import {DEV} from 'esm-env';
 import type {Middleware, Padding} from '../types';
 import {getLengthFromAxis} from '../utils/getLengthFromAxis';
 import {getMainAxisFromPlacement} from '../utils/getMainAxisFromPlacement';
@@ -33,7 +34,7 @@ export const arrow = (options: Options): Middleware => ({
     const {x, y, placement, rects, platform} = middlewareArguments;
 
     if (element == null) {
-      if (__DEV__) {
+      if (DEV) {
         console.warn(
           'Floating UI: No `element` was passed to the `arrow` middleware.'
         );

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "^0.6.1",
     "aria-hidden": "^1.1.3",
+    "esm-env": "^1.0.0",
     "tabbable": "^6.0.1"
   },
   "devDependencies": {

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -29,6 +29,7 @@ const bundles = [
       file: path.join(__dirname, 'dist/floating-ui.react.umd.js'),
       format: 'umd',
       globals: {
+        'esm-env': 'esmEnv',
         react: 'React',
         'react-dom': 'ReactDOM',
         'aria-hidden': 'ariaHidden',
@@ -46,6 +47,7 @@ const bundles = [
       file: path.join(__dirname, 'dist/floating-ui.react.umd.min.js'),
       format: 'umd',
       globals: {
+        'esm-env': 'esmEnv',
         react: 'React',
         'react-dom': 'ReactDOM',
         'aria-hidden': 'ariaHidden',
@@ -74,7 +76,9 @@ export default bundles.map(({input, output}) => ({
     '@floating-ui/core',
     '@floating-ui/dom',
     '@floating-ui/react-dom',
-  ].concat(output.format !== 'umd' ? ['aria-hidden', 'tabbable'] : []),
+  ].concat(
+    output.format !== 'umd' ? ['aria-hidden', 'tabbable', 'esm-env'] : []
+  ),
   plugins: [
     commonjs(),
     nodeResolve({extensions: ['.ts', '.tsx']}),

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {DEV} from 'esm-env';
 import {flushSync} from 'react-dom';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
 import {
@@ -194,7 +195,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
     onNavigate: () => {},
   }
 ): ElementProps => {
-  if (__DEV__) {
+  if (DEV) {
     if (allowEscape) {
       if (!loop) {
         console.warn(

--- a/packages/react/src/hooks/utils/useEvent.ts
+++ b/packages/react/src/hooks/utils/useEvent.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {DEV} from 'esm-env';
 
 type AnyFunction = (...args: any[]) => any;
 
@@ -11,7 +12,7 @@ const useSafeInsertionEffect = useInsertionEffect || ((fn) => fn());
 
 export function useEvent<T extends AnyFunction>(callback?: T) {
   const ref = React.useRef<AnyFunction | undefined>(() => {
-    if (__DEV__) {
+    if (DEV) {
       throw new Error('Cannot call an event handler while rendering.');
     }
   });

--- a/packages/react/src/inner.ts
+++ b/packages/react/src/inner.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {DEV} from 'esm-env';
 import {detectOverflow, offset} from '@floating-ui/react-dom';
 import type {
   SideObject,
@@ -62,7 +63,7 @@ export const inner = (
 
     const item = listRef.current[index];
 
-    if (__DEV__) {
+    if (DEV) {
       if (!middlewareArguments.placement.startsWith('bottom')) {
         console.warn(
           [

--- a/packages/react/src/safePolygon.ts
+++ b/packages/react/src/safePolygon.ts
@@ -1,3 +1,4 @@
+import {DEV} from 'esm-env';
 import type {Side} from '@floating-ui/core';
 import type {FloatingContext, FloatingTreeType, ReferenceType} from './types';
 import {contains} from './utils/contains';
@@ -340,7 +341,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
 
       const poly = getPolygon([x, y]);
 
-      if (__DEV__) {
+      if (DEV) {
         debug?.(poly.slice(0, 4).join(', '));
       }
 


### PR DESCRIPTION
I'm not sure if this is fully backwards-compatible, but it seems like a better solution than the one we came up with @Westbrook 

Will need to validate this against bundlers etc to ensure it actually eliminates the dead code when building for production, and keeps it in dev mode.

Reference: https://twitter.com/Rich_Harris/status/1601609347376652290