### PR TITLE
fix(dom): use local cache

### DIFF
--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -2,8 +2,6 @@ import type {
   ComputePositionConfig,
   ReferenceElement,
   FloatingElement,
-  VirtualElement,
-  Platform,
 } from './types';
 import {computePosition as computePositionCore} from '@floating-ui/core';
 import {platform} from './platform';
@@ -18,27 +16,13 @@ export const computePosition = (
   floating: FloatingElement,
   options?: Partial<ComputePositionConfig>
 ) => {
-  // The HTML element can also be in the cache when using virtual reference
-  // elements, but since it doesn't change for the given script, we can just
-  // leave it in there.
-  const possibleCachedElements = [reference, floating].concat(
-    reference ? (reference as VirtualElement).contextElement || [] : []
-  );
-
   const cache = new Map<ReferenceElement, Array<Element>>();
   const mergedOptions = {platform, ...options};
-  const mergedPlatform = mergedOptions.platform as Platform & {
-    _c: Map<ReferenceElement, Element[]>;
-  };
+  const platformWithCache = {...mergedOptions.platform, _c: cache};
 
-  mergedPlatform._c = cache;
-
-  const result = computePositionCore(reference, floating, mergedOptions);
-
-  result.then(() => {
-    possibleCachedElements.forEach((el) => {
-      cache.delete(el);
-    });
+  const result = computePositionCore(reference, floating, {
+    ...mergedOptions,
+    platform: platformWithCache,
   });
 
   return result;

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -50,10 +50,6 @@ export interface Platform {
   getScale?: (element: HTMLElement) => Promisable<{x: number; y: number}>;
 }
 
-export type PlatformWithCache = Platform & {
-  _c: Map<ReferenceElement, Element[]>;
-};
-
 export interface NodeScroll {
   scrollLeft: number;
   scrollTop: number;

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -50,6 +50,10 @@ export interface Platform {
   getScale?: (element: HTMLElement) => Promisable<{x: number; y: number}>;
 }
 
+export type PlatformWithCache = Platform & {
+  _c: Map<ReferenceElement, Element[]>;
+};
+
 export interface NodeScroll {
   scrollLeft: number;
   scrollTop: number;

--- a/packages/dom/src/utils/cache.ts
+++ b/packages/dom/src/utils/cache.ts
@@ -1,7 +1,0 @@
-import type {FloatingElement, ReferenceElement} from '../types';
-
-// This cache is in effect for a single `computePosition()` call.
-export const clippingAncestorsCache = new WeakMap<
-  ReferenceElement | FloatingElement,
-  Array<Element>
->();

--- a/packages/dom/src/utils/getClippingRect.ts
+++ b/packages/dom/src/utils/getClippingRect.ts
@@ -22,7 +22,11 @@ import {max, min} from './math';
 import {getParentNode} from './getParentNode';
 import {getNodeName} from './getNodeName';
 import {getScale} from './getScale';
-import {PlatformWithCache} from '../types';
+import {Platform, ReferenceElement} from '../types';
+
+type PlatformWithCache = Platform & {
+  _c: Map<ReferenceElement, Element[]>;
+};
 
 // Returns the inner client rect, subtracting scrollbars if present
 function getInnerBoundingClientRect(

--- a/packages/dom/src/utils/getClippingRect.ts
+++ b/packages/dom/src/utils/getClippingRect.ts
@@ -22,7 +22,7 @@ import {max, min} from './math';
 import {getParentNode} from './getParentNode';
 import {getNodeName} from './getNodeName';
 import {getScale} from './getScale';
-import {clippingAncestorsCache} from './cache';
+import {PlatformWithCache} from '../types';
 
 // Returns the inner client rect, subtracting scrollbars if present
 function getInnerBoundingClientRect(
@@ -69,8 +69,11 @@ function getClientRectFromClippingAncestor(
 // A "clipping ancestor" is an `overflow` element with the characteristic of
 // clipping (or hiding) child elements. This returns all clipping ancestors
 // of the given element up the tree.
-function getClippingElementAncestors(element: Element): Array<Element> {
-  const cachedResult = clippingAncestorsCache.get(element);
+function getClippingElementAncestors(
+  element: Element,
+  cache: PlatformWithCache['_c']
+): Array<Element> {
+  const cachedResult = cache.get(element);
   if (cachedResult) {
     return cachedResult;
   }
@@ -109,27 +112,30 @@ function getClippingElementAncestors(element: Element): Array<Element> {
     currentNode = getParentNode(currentNode);
   }
 
-  clippingAncestorsCache.set(element, result);
+  cache.set(element, result);
 
   return result;
 }
 
 // Gets the maximum area that the element is visible in due to any number of
 // clipping ancestors
-export function getClippingRect({
-  element,
-  boundary,
-  rootBoundary,
-  strategy,
-}: {
-  element: Element;
-  boundary: Boundary;
-  rootBoundary: RootBoundary;
-  strategy: Strategy;
-}): Rect {
+export function getClippingRect(
+  this: PlatformWithCache,
+  {
+    element,
+    boundary,
+    rootBoundary,
+    strategy,
+  }: {
+    element: Element;
+    boundary: Boundary;
+    rootBoundary: RootBoundary;
+    strategy: Strategy;
+  }
+): Rect {
   const elementClippingAncestors =
     boundary === 'clippingAncestors'
-      ? getClippingElementAncestors(element)
+      ? getClippingElementAncestors(element, this._c)
       : [].concat(boundary);
   const clippingAncestors = [...elementClippingAncestors, rootBoundary];
   const firstClippingAncestor = clippingAncestors[0];


### PR DESCRIPTION
Using a global cache is problematic due to the async function if you call `computePosition()` one after the other.

```js
computePosition(a, b).then(() => ...);
// Uses `a` / `b`'s cache, because it hasn't evicted
// the cache yet
computePosition(c, d).then(() => ...);
```