### PR TITLE
feat: `positionReference` callback ref

### DIFF
--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -79,6 +79,7 @@ export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =
     update: () => void;
     reference: (node: RT | null) => void;
     floating: (node: HTMLElement | null) => void;
+    positionReference: (node: RT | null) => void;
     context: FloatingContext<RT>;
     refs: ExtendedRefs<RT>;
   };

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -94,10 +94,9 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
           : node
       ) as RT;
 
-      context.refs.reference.current = positionReference;
       reference(positionReference);
     },
-    [reference, context.refs]
+    [reference]
   );
 
   return React.useMemo(

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -73,7 +73,29 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
         setDomReference(node);
       }
 
-      reference(node);
+      if (
+        context.refs.reference.current === null ||
+        isElement(context.refs.reference.current)
+      ) {
+        reference(node);
+      }
+    },
+    [reference, context.refs]
+  );
+
+  const setPositionReference = React.useCallback(
+    (node: RT | null) => {
+      const positionReference = (
+        isElement(node)
+          ? {
+              getBoundingClientRect: () => node.getBoundingClientRect(),
+              contextElement: node,
+            }
+          : node
+      ) as RT;
+
+      context.refs.reference.current = positionReference;
+      reference(positionReference);
     },
     [reference, context.refs]
   );
@@ -84,7 +106,8 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       context,
       refs,
       reference: setReference,
+      positionReference: setPositionReference,
     }),
-    [position, refs, context, setReference]
+    [position, refs, context, setReference, setPositionReference]
   );
 }

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -92,7 +92,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
               contextElement: node,
             }
           : node
-      ) as RT;
+      ) as RT | null;
 
       reference(positionReference);
     },

--- a/packages/react/test/unit/useFloating.test.tsx
+++ b/packages/react/test/unit/useFloating.test.tsx
@@ -1,0 +1,109 @@
+import {render} from '@testing-library/react';
+import {useLayoutEffect} from 'react';
+import {useFloating} from '../../src';
+import {isElement} from '../../src/utils/is';
+
+describe('positionReference', () => {
+  test('sets separate refs', () => {
+    function App() {
+      const {reference, positionReference, refs} =
+        useFloating<HTMLDivElement>();
+
+      return (
+        <>
+          <div ref={reference} data-testid="reference" />
+          <div ref={positionReference} data-testid="position-reference" />
+          <div data-testid="reference-text">
+            {String(refs.domReference.current?.getAttribute('data-testid'))}
+          </div>
+          <div data-testid="position-reference-text">
+            {String(isElement(refs.reference.current))}
+          </div>
+        </>
+      );
+    }
+
+    const {getByTestId, rerender} = render(<App />);
+
+    expect(getByTestId('reference-text').textContent).toBe('reference');
+    expect(getByTestId('position-reference-text').textContent).toBe('false');
+
+    rerender(<App />);
+
+    expect(getByTestId('reference-text').textContent).toBe('reference');
+    expect(getByTestId('position-reference-text').textContent).toBe('false');
+  });
+
+  test('handles unstable reference prop', () => {
+    function App() {
+      const {reference, positionReference, refs} =
+        useFloating<HTMLDivElement>();
+
+      return (
+        <>
+          <div ref={(node) => reference(node)} data-testid="reference" />
+          <div ref={positionReference} data-testid="position-reference" />
+          <div data-testid="reference-text">
+            {String(refs.domReference.current?.getAttribute('data-testid'))}
+          </div>
+          <div data-testid="position-reference-text">
+            {String(isElement(refs.reference.current))}
+          </div>
+        </>
+      );
+    }
+
+    const {getByTestId, rerender} = render(<App />);
+
+    expect(getByTestId('reference-text').textContent).toBe('reference');
+    expect(getByTestId('position-reference-text').textContent).toBe('false');
+
+    rerender(<App />);
+
+    expect(getByTestId('reference-text').textContent).toBe('reference');
+    expect(getByTestId('position-reference-text').textContent).toBe('false');
+  });
+
+  test('handles real virtual element', () => {
+    function App() {
+      const {reference, positionReference, refs} = useFloating();
+
+      useLayoutEffect(() => {
+        positionReference({
+          getBoundingClientRect: () => ({
+            x: 218,
+            y: 0,
+            width: 0,
+            height: 0,
+            left: 0,
+            right: 0,
+            top: 0,
+            bottom: 0,
+          }),
+        });
+      }, [positionReference]);
+
+      return (
+        <>
+          <div ref={(node) => reference(node)} data-testid="reference" />
+          <div data-testid="reference-text">
+            {String(refs.domReference.current?.getAttribute('data-testid'))}
+          </div>
+          <div data-testid="position-reference-text">
+            {refs.reference.current?.getBoundingClientRect().x}
+          </div>
+        </>
+      );
+    }
+
+    const {getByTestId, rerender} = render(<App />);
+
+    expect(getByTestId('reference-text').textContent).toBe('reference');
+    expect(getByTestId('position-reference-text').textContent).toBe('218');
+
+    rerender(<App />);
+
+    expect(getByTestId('reference-text').textContent).toBe('reference');
+    expect(getByTestId('position-reference-text').textContent).toBe('218');
+  });
+});


### PR DESCRIPTION
Closes #1991

Right now to use a custom position reference, you call `reference()` _after_  it has set the DOM reference (e.g. in an effect), but if the `ref` prop is not stable, such as with an external library, this means it can overwrite the virtual element and is generally not reliable.
 
This returns a new callback ref, `positionReference` for this purpose. It can accept either a real element or a virtual element. Under the hood it normalizes it into a virtual element.

If `positionReference` isn't used, then `reference` is used as both the position and events reference as expected.

```js
const {reference, positionReference} = useFloating();

return <>
  <div ref={reference} />
  <div ref={positionReference} />
</>;
```

When both are used:
- `refs.reference.current === positionReference`
- `refs.domReference.current === reference`