### PR TITLE
fix(FloatingFocusManager): always consider focus guards as related targets

### DIFF
--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -200,12 +200,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
         contains(floating, relatedTarget) ||
         contains(relatedTarget, floating) ||
         contains(portalContext?.portalNode, relatedTarget) ||
-        [
-          portalContext?.beforeOutsideRef.current,
-          portalContext?.afterOutsideRef.current,
-        ]
-          .filter(Boolean)
-          .includes(relatedTarget as HTMLSpanElement | null) ||
+        relatedTarget?.hasAttribute('data-floating-ui-focus-guard') ||
         (tree &&
           (getChildren(tree.nodesRef.current, nodeId).find(
             (node) =>


### PR DESCRIPTION
Fixes #2039

I'm not sure if focus hitting a guard shouldn't ever be considered "unrelated" @mihkeleidast 