### PR TITLE
fix(react): backwards-compat for virtual element separation

### DIFF
--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -73,19 +73,25 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
   const setReference: UseFloatingReturn<RT>['reference'] = React.useCallback(
     (node) => {
       if (isElement(node) || node === null) {
-        (
-          context.refs.domReference as React.MutableRefObject<Element | null>
-        ).current = node;
+        (refs.domReference as React.MutableRefObject<Element | null>).current =
+          node;
         setDomReference(node);
       }
 
       // Backwards-compatibility for passing a virtual element to `reference`
       // after it has set the DOM reference.
-      if ((node && !isElement(node)) || node === null) {
+      if (
+        // Allow setting DOM references back to `null`.
+        (isElement(refs.reference.current) && node === null) ||
+        // Don't allow setting virtual elements using the old technique back to
+        // `null` to support `positionReference` + an unstable `reference`
+        // callback ref.
+        (node && !isElement(node))
+      ) {
         reference(node);
       }
     },
-    [reference, context.refs]
+    [reference, refs]
   );
 
   const setPositionReference = React.useCallback(

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -79,10 +79,9 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
         setDomReference(node);
       }
 
-      if (
-        context.refs.reference.current === null ||
-        isElement(context.refs.reference.current)
-      ) {
+      // Backwards-compatibility for passing a virtual element to `reference`
+      // after it has set the DOM reference.
+      if (node && !isElement(node)) {
         reference(node);
       }
     },

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -81,7 +81,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
 
       // Backwards-compatibility for passing a virtual element to `reference`
       // after it has set the DOM reference.
-      if (node && !isElement(node)) {
+      if ((node && !isElement(node)) || node === null) {
         reference(node);
       }
     },

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -81,12 +81,12 @@ export function useFloating<RT extends ReferenceType = ReferenceType>({
       // Backwards-compatibility for passing a virtual element to `reference`
       // after it has set the DOM reference.
       if (
-        // Allow setting DOM references back to `null`.
-        (isElement(refs.reference.current) && node === null) ||
+        isElement(refs.reference.current) ||
+        refs.reference.current === null ||
         // Don't allow setting virtual elements using the old technique back to
         // `null` to support `positionReference` + an unstable `reference`
         // callback ref.
-        (node && !isElement(node))
+        (node !== null && !isElement(node))
       ) {
         reference(node);
       }


### PR DESCRIPTION
Fixes #2091 - only the first update worked following the change, this allows it to update at any time