### PR TITLE
fix(vue): Add a type to vue arrow middleware

### DIFF
--- a/packages/vue/src/arrow.ts
+++ b/packages/vue/src/arrow.ts
@@ -13,7 +13,7 @@ export function arrow(options: ArrowOptions): Middleware {
   return {
     name: 'arrow',
     options,
-    fn(args) {
+    fn<T>(args: T) {
       const element = unwrapElement(unref(options.element));
 
       if (element == null) {


### PR DESCRIPTION
Add a type to vue arrow middleware