### PR TITLE
fix(FloatingDelayGroup): default delay in context

### DIFF
--- a/packages/react/src/components/FloatingDelayGroup.tsx
+++ b/packages/react/src/components/FloatingDelayGroup.tsx
@@ -21,8 +21,8 @@ const FloatingDelayGroupContext = React.createContext<
     setState: React.Dispatch<React.SetStateAction<GroupState>>;
   }
 >({
-  delay: 1000,
-  initialDelay: 1000,
+  delay: 0,
+  initialDelay: 0,
   currentId: null,
   setCurrentId: () => {},
   setState: () => {},


### PR DESCRIPTION
Sets the default delay in the delay group context to 0, which is the same default delay used by `useHover`.

I was a bit surprised today that all my Tooltips got a delay after implementing the opt-in support for the delay group functionality. That is - I added the `useDelayGroupContext` and `useDelayGroup` hooks to my component, and I expect the delay group provider itself to be added as some outer wrapper, which I think is the expected implementation.

I think these should be 0, as in no delay, otherwise I don't understand how to default to 0. If one needs a different default delay, that's easier to implement in the custom Tooltip component that uses the hooks.