### PR TITLE
fix(FloatingDelayGroup): simplify usage by syncing current id internally

### DIFF
--- a/packages/react/src/components/FloatingDelayGroup.tsx
+++ b/packages/react/src/components/FloatingDelayGroup.tsx
@@ -79,7 +79,8 @@ export const useDelayGroup = (
   {open, onOpenChange}: FloatingContext,
   {id}: UseGroupOptions
 ) => {
-  const {currentId, initialDelay, setState, timeoutMs} = useDelayGroupContext();
+  const {currentId, setCurrentId, initialDelay, setState, timeoutMs} =
+    useDelayGroupContext();
   const timeoutIdRef = React.useRef<number>();
 
   React.useEffect(() => {
@@ -113,6 +114,12 @@ export const useDelayGroup = (
       }
     }
   }, [open, setState, currentId, id, onOpenChange, initialDelay, timeoutMs]);
+
+  React.useEffect(() => {
+    if (open) {
+      setCurrentId(id);
+    }
+  }, [open, setCurrentId, id]);
 
   React.useEffect(() => {
     return () => {

--- a/packages/react/test/unit/FloatingDelayGroup.test.tsx
+++ b/packages/react/test/unit/FloatingDelayGroup.test.tsx
@@ -19,15 +19,12 @@ interface Props {
 }
 
 export const Tooltip = ({children, label}: Props) => {
-  const {delay, setCurrentId} = useDelayGroupContext();
+  const {delay} = useDelayGroupContext();
   const [open, setOpen] = useState(false);
 
   const {x, y, reference, floating, strategy, context} = useFloating({
     open,
-    onOpenChange(open) {
-      setOpen(open);
-      open && setCurrentId(label);
-    },
+    onOpenChange: setOpen,
   });
 
   const {getReferenceProps} = useInteractions([


### PR DESCRIPTION
This was such a weird oversight, I have no idea how I missed this simplification.

As for internalizing it into `useHover` per your suggestion, we can try to work out API simplifications for the v1 release later to require less importing. For now it'd be good to prevent breaking too many things

@mihkeleidast

Also the tests pass with and without changing the test, so it's backwards-compatible.