### PR TITLE
fix(isOverflowElement): check for `clip` value

### DIFF
--- a/packages/dom/src/utils/is.ts
+++ b/packages/dom/src/utils/is.ts
@@ -35,10 +35,9 @@ export function isShadowRoot(node: Node): node is ShadowRoot {
 }
 
 export function isOverflowElement(element: Element): boolean {
-  // Firefox wants us to check `-x` and `-y` variations as well
-  const {overflow, overflowX, overflowY, display} = getComputedStyle(element);
+  const {overflowX, overflowY, display} = getComputedStyle(element);
   return (
-    /auto|scroll|overlay|hidden/.test(overflow + overflowY + overflowX) &&
+    /auto|scroll|overlay|hidden|clip/.test(overflowY + overflowX) &&
     !['inline', 'contents'].includes(display)
   );
 }

--- a/packages/dom/src/utils/is.ts
+++ b/packages/dom/src/utils/is.ts
@@ -35,9 +35,9 @@ export function isShadowRoot(node: Node): node is ShadowRoot {
 }
 
 export function isOverflowElement(element: Element): boolean {
-  const {overflowX, overflowY, display} = getComputedStyle(element);
+  const {overflow, overflowX, overflowY, display} = getComputedStyle(element);
   return (
-    /auto|scroll|overlay|hidden|clip/.test(overflowY + overflowX) &&
+    /auto|scroll|overlay|hidden|clip/.test(overflow + overflowY + overflowX) &&
     !['inline', 'contents'].includes(display)
   );
 }


### PR DESCRIPTION
Relatively new CSS value for `overflow`. Also, remove the `overflow` check because it's `{x} {y}` and is redundant to check.