### PR TITLE
fix: avoid export collisions

### DIFF
--- a/packages/react-dom/src/index.ts
+++ b/packages/react-dom/src/index.ts
@@ -1,3 +1,17 @@
 export {arrow} from './arrow';
 export {useFloating} from './useFloating';
-export * from '@floating-ui/dom';
+export {
+  autoPlacement,
+  autoUpdate,
+  computePosition,
+  detectOverflow,
+  flip,
+  getOverflowAncestors,
+  hide,
+  inline,
+  limitShift,
+  offset,
+  platform,
+  shift,
+  size,
+} from '@floating-ui/dom';

--- a/packages/react-dom/src/types.ts
+++ b/packages/react-dom/src/types.ts
@@ -5,9 +5,23 @@ import type {
 } from '@floating-ui/dom';
 import * as React from 'react';
 
-export {useFloating} from './';
-export {arrow} from './';
-export * from '@floating-ui/dom';
+export {arrow} from './arrow';
+export {useFloating} from './useFloating';
+export {
+  autoPlacement,
+  autoUpdate,
+  computePosition,
+  detectOverflow,
+  flip,
+  getOverflowAncestors,
+  hide,
+  inline,
+  limitShift,
+  offset,
+  platform,
+  shift,
+  size,
+} from '@floating-ui/dom';
 
 export type UseFloatingData = Omit<ComputePositionReturn, 'x' | 'y'> & {
   x: number | null;

--- a/packages/react-dom/src/types.ts
+++ b/packages/react-dom/src/types.ts
@@ -20,6 +20,7 @@ export type {
   Dimensions,
   ElementContext,
   ElementRects,
+  Elements,
   FloatingElement,
   Length,
   Middleware,

--- a/packages/react-dom/src/types.ts
+++ b/packages/react-dom/src/types.ts
@@ -7,6 +7,38 @@ import * as React from 'react';
 
 export {arrow} from './arrow';
 export {useFloating} from './useFloating';
+export type {
+  AlignedPlacement,
+  Alignment,
+  Axis,
+  Boundary,
+  ClientRectObject,
+  ComputePositionConfig,
+  ComputePositionReturn,
+  Coords,
+  DetectOverflowOptions,
+  Dimensions,
+  ElementContext,
+  ElementRects,
+  FloatingElement,
+  Length,
+  Middleware,
+  MiddlewareArguments,
+  MiddlewareData,
+  MiddlewareReturn,
+  NodeScroll,
+  Padding,
+  Placement,
+  Platform,
+  Rect,
+  ReferenceElement,
+  RootBoundary,
+  Side,
+  SideObject,
+  SizeOptions,
+  Strategy,
+  VirtualElement,
+} from '@floating-ui/dom';
 export {
   autoPlacement,
   autoUpdate,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,5 +30,19 @@ export {inner, useInnerOffset} from './inner';
 export {safePolygon} from './safePolygon';
 export {useFloating} from './useFloating';
 export {useInteractions} from './useInteractions';
-export * from '@floating-ui/dom';
+export {
+  autoPlacement,
+  autoUpdate,
+  computePosition,
+  detectOverflow,
+  flip,
+  getOverflowAncestors,
+  hide,
+  inline,
+  limitShift,
+  offset,
+  platform,
+  shift,
+  size,
+} from '@floating-ui/dom';
 export {arrow} from '@floating-ui/react-dom';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,3 @@
-// Fix webpack 4 bug, this export must come first:
-// https://github.com/floating-ui/floating-ui/issues/2110
-/* eslint-disable-next-line */
-export * from '@floating-ui/react-dom';
 export {
   FloatingDelayGroup,
   useDelayGroup,
@@ -34,3 +30,5 @@ export {inner, useInnerOffset} from './inner';
 export {safePolygon} from './safePolygon';
 export {useFloating} from './useFloating';
 export {useInteractions} from './useInteractions';
+export * from '@floating-ui/dom';
+export {arrow} from '@floating-ui/react-dom';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -23,6 +23,55 @@ export {
 } from './hooks/useTransition';
 export {Props as UseTypeaheadProps} from './hooks/useTypeahead';
 export {InnerProps, UseInnerOffsetProps} from './inner';
+export {useFloating} from './useFloating';
+export type {
+  AlignedPlacement,
+  Alignment,
+  Axis,
+  Boundary,
+  ClientRectObject,
+  ComputePositionConfig,
+  ComputePositionReturn,
+  Coords,
+  DetectOverflowOptions,
+  Dimensions,
+  ElementContext,
+  ElementRects,
+  FloatingElement,
+  Length,
+  Middleware,
+  MiddlewareArguments,
+  MiddlewareData,
+  MiddlewareReturn,
+  NodeScroll,
+  Padding,
+  Placement,
+  Platform,
+  Rect,
+  ReferenceElement,
+  RootBoundary,
+  Side,
+  SideObject,
+  SizeOptions,
+  Strategy,
+  VirtualElement,
+} from '@floating-ui/dom';
+export {
+  autoPlacement,
+  autoUpdate,
+  computePosition,
+  detectOverflow,
+  flip,
+  getOverflowAncestors,
+  hide,
+  inline,
+  limitShift,
+  offset,
+  platform,
+  shift,
+  size,
+} from '@floating-ui/dom';
+export {arrow} from '@floating-ui/react-dom';
 
 export type NarrowedElement<T> = T extends Element ? T : Element;
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -23,8 +23,6 @@ export {
 } from './hooks/useTransition';
 export {Props as UseTypeaheadProps} from './hooks/useTypeahead';
 export {InnerProps, UseInnerOffsetProps} from './inner';
-export * from '@floating-ui/dom';
-export {arrow} from '@floating-ui/react-dom';
 
 export type NarrowedElement<T> = T extends Element ? T : Element;
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -23,7 +23,6 @@ export {
 } from './hooks/useTransition';
 export {Props as UseTypeaheadProps} from './hooks/useTypeahead';
 export {InnerProps, UseInnerOffsetProps} from './inner';
-export {useFloating} from './useFloating';
 export type {
   AlignedPlacement,
   Alignment,
@@ -37,6 +36,7 @@ export type {
   Dimensions,
   ElementContext,
   ElementRects,
+  Elements,
   FloatingElement,
   Length,
   Middleware,


### PR DESCRIPTION
Fixes #2110 @hpaul

This avoids the `useFloating` collision in `@floating-ui/react` and the `arrow` collision in both `react-dom` and `react`