### PR TITLE
fix(react-dom): re-allow unstable ref callbacks

### DIFF
--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -98,16 +98,20 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
 
   const setReference: UseFloatingReturn<RT>['reference'] = React.useCallback(
     (node) => {
-      reference.current = node;
-      runElementMountCallback();
+      if (reference.current !== node) {
+        reference.current = node;
+        runElementMountCallback();
+      }
     },
     [runElementMountCallback]
   );
 
   const setFloating: UseFloatingReturn<RT>['floating'] = React.useCallback(
     (node) => {
-      floating.current = node;
-      runElementMountCallback();
+      if (floating.current !== node) {
+        floating.current = node;
+        runElementMountCallback();
+      }
     },
     [runElementMountCallback]
   );

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -51,8 +51,8 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       placement,
       strategy,
     }).then((data) => {
-      if (isMountedRef.current && !deepEqual(dataRef.current, data)) {
-        const value = {...data, isPositioned: true};
+      const value = {...data, isPositioned: true};
+      if (isMountedRef.current && !deepEqual(dataRef.current, value)) {
         dataRef.current = value;
         ReactDOM.flushSync(() => {
           setData(value);

--- a/packages/react-dom/test/index.test.tsx
+++ b/packages/react-dom/test/index.test.tsx
@@ -1,8 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import {act,cleanup, fireEvent, render, screen} from '@testing-library/react';
-import {useEffect,useRef, useState} from 'react';
+import {act, cleanup, fireEvent, render, screen} from '@testing-library/react';
+import {useEffect, useRef, useState} from 'react';
 
 import {
   arrow,
@@ -260,4 +260,48 @@ describe('whileElementsMounted', () => {
 
     cleanup();
   });
+});
+
+test('unstable callback refs', async () => {
+  function App() {
+    const {reference, floating} = useFloating();
+
+    return (
+      <>
+        <div ref={(node) => reference(node)} />
+        <div ref={(node) => floating(node)} />
+      </>
+    );
+  }
+
+  render(<App />);
+
+  await act(async () => {});
+
+  cleanup();
+});
+
+test('callback refs invoked during render', async () => {
+  function App() {
+    const [r, setR] = useState<HTMLDivElement | null>(null);
+    const [f, setF] = useState<HTMLDivElement | null>(null);
+
+    const {reference, floating} = useFloating();
+
+    reference(r);
+    floating(f);
+
+    return (
+      <>
+        <div ref={setR} />
+        <div ref={setF} />
+      </>
+    );
+  }
+
+  render(<App />);
+
+  await act(async () => {});
+
+  cleanup();
 });


### PR DESCRIPTION
Fixes #2086 

The `deepEqual` check no longer worked because of the new `isPositioned` value