### PR TITLE
fix(hide): return options on object

### DIFF
--- a/packages/core/src/middleware/hide.ts
+++ b/packages/core/src/middleware/hide.ts
@@ -27,12 +27,13 @@ export interface Options {
  * when it is not in the same clipping context as the reference element.
  * @see https://floating-ui.com/docs/hide
  */
-export const hide = ({
-  strategy = 'referenceHidden',
-  ...detectOverflowOptions
-}: Partial<Options & DetectOverflowOptions> = {}): Middleware => ({
+export const hide = (
+  options: Partial<Options & DetectOverflowOptions> = {}
+): Middleware => ({
   name: 'hide',
+  options,
   async fn(middlewareArguments) {
+    const {strategy = 'referenceHidden', ...detectOverflowOptions} = options;
     const {rects} = middlewareArguments;
 
     switch (strategy) {


### PR DESCRIPTION
This middleware is missing `options` returned on the object, so it can't be updated either conditionally with state, or via Fast Refresh.