### PR TITLE
fix: size modifier side check in calculations

### DIFF
--- a/packages/core/src/middleware/size.ts
+++ b/packages/core/src/middleware/size.ts
@@ -66,7 +66,7 @@ export const size = (
     const dimensions = {
       availableHeight:
         rects.floating.height -
-        (['left', 'right'].includes(placement)
+        (['left', 'right'].includes(side)
           ? 2 *
             (yMin !== 0 || yMax !== 0
               ? yMin + yMax
@@ -74,7 +74,7 @@ export const size = (
           : overflow[heightSide]),
       availableWidth:
         rects.floating.width -
-        (['top', 'bottom'].includes(placement)
+        (['top', 'bottom'].includes(side)
           ? 2 *
             (xMin !== 0 || xMax !== 0
               ? xMin + xMax


### PR DESCRIPTION
Hi,

I just noticed there's a little 🐛 crawling around here.
`placement` represented as a string `{side}-{alignment}`, so searching that in `[left, right, top, bottom]` will not work as expected.
I replaced it with just the `side` variable, that is more appropriate for that union.