### PR TITLE
fix(FloatingFocusManager): handle sync return focus edge cases

### DIFF
--- a/packages/react/src/hooks/useClick.ts
+++ b/packages/react/src/hooks/useClick.ts
@@ -82,6 +82,10 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
           dataRef.current.openEvent = event.nativeEvent;
         },
         onClick(event) {
+          if (dataRef.current.__syncReturnFocus) {
+            return;
+          }
+
           if (eventOption === 'mousedown' && pointerTypeRef.current) {
             pointerTypeRef.current = undefined;
             return;


### PR DESCRIPTION
Found two edge cases with sync return focus:

1. Click-toggling the reference element caused the focus ring to now appear for pointer usage (happens with `mousedown` click event, and if nothing else was focused prior)
2. Calling `setOpen(false)` in an `onKeyDown` listener now requires `event.preventDefault()` in the listener, but used to not.

Neither seem testable in JSDOM