### PR TITLE
feat(react): `useMergeRefs` hook

### DIFF
--- a/packages/react/index.test-d.tsx
+++ b/packages/react/index.test-d.tsx
@@ -12,6 +12,7 @@ import {
   useListNavigation,
   useTypeahead,
   safePolygon,
+  useMergeRefs,
 } from '.';
 
 App;
@@ -47,7 +48,12 @@ function App() {
   reference(null);
   floating(null);
   update();
-  return <div ref={arrowRef} />;
+
+  const ref1 = useRef<HTMLDivElement>(null);
+  const ref2 = useRef<HTMLDivElement>(null);
+  const ref = useMergeRefs([ref1, ref2, arrowRef, null]);
+
+  return <div ref={ref} />;
 }
 
 NarrowRefType;

--- a/packages/react/src/hooks/useMergeRefs.ts
+++ b/packages/react/src/hooks/useMergeRefs.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export function useMergeRefs<Instance>(
-  refs: Array<React.Ref<Instance> | undefined>
+  refs: Array<React.Ref<Instance>>
 ): React.RefCallback<Instance> | null {
   return React.useMemo(() => {
     if (refs.every((ref) => ref == null)) {

--- a/packages/react/src/hooks/useMergeRefs.ts
+++ b/packages/react/src/hooks/useMergeRefs.ts
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+export function useMergeRefs<Instance>(
+  refs: Array<React.Ref<Instance> | undefined>
+): React.RefCallback<Instance> | null {
+  return React.useMemo(() => {
+    if (refs.every((ref) => ref == null)) {
+      return null;
+    }
+
+    return (value) => {
+      refs.forEach((ref) => {
+        if (typeof ref === 'function') {
+          ref(value);
+        } else if (ref != null) {
+          (ref as React.MutableRefObject<Instance | null>).current = value;
+        }
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, refs);
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,3 +30,4 @@ export {useFocus} from './hooks/useFocus';
 export {useHover} from './hooks/useHover';
 export {useListNavigation} from './hooks/useListNavigation';
 export {useTypeahead} from './hooks/useTypeahead';
+export {useMergeRefs} from './hooks/useMergeRefs';

--- a/packages/react/test/unit/useMergeRefs.test.tsx
+++ b/packages/react/test/unit/useMergeRefs.test.tsx
@@ -1,0 +1,63 @@
+import {render} from '@testing-library/react';
+import * as React from 'react';
+import {useMergeRefs} from '../../src/hooks/useMergeRefs';
+
+test('merges refs and cleans up', () => {
+  const callbackSpy = jest.fn();
+  let refSpy: HTMLElement | null = null;
+
+  function App({show}: {show: boolean}) {
+    const ref1 = React.useRef<HTMLDivElement>(null);
+    const ref2 = React.useCallback(callbackSpy, []);
+    const ref = useMergeRefs([ref1, ref2]);
+
+    React.useLayoutEffect(() => {
+      refSpy = ref1.current;
+    }, [show]);
+
+    return show ? <div id="test" ref={ref} /> : null;
+  }
+
+  const {rerender} = render(<App show />);
+
+  // @ts-expect-error
+  expect(refSpy?.id).toBe('test');
+  expect(callbackSpy.mock.calls[0][0]?.id).toBe('test');
+  callbackSpy.mockReset();
+
+  rerender(<App show={false} />);
+
+  expect(refSpy).toBe(null);
+  expect(callbackSpy.mock.calls[0][0]).toBe(null);
+});
+
+test('conditional refs', () => {
+  const callbackSpy = jest.fn();
+  const callbackSpy2 = jest.fn();
+  const callbackSpy3 = jest.fn();
+
+  function App({change}: {change: boolean}) {
+    const ref1 = React.useCallback(callbackSpy, []);
+    const ref2 = React.useCallback(callbackSpy2, []);
+    const ref3 = React.useCallback(callbackSpy3, []);
+    const ref = useMergeRefs([ref1, change ? ref3 : ref2]);
+
+    return <div id="test" ref={ref} />;
+  }
+
+  const {rerender} = render(<App change={false} />);
+
+  expect(callbackSpy.mock.calls[0][0]?.id).toBe('test');
+  expect(callbackSpy2.mock.calls[0][0]?.id).toBe('test');
+  expect(callbackSpy3.mock.calls.length).toBe(0);
+  callbackSpy.mockReset();
+  callbackSpy2.mockReset();
+
+  rerender(<App change={true} />);
+
+  expect(callbackSpy.mock.calls[0][0]).toBe(null);
+  expect(callbackSpy2.mock.calls[0][0]).toBe(null);
+  expect(callbackSpy.mock.calls[1][0]?.id).toBe('test');
+  expect(callbackSpy2.mock.calls.length).toBe(1);
+  expect(callbackSpy3.mock.calls[0][0]?.id).toBe('test');
+});


### PR DESCRIPTION
The reusable component examples currently require an external lib, and by default it doesn't memo the value - a dedicated hook should be exported from the package to use.