### PR TITLE
fix: close when unhovering focus managed floating element

### DIFF
--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -347,7 +347,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
         previouslyFocusedElementRef.current = refs.domReference.current;
       }
 
-      if (payload.type !== 'outsidePress') {
+      if (['referencePress', 'escapeKey'].includes(payload.type)) {
         return;
       }
 

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -25,7 +25,7 @@ const captureHandlerKeys = {
 };
 
 export interface DismissPayload {
-  type: 'outsidePress' | 'referencePress' | 'escapeKey';
+  type: 'outsidePress' | 'referencePress' | 'escapeKey' | 'mouseLeave';
   data: {
     returnFocus: boolean | {preventScroll: boolean};
   };

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -400,9 +400,15 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
           clearTimeout(timeoutRef.current);
         },
         onMouseLeave() {
+          events.emit('dismiss', {
+            type: 'mouseLeave',
+            data: {
+              returnFocus: false,
+            },
+          });
           closeWithDelay(false);
         },
       },
     };
-  }, [enabled, restMs, open, onOpenChange, closeWithDelay]);
+  }, [events, enabled, restMs, open, onOpenChange, closeWithDelay]);
 };

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -715,6 +715,14 @@ describe('Navigation', () => {
     await userEvent.keyboard('{Escape}');
     expect(screen.queryByText('Link 1')).not.toBeInTheDocument();
   });
+
+  test('closes when unhovering floating element even when focus is inside it', async () => {
+    render(<Navigation />);
+    await userEvent.hover(screen.getByText('Product'));
+    await userEvent.click(screen.getByTestId('subnavigation'));
+    await userEvent.unhover(screen.getByTestId('subnavigation'));
+    expect(screen.queryByTestId('subnavigation')).not.toBeInTheDocument();
+  });
 });
 
 describe('Drawer', () => {

--- a/packages/react/test/visual/components/Navigation.tsx
+++ b/packages/react/test/visual/components/Navigation.tsx
@@ -97,6 +97,7 @@ export const NavigationItem = React.forwardRef<
             initialFocus={-1}
           >
             <div
+              data-testid="subnavigation"
               ref={floating}
               className="SubNavigation"
               style={{


### PR DESCRIPTION
Another fix for hover-openable, but focus managed floating elements. The test is a bit weird perhaps, but the real problem we ran into was that when clicking the subnavigation links, then unhovering the floating element, it did not close, as would be expected. This happened because `FloatingFocusManager ` was not aware that in that scenario it should not return focus to the reference (which re-opened the floating element again).