### PR TITLE
refactor: replace nullish coalescing where possible

### DIFF
--- a/packages/core/src/middleware/arrow.ts
+++ b/packages/core/src/middleware/arrow.ts
@@ -29,7 +29,7 @@ export const arrow = (options: Options): Middleware => ({
   options,
   async fn(middlewareArguments) {
     // Since `element` is required, we don't Partial<> the type
-    const {element, padding = 0} = options ?? {};
+    const {element, padding = 0} = options || {};
     const {x, y, placement, rects, platform} = middlewareArguments;
 
     if (element == null) {

--- a/packages/core/src/middleware/autoPlacement.ts
+++ b/packages/core/src/middleware/autoPlacement.ts
@@ -89,7 +89,7 @@ export const autoPlacement = (
       detectOverflowOptions
     );
 
-    const currentIndex = middlewareData.autoPlacement?.index ?? 0;
+    const currentIndex = middlewareData.autoPlacement?.index || 0;
     const currentPlacement = placements[currentIndex];
 
     if (currentPlacement == null) {
@@ -120,7 +120,7 @@ export const autoPlacement = (
     ];
 
     const allOverflows = [
-      ...(middlewareData.autoPlacement?.overflows ?? []),
+      ...(middlewareData.autoPlacement?.overflows || []),
       {placement: currentPlacement, overflows: currentOverflows},
     ];
 

--- a/packages/core/src/middleware/flip.ts
+++ b/packages/core/src/middleware/flip.ts
@@ -102,7 +102,7 @@ export const flip = (
 
     // One or more sides is overflowing
     if (!overflows.every((side) => side <= 0)) {
-      const nextIndex = (middlewareData.flip?.index ?? 0) + 1;
+      const nextIndex = (middlewareData.flip?.index || 0) + 1;
       const nextPlacement = placements[nextIndex];
 
       if (nextPlacement) {

--- a/packages/core/src/middleware/inline.ts
+++ b/packages/core/src/middleware/inline.ts
@@ -51,7 +51,7 @@ export const inline = (options: Partial<Options> = {}): Middleware => ({
         : rects.reference
     );
     const clientRects =
-      (await platform.getClientRects?.(elements.reference)) ?? [];
+      (await platform.getClientRects?.(elements.reference)) || [];
     const paddingObject = getSideObjectFromPadding(padding);
 
     function getBoundingClientRect() {
@@ -70,7 +70,7 @@ export const inline = (options: Partial<Options> = {}): Middleware => ({
               x < rect.right + paddingObject.right &&
               y > rect.top - paddingObject.top &&
               y < rect.bottom + paddingObject.bottom
-          ) ?? fallback
+          ) || fallback
         );
       }
 

--- a/packages/core/src/middleware/shift.ts
+++ b/packages/core/src/middleware/shift.ts
@@ -197,12 +197,12 @@ export const limitShift = (
       const limitMin =
         rects.reference[crossAxis] -
         rects.floating[len] +
-        (isOriginSide ? middlewareData.offset?.[crossAxis] ?? 0 : 0) +
+        (isOriginSide ? middlewareData.offset?.[crossAxis] || 0 : 0) +
         (isOriginSide ? 0 : computedOffset.crossAxis);
       const limitMax =
         rects.reference[crossAxis] +
         rects.reference[len] +
-        (isOriginSide ? 0 : middlewareData.offset?.[crossAxis] ?? 0) -
+        (isOriginSide ? 0 : middlewareData.offset?.[crossAxis] || 0) -
         (isOriginSide ? computedOffset.crossAxis : 0);
 
       if (crossAxisCoord < limitMin) {

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -251,7 +251,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     const portalNodes = Array.from(
       portalContext?.portalNode?.querySelectorAll(
         '[data-floating-ui-portal]'
-      ) ?? []
+      ) || []
     );
 
     function getDismissButtons() {

--- a/packages/react/src/components/FloatingOverlay.tsx
+++ b/packages/react/src/components/FloatingOverlay.tsx
@@ -53,8 +53,8 @@ export const FloatingOverlay = React.forwardRef<
     }
 
     // iOS 12 does not support `visualViewport`.
-    const offsetLeft = window.visualViewport?.offsetLeft ?? 0;
-    const offsetTop = window.visualViewport?.offsetTop ?? 0;
+    const offsetLeft = window.visualViewport?.offsetLeft || 0;
+    const offsetTop = window.visualViewport?.offsetTop || 0;
     const scrollX = window.pageXOffset;
     const scrollY = window.pageYOffset;
 

--- a/packages/react/src/components/FloatingTree.tsx
+++ b/packages/react/src/components/FloatingTree.tsx
@@ -8,7 +8,7 @@ const FloatingNodeContext = React.createContext<FloatingNodeType | null>(null);
 const FloatingTreeContext = React.createContext<FloatingTreeType | null>(null);
 
 export const useFloatingParentNodeId = (): string | null =>
-  React.useContext(FloatingNodeContext)?.id ?? null;
+  React.useContext(FloatingNodeContext)?.id || null;
 export const useFloatingTree = <
   RT extends ReferenceType = ReferenceType
 >(): FloatingTreeType<RT> | null =>

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -128,7 +128,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
 
       // Check if the click occurred on the scrollbar
       if (isElement(target) && refs.floating.current) {
-        const win = refs.floating.current.ownerDocument.defaultView ?? window;
+        const win = refs.floating.current.ownerDocument.defaultView || window;
         const canScrollX = target.scrollWidth > target.clientWidth;
         const canScrollY = target.scrollHeight > target.clientHeight;
 

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -30,7 +30,7 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
     }
 
     const doc = getDocument(refs.floating.current);
-    const win = doc.defaultView ?? window;
+    const win = doc.defaultView || window;
 
     // If the reference was focused and the user left the tab/window, and the
     // floating element was not open, the focus should be blocked when they

--- a/packages/react/src/hooks/useId.ts
+++ b/packages/react/src/hooks/useId.ts
@@ -35,4 +35,4 @@ const useReactId = (React as any)['useId'.toString()] as () => string;
  * earlier React versions.
  * @see https://floating-ui.com/docs/useId
  */
-export const useId = useReactId ?? useFloatingId;
+export const useId = useReactId || useFloatingId;

--- a/packages/react/src/hooks/useTypeahead.ts
+++ b/packages/react/src/hooks/useTypeahead.ts
@@ -146,8 +146,8 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
       const prevIndex = prevIndexRef.current;
 
       const orderedList = [
-        ...listContent.slice((prevIndex ?? 0) + 1),
-        ...listContent.slice(0, (prevIndex ?? 0) + 1),
+        ...listContent.slice((prevIndex || 0) + 1),
+        ...listContent.slice(0, (prevIndex || 0) + 1),
       ];
 
       const str = findMatchRef.current

--- a/packages/react/src/inner.ts
+++ b/packages/react/src/inner.ts
@@ -87,7 +87,7 @@ export const inner = (
       ).fn(middlewareArguments)),
     };
 
-    const el = scrollRef?.current ?? floating;
+    const el = scrollRef?.current || floating;
 
     const overflow = await detectOverflow(
       getArgsWithCustomFloatingHeight(nextArgs, el.scrollHeight),
@@ -193,7 +193,7 @@ export const useInnerOffset = (
       }
     }
 
-    const el = scrollRef?.current ?? refs.floating.current;
+    const el = scrollRef?.current || refs.floating.current;
 
     if (open && el) {
       el.addEventListener('wheel', onWheel);

--- a/packages/react/src/utils/getChildren.ts
+++ b/packages/react/src/utils/getChildren.ts
@@ -5,7 +5,7 @@ export function getChildren<RT extends ReferenceType = ReferenceType>(
   id: string | undefined
 ) {
   let allChildren =
-    nodes.filter((node) => node.parentId === id && node.context?.open) ?? [];
+    nodes.filter((node) => node.parentId === id && node.context?.open) || [];
   let currentChildren = allChildren;
 
   while (currentChildren.length) {
@@ -14,7 +14,7 @@ export function getChildren<RT extends ReferenceType = ReferenceType>(
         currentChildren?.some(
           (n) => node.parentId === n.id && node.context?.open
         )
-      ) ?? [];
+      ) || [];
 
     allChildren = allChildren.concat(currentChildren);
   }

--- a/packages/react/src/utils/getDocument.ts
+++ b/packages/react/src/utils/getDocument.ts
@@ -1,3 +1,3 @@
 export function getDocument(floating: HTMLElement | null) {
-  return floating?.ownerDocument ?? document;
+  return floating?.ownerDocument || document;
 }

--- a/packages/react/src/utils/is.ts
+++ b/packages/react/src/utils/is.ts
@@ -2,7 +2,7 @@ import {getDocument} from './getDocument';
 import {getPlatform, getUserAgent} from './getPlatform';
 
 function getWindow(value: any) {
-  return getDocument(value).defaultView ?? window;
+  return getDocument(value).defaultView || window;
 }
 
 export function isElement(value: any): value is HTMLElement {

--- a/packages/react/src/utils/tabbable.ts
+++ b/packages/react/src/utils/tabbable.ts
@@ -53,7 +53,7 @@ export function isOutsideEvent(
 export function disableFocusInside(container: HTMLElement) {
   const tabbableElements = tabbable(container, getTabbableOptions());
   tabbableElements.forEach((element) => {
-    element.dataset.tabindex = element.getAttribute('tabindex') ?? '';
+    element.dataset.tabindex = element.getAttribute('tabindex') || '';
     element.setAttribute('tabindex', '-1');
   });
 }


### PR DESCRIPTION
In each of these places it has no benefit over `||` but transpiles to something much larger, so this just reduces the bundle size cost of the operator.