### PR TITLE
fix(safePolygon): use real polygon to block pointer events

### DIFF
--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -218,6 +218,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
           x: event.clientX,
           y: event.clientY,
           onClose() {
+            removePolygon();
             cleanupMouseMoveHandler();
             closeWithDelay();
           },
@@ -246,6 +247,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         y: event.clientY,
         leave: true,
         onClose() {
+          removePolygon();
           cleanupMouseMoveHandler();
           closeWithDelay();
         },
@@ -288,6 +290,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     delayRef,
     handleCloseRef,
     dataRef,
+    removePolygon,
   ]);
 
   useLayoutEffect(() => {

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
-import {
-  useFloatingParentNodeId,
-  useFloatingTree,
-} from '../components/FloatingTree';
+import {useFloatingTree} from '../components/FloatingTree';
 import type {
   ElementProps,
   FloatingContext,
@@ -14,17 +11,15 @@ import {getDocument} from '../utils/getDocument';
 import {isElement} from '../utils/is';
 import {useLatestRef} from './utils/useLatestRef';
 
-interface HandleCloseFn<RT extends ReferenceType = ReferenceType> {
+export interface HandleCloseFn<RT extends ReferenceType = ReferenceType> {
   (
     context: FloatingContext<RT> & {
       onClose: () => void;
       tree?: FloatingTreeType<RT> | null;
       leave?: boolean;
+      polygonRef: React.MutableRefObject<SVGElement | null>;
     }
   ): (event: MouseEvent) => void;
-  __options: {
-    blockPointerEvents: boolean;
-  };
 }
 
 // On some Linux machines with Chromium, mouse inputs return a `pointerType` of
@@ -74,7 +69,6 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
   const {open, onOpenChange, dataRef, events, refs, _} = context;
 
   const tree = useFloatingTree<RT>();
-  const parentId = useFloatingParentNodeId();
   const handleCloseRef = useLatestRef(handleClose);
   const delayRef = useLatestRef(delay);
 
@@ -83,12 +77,17 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
   const handlerRef = React.useRef<(event: MouseEvent) => void>();
   const restTimeoutRef = React.useRef<any>();
   const blockMouseMoveRef = React.useRef(true);
-  const performedPointerEventsMutationRef = React.useRef(false);
+  const polygonRef = React.useRef<SVGElement | null>(null);
 
   const isHoverOpen = React.useCallback(() => {
     const type = dataRef.current.openEvent?.type;
     return type?.includes('mouse') && type !== 'mousedown';
   }, [dataRef]);
+
+  const removePolygon = React.useCallback(() => {
+    polygonRef.current?.remove();
+    polygonRef.current = null;
+  }, []);
 
   // When dismissing before opening, clear the delay timeouts to cancel it
   // from showing.
@@ -155,11 +154,6 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     }
   }, [refs]);
 
-  const clearPointerEvents = React.useCallback(() => {
-    getDocument(refs.floating.current).body.style.pointerEvents = '';
-    performedPointerEventsMutationRef.current = false;
-  }, [refs]);
-
   // Registering the mouse events on the reference directly to bypass React's
   // delegation system. If the cursor was on a disabled element and then entered
   // the reference (no gap), `mouseenter` doesn't fire in the delegation system.
@@ -220,10 +214,10 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         handlerRef.current = handleCloseRef.current({
           ...context,
           tree,
+          polygonRef,
           x: event.clientX,
           y: event.clientY,
           onClose() {
-            clearPointerEvents();
             cleanupMouseMoveHandler();
             closeWithDelay();
           },
@@ -247,11 +241,11 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       handleCloseRef.current?.({
         ...context,
         tree,
+        polygonRef,
         x: event.clientX,
         y: event.clientY,
         leave: true,
         onClose() {
-          clearPointerEvents();
           cleanupMouseMoveHandler();
           closeWithDelay();
         },
@@ -287,7 +281,6 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     move,
     closeWithDelay,
     cleanupMouseMoveHandler,
-    clearPointerEvents,
     onOpenChange,
     open,
     tree,
@@ -297,77 +290,22 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     dataRef,
   ]);
 
-  // Block pointer-events of every element other than the reference and floating
-  // while the floating element is open and has a `handleClose` handler. Also
-  // handles nested floating elements.
-  // https://github.com/floating-ui/floating-ui/issues/1722
-  useLayoutEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
-    if (
-      open &&
-      handleCloseRef.current &&
-      handleCloseRef.current.__options.blockPointerEvents &&
-      isHoverOpen()
-    ) {
-      getDocument(refs.floating.current).body.style.pointerEvents = 'none';
-      performedPointerEventsMutationRef.current = true;
-      const reference = refs.domReference.current;
-      const floating = refs.floating.current;
-
-      if (isElement(reference) && floating) {
-        const parentFloating = tree?.nodesRef.current.find(
-          (node) => node.id === parentId
-        )?.context?.refs.floating.current;
-
-        if (parentFloating) {
-          parentFloating.style.pointerEvents = '';
-        }
-
-        reference.style.pointerEvents = 'auto';
-        floating.style.pointerEvents = 'auto';
-
-        return () => {
-          reference.style.pointerEvents = '';
-          floating.style.pointerEvents = '';
-        };
-      }
-    }
-  }, [
-    enabled,
-    open,
-    parentId,
-    refs,
-    tree,
-    handleCloseRef,
-    dataRef,
-    isHoverOpen,
-  ]);
-
   useLayoutEffect(() => {
     if (!open) {
       pointerTypeRef.current = undefined;
       cleanupMouseMoveHandler();
-
-      if (performedPointerEventsMutationRef.current) {
-        clearPointerEvents();
-      }
+      removePolygon();
     }
-  }, [open, cleanupMouseMoveHandler, clearPointerEvents]);
+  }, [open, cleanupMouseMoveHandler, removePolygon]);
 
   React.useEffect(() => {
     return () => {
       cleanupMouseMoveHandler();
       clearTimeout(timeoutRef.current);
       clearTimeout(restTimeoutRef.current);
-
-      if (performedPointerEventsMutationRef.current) {
-        clearPointerEvents();
-      }
+      removePolygon();
     };
-  }, [enabled, cleanupMouseMoveHandler, clearPointerEvents]);
+  }, [enabled, cleanupMouseMoveHandler, removePolygon]);
 
   return React.useMemo(() => {
     if (!enabled) {

--- a/packages/react/src/safePolygon.ts
+++ b/packages/react/src/safePolygon.ts
@@ -1,5 +1,5 @@
 import type {Side} from '@floating-ui/core';
-import type {ReferenceType} from '@floating-ui/react-dom';
+import type {ReferenceType} from './types';
 import type {HandleCloseFn} from './hooks/useHover';
 import {contains} from './utils/contains';
 import {getChildren} from './utils/getChildren';

--- a/packages/react/src/safePolygon.ts
+++ b/packages/react/src/safePolygon.ts
@@ -37,6 +37,7 @@ function createPolygonElement(points: Point[], doc: Document) {
     width: '100%',
     height: '100%',
     pointerEvents: 'none',
+    zIndex: 2147483647,
   });
 
   const polygon = doc.createElementNS(svgNs, 'polygon');

--- a/packages/react/src/safePolygon.ts
+++ b/packages/react/src/safePolygon.ts
@@ -25,27 +25,22 @@ function isPointInPolygon(point: Point, polygon: Polygon) {
   return isInside;
 }
 
+const svgNs = 'http://www.w3.org/2000/svg';
+
 function createPolygonElement(points: Point[]) {
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  const svg = document.createElementNS(svgNs, 'svg');
   Object.assign(svg.style, {
     position: 'fixed',
     left: 0,
     top: 0,
-    pointerEvents: 'none',
     width: '100%',
     height: '100%',
+    pointerEvents: 'none',
   });
 
-  const polygon = document.createElementNS(
-    'http://www.w3.org/2000/svg',
-    'polygon'
-  );
+  const polygon = document.createElementNS(svgNs, 'polygon');
   polygon.setAttribute('points', points.map(([x, y]) => `${x},${y}`).join(' '));
-  Object.assign(polygon.style, {
-    fill: 'red',
-    opacity: 0.1,
-    pointerEvents: 'auto',
-  });
+  polygon.style.pointerEvents = 'auto';
 
   svg.appendChild(polygon);
 

--- a/packages/react/src/safePolygon.ts
+++ b/packages/react/src/safePolygon.ts
@@ -3,6 +3,7 @@ import type {ReferenceType} from '@floating-ui/react-dom';
 import type {HandleCloseFn} from './hooks/useHover';
 import {contains} from './utils/contains';
 import {getChildren} from './utils/getChildren';
+import {getDocument} from './utils/getDocument';
 import {getTarget} from './utils/getTarget';
 import {isElement} from './utils/is';
 
@@ -27,8 +28,8 @@ function isPointInPolygon(point: Point, polygon: Polygon) {
 
 const svgNs = 'http://www.w3.org/2000/svg';
 
-function createPolygonElement(points: Point[]) {
-  const svg = document.createElementNS(svgNs, 'svg');
+function createPolygonElement(points: Point[], doc: Document) {
+  const svg = doc.createElementNS(svgNs, 'svg');
   Object.assign(svg.style, {
     position: 'fixed',
     left: 0,
@@ -38,7 +39,7 @@ function createPolygonElement(points: Point[]) {
     pointerEvents: 'none',
   });
 
-  const polygon = document.createElementNS(svgNs, 'polygon');
+  const polygon = doc.createElementNS(svgNs, 'polygon');
   polygon.setAttribute('points', points.map(([x, y]) => `${x},${y}`).join(' '));
   polygon.style.pointerEvents = 'auto';
 
@@ -359,8 +360,9 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
       const poly = getPolygon([x, y]);
 
       if (!polygonRef.current && blockPointerEvents && leave) {
-        polygonRef.current = createPolygonElement(poly);
-        document.body.appendChild(polygonRef.current);
+        const doc = getDocument(refs.floating.current);
+        polygonRef.current = createPolygonElement(poly, doc);
+        doc.body.appendChild(polygonRef.current);
       }
 
       if (!isPointInPolygon([clientX, clientY], poly)) {

--- a/packages/react/src/safePolygon.ts
+++ b/packages/react/src/safePolygon.ts
@@ -41,7 +41,10 @@ function createPolygonElement(points: Point[], doc: Document) {
 
   const polygon = doc.createElementNS(svgNs, 'polygon');
   polygon.setAttribute('points', points.map(([x, y]) => `${x},${y}`).join(' '));
-  polygon.style.pointerEvents = 'auto';
+  Object.assign(polygon.style, {
+    pointerEvents: 'auto',
+    fill: 'transparent',
+  });
 
   svg.appendChild(polygon);
 

--- a/packages/react/test/unit/useInteractions.test.tsx
+++ b/packages/react/test/unit/useInteractions.test.tsx
@@ -88,7 +88,6 @@ test('prop getters are memoized', () => {
     c;
 
     const handleClose = () => () => {};
-    handleClose.__options = {blockPointerEvents: false};
 
     const listRef = useRef([]);
     const overflowRef = useRef({top: 0, left: 0, bottom: 0, right: 0});


### PR DESCRIPTION
Supersedes #1814 
Fixes #1811

Bypassing React's DOM rendering fixes the issue in Firefox