### PR TITLE
feat(useDismiss): allow specifying different value for outside press bubbling and escape key bubbling

### DIFF
--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -38,6 +38,7 @@ export interface Props {
   referencePressEvent?: 'pointerdown' | 'mousedown' | 'click';
   outsidePress?: boolean | ((event: MouseEvent) => boolean);
   outsidePressEvent?: 'pointerdown' | 'mousedown' | 'click';
+  outsidePressBubbles?: boolean;
   ancestorScroll?: boolean;
   bubbles?: boolean;
 }
@@ -57,6 +58,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     referencePressEvent = 'pointerdown',
     ancestorScroll = false,
     bubbles = true,
+    outsidePressBubbles = bubbles,
   }: Props = {}
 ): ElementProps => {
   const tree = useFloatingTree();
@@ -154,7 +156,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
       }
 
       if (
-        !bubbles &&
+        !outsidePressBubbles &&
         tree &&
         getChildren(tree.nodesRef.current, nodeId).length > 0
       ) {
@@ -237,6 +239,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     ancestorScroll,
     enabled,
     bubbles,
+    outsidePressBubbles,
     refs,
     nested,
   ]);

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -38,9 +38,8 @@ export interface Props {
   referencePressEvent?: 'pointerdown' | 'mousedown' | 'click';
   outsidePress?: boolean | ((event: MouseEvent) => boolean);
   outsidePressEvent?: 'pointerdown' | 'mousedown' | 'click';
-  outsidePressBubbles?: boolean;
   ancestorScroll?: boolean;
-  bubbles?: boolean;
+  bubbles?: boolean | {escapeKey?: boolean; outsidePress?: boolean};
 }
 
 /**
@@ -58,7 +57,6 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     referencePressEvent = 'pointerdown',
     ancestorScroll = false,
     bubbles = true,
-    outsidePressBubbles = bubbles,
   }: Props = {}
 ): ElementProps => {
   const tree = useFloatingTree();
@@ -73,6 +71,18 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
       ? outsidePressFn
       : unstable_outsidePress;
   const insideReactTreeRef = React.useRef(false);
+  const escapeKeyBubbles =
+    typeof bubbles === 'boolean'
+      ? bubbles
+      : bubbles.escapeKey === false
+      ? false
+      : true;
+  const outsidePressBubbles =
+    typeof bubbles === 'boolean'
+      ? bubbles
+      : bubbles.outsidePress === false
+      ? false
+      : true;
 
   React.useEffect(() => {
     if (!open || !enabled) {
@@ -82,7 +92,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
         if (
-          !bubbles &&
+          !escapeKeyBubbles &&
           tree &&
           getChildren(tree.nodesRef.current, nodeId).length > 0
         ) {
@@ -238,7 +248,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     onOpenChange,
     ancestorScroll,
     enabled,
-    bubbles,
+    escapeKeyBubbles,
     outsidePressBubbles,
     refs,
     nested,

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -24,6 +24,17 @@ const captureHandlerKeys = {
   click: 'onClickCapture',
 };
 
+export const normalizeBubblesProp = (
+  bubbles: boolean | {escapeKey?: boolean; outsidePress?: boolean} = true
+) => {
+  return {
+    escapeKeyBubbles:
+      typeof bubbles === 'boolean' ? bubbles : bubbles.escapeKey ?? true,
+    outsidePressBubbles:
+      typeof bubbles === 'boolean' ? bubbles : bubbles.outsidePress ?? true,
+  };
+};
+
 export interface DismissPayload {
   type: 'outsidePress' | 'referencePress' | 'escapeKey';
   data: {
@@ -71,11 +82,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
       ? outsidePressFn
       : unstable_outsidePress;
   const insideReactTreeRef = React.useRef(false);
-  const allBubbles = typeof bubbles === 'boolean';
-  const escapeKeyBubbles = allBubbles ? bubbles : bubbles.escapeKey ?? true;
-  const outsidePressBubbles = allBubbles
-    ? bubbles
-    : bubbles.outsidePress ?? true;
+  const {escapeKeyBubbles, outsidePressBubbles} = normalizeBubblesProp(bubbles);
 
   React.useEffect(() => {
     if (!open || !enabled) {

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -71,18 +71,11 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
       ? outsidePressFn
       : unstable_outsidePress;
   const insideReactTreeRef = React.useRef(false);
-  const escapeKeyBubbles =
-    typeof bubbles === 'boolean'
-      ? bubbles
-      : bubbles.escapeKey === false
-      ? false
-      : true;
-  const outsidePressBubbles =
-    typeof bubbles === 'boolean'
-      ? bubbles
-      : bubbles.outsidePress === false
-      ? false
-      : true;
+  const allBubbles = typeof bubbles === 'boolean';
+  const escapeKeyBubbles = allBubbles ? bubbles : bubbles.escapeKey ?? true;
+  const outsidePressBubbles = allBubbles
+    ? bubbles
+    : bubbles.outsidePress ?? true;
 
   React.useEffect(() => {
     if (!open || !enabled) {


### PR DESCRIPTION
Given a nested Popover pattern ([example](https://codesandbox.io/s/goofy-sunset-pplzyj?file=/src/Popover.tsx)), it is generally preferred to disable escape key close bubbling, as that is considered an explicit request to close the immediate open dialog (you say as much in the docs, I believe). However, the current `bubbles` flag also disabled bubbling of the outside press event. This seems counterintuitive for mouse users - if I intentionally click outside both of the open Popovers, I'd expect both of them to close as well. Currently, when disabling bubbling, it also necessitates multiple outside clicks, one for each level of open Popovers.

~~It seems like a good idea to allow configuring this for both events separately. I currently added a `outsidePressBubbles` option that inherits from the `bubbles` option. But it might be better to make it not inherit, and rename the current option to `escapeKeyBubbles` instead. I did not want to do that without an agreement, as that is a breaking change, albeit a small one.~~

This change allows specifying an object to the `bubbles` prop, to turn one or the other off specifically. Any omitted properties from the object default to `true`, i.e. the default value.

Also:
- ~~Any tests necessary for this?~~ Added tests as well.
- I'll file a separate PR for docs once this has a general approval: https://github.com/floating-ui/floating-ui/pull/2046