### PR TITLE
fix: account for closeOnFocusOut in FloatingPortal

### DIFF
--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -404,12 +404,13 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     portalContext.setFocusManagerState({
       ...context,
       modal,
+      closeOnFocusOut,
       // Not concerned about the <RT> generic type.
     } as any);
     return () => {
       portalContext.setFocusManagerState(null);
     };
-  }, [portalContext, modal, context]);
+  }, [portalContext, modal, closeOnFocusOut, context]);
 
   useLayoutEffect(() => {
     const floating = refs.floating.current;

--- a/packages/react/src/components/FloatingPortal.tsx
+++ b/packages/react/src/components/FloatingPortal.tsx
@@ -13,12 +13,14 @@ import {
 } from '../utils/tabbable';
 import {FocusGuard, HIDDEN_STYLES} from './FocusGuard';
 
+type FocusManagerState =
+  | (FloatingContext & {modal: boolean; closeOnFocusOut: boolean})
+  | null;
+
 const PortalContext = React.createContext<null | {
   preserveTabOrder: boolean;
   portalNode: HTMLElement | null;
-  setFocusManagerState: React.Dispatch<
-    React.SetStateAction<(FloatingContext & {modal: boolean}) | null>
-  >;
+  setFocusManagerState: React.Dispatch<React.SetStateAction<FocusManagerState>>;
   beforeInsideRef: React.RefObject<HTMLSpanElement>;
   afterInsideRef: React.RefObject<HTMLSpanElement>;
   beforeOutsideRef: React.RefObject<HTMLSpanElement>;
@@ -78,9 +80,8 @@ export const FloatingPortal = ({
   preserveTabOrder?: boolean;
 }) => {
   const portalNode = useFloatingPortalNode({id, enabled: !root});
-  const [focusManagerState, setFocusManagerState] = React.useState<
-    (FloatingContext & {modal: boolean}) | null
-  >(null);
+  const [focusManagerState, setFocusManagerState] =
+    React.useState<FocusManagerState>(null);
 
   const beforeOutsideRef = React.useRef<HTMLSpanElement>(null);
   const afterOutsideRef = React.useRef<HTMLSpanElement>(null);
@@ -171,7 +172,8 @@ export const FloatingPortal = ({
                 getNextTabbable() ||
                 focusManagerState?.refs.domReference.current;
               nextTabbable?.focus();
-              focusManagerState?.onOpenChange(false);
+              focusManagerState?.closeOnFocusOut &&
+                focusManagerState?.onOpenChange(false);
             }
           }}
         />

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -739,4 +739,18 @@ describe('Drawer', () => {
     await act(async () => {});
     expect(screen.queryByText('Close')).toBeInTheDocument();
   });
+
+  test('closeOnFocusOut=false - does not close when tabbing out', async () => {
+    render(
+      <ResponsiveContext.Provider value={{width: 1600}}>
+        <Drawer />
+      </ResponsiveContext.Provider>
+    );
+    await userEvent.click(screen.getByText('My button'));
+    expect(screen.queryByText('Close')).toBeInTheDocument();
+    await userEvent.keyboard('{Tab}');
+    await act(async () => {});
+    expect(document.activeElement).toBe(screen.getByText('Next button'));
+    expect(screen.queryByText('Close')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
The focus guard in FloatingPortal still tries to close the floating element on focus out, even if `closeOnFocusOut={false}` is set on FloatingFocusManager. I think the context was meant for passing the values from FloatingFocusManager to FloatingPortal for scenarios like this, so reused it.

LMK if a test is necessary for this.