### PR TITLE
fix(autoPlacement): preserve explicit `allowedPlacements`

### DIFF
--- a/packages/core/src/middleware/autoPlacement.ts
+++ b/packages/core/src/middleware/autoPlacement.ts
@@ -42,7 +42,7 @@ export function getPlacementList(
 export interface Options {
   /**
    * Choose placements with a particular alignment.
-   * @default null
+   * @default undefined
    */
   alignment: Alignment | null;
   /**
@@ -80,8 +80,8 @@ export const autoPlacement = (
     } = options;
 
     const placements =
-      alignment !== undefined
-        ? getPlacementList(alignment, autoAlignment, allowedPlacements)
+      alignment !== undefined || allowedPlacements === allPlacements
+        ? getPlacementList(alignment || null, autoAlignment, allowedPlacements)
         : allowedPlacements;
 
     const overflow = await detectOverflow(

--- a/packages/core/src/middleware/autoPlacement.ts
+++ b/packages/core/src/middleware/autoPlacement.ts
@@ -73,17 +73,16 @@ export const autoPlacement = (
       middlewareArguments;
 
     const {
-      alignment = null,
+      alignment,
       allowedPlacements = allPlacements,
       autoAlignment = true,
       ...detectOverflowOptions
     } = options;
 
-    const placements = getPlacementList(
-      alignment,
-      autoAlignment,
-      allowedPlacements
-    );
+    const placements =
+      alignment !== undefined
+        ? getPlacementList(alignment, autoAlignment, allowedPlacements)
+        : allowedPlacements;
 
     const overflow = await detectOverflow(
       middlewareArguments,


### PR DESCRIPTION
Fixes #2072

If the user doesn't explicitly specify `alignment`, then we should always respect the `allowedPlacements` that get passed in. If they do, then it should filter out unsupported placements as before.