### PR TITLE
feat(useDelayGroupContext): `isInstantPhase` bool

### DIFF
--- a/packages/react/src/components/FloatingDelayGroup.tsx
+++ b/packages/react/src/components/FloatingDelayGroup.tsx
@@ -78,10 +78,12 @@ interface UseGroupOptions {
 export const useDelayGroup = (
   {open, onOpenChange}: FloatingContext,
   {id}: UseGroupOptions
-) => {
+): {isGrouped: boolean} => {
   const {currentId, setCurrentId, initialDelay, setState, timeoutMs} =
     useDelayGroupContext();
   const timeoutIdRef = React.useRef<number>();
+
+  const [isGrouped, setIsGrouped] = React.useState(false);
 
   React.useEffect(() => {
     if (currentId) {
@@ -118,12 +120,33 @@ export const useDelayGroup = (
   React.useEffect(() => {
     if (open) {
       setCurrentId(id);
+    } else {
+      setIsGrouped(false);
     }
   }, [open, setCurrentId, id]);
+
+  React.useEffect(() => {
+    if (currentId) {
+      const frame = requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          setIsGrouped(true);
+        });
+      });
+      return () => {
+        cancelAnimationFrame(frame);
+      };
+    } else {
+      setIsGrouped(false);
+    }
+  }, [currentId]);
 
   React.useEffect(() => {
     return () => {
       clearTimeout(timeoutIdRef.current);
     };
   }, []);
+
+  return {
+    isGrouped,
+  };
 };

--- a/packages/react/src/components/FloatingDelayGroup.tsx
+++ b/packages/react/src/components/FloatingDelayGroup.tsx
@@ -134,7 +134,7 @@ export const useDelayGroup = (
         });
       });
       return () => {
-        [frame, subFrame].forEach((frame) => cancelAnimationFrame(frame));
+        [frame, subFrame].forEach((f) => cancelAnimationFrame(f));
       };
     } else {
       setIsGrouped(false);

--- a/packages/react/src/components/FloatingDelayGroup.tsx
+++ b/packages/react/src/components/FloatingDelayGroup.tsx
@@ -65,25 +65,22 @@ export const FloatingDelayGroup = ({
     }
   );
 
+  const initialCurrentIdRef = React.useRef<any>(null);
+
   const setCurrentId = React.useCallback((currentId: any) => {
     setState({currentId});
   }, []);
 
   useLayoutEffect(() => {
     if (state.currentId) {
-      let subFrame: number;
-      const frame = requestAnimationFrame(() => {
-        subFrame = requestAnimationFrame(() => {
-          setState({isInstantPhase: true});
-        });
-      });
-
-      return () => {
-        cancelAnimationFrame(frame);
-        cancelAnimationFrame(subFrame);
-      };
+      if (initialCurrentIdRef.current === null) {
+        initialCurrentIdRef.current = state.currentId;
+      } else {
+        setState({isInstantPhase: true});
+      }
     } else {
       setState({isInstantPhase: false});
+      initialCurrentIdRef.current = null;
     }
   }, [state.currentId]);
 

--- a/packages/react/src/components/FloatingDelayGroup.tsx
+++ b/packages/react/src/components/FloatingDelayGroup.tsx
@@ -106,12 +106,9 @@ export const useDelayGroup = (
 ) => {
   const {currentId, setCurrentId, initialDelay, setState, timeoutMs} =
     useDelayGroupContext();
-  const timeoutIdRef = React.useRef<number>();
 
   React.useEffect(() => {
     if (currentId) {
-      clearTimeout(timeoutIdRef.current);
-
       setState({
         delay: {
           open: 1,
@@ -131,11 +128,12 @@ export const useDelayGroup = (
       setState({delay: initialDelay, currentId: null});
     }
 
-    clearTimeout(timeoutIdRef.current);
-
     if (!open && currentId === id) {
       if (timeoutMs) {
-        timeoutIdRef.current = window.setTimeout(unset, timeoutMs);
+        const timeout = window.setTimeout(unset, timeoutMs);
+        return () => {
+          clearTimeout(timeout);
+        };
       } else {
         unset();
       }
@@ -147,10 +145,4 @@ export const useDelayGroup = (
       setCurrentId(id);
     }
   }, [open, setCurrentId, id]);
-
-  React.useEffect(() => {
-    return () => {
-      clearTimeout(timeoutIdRef.current);
-    };
-  }, []);
 };

--- a/packages/react/src/components/FloatingDelayGroup.tsx
+++ b/packages/react/src/components/FloatingDelayGroup.tsx
@@ -127,13 +127,14 @@ export const useDelayGroup = (
 
   React.useEffect(() => {
     if (currentId) {
+      let subFrame: number;
       const frame = requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
+        subFrame = requestAnimationFrame(() => {
           setIsGrouped(true);
         });
       });
       return () => {
-        cancelAnimationFrame(frame);
+        [frame, subFrame].forEach((frame) => cancelAnimationFrame(frame));
       };
     } else {
       setIsGrouped(false);

--- a/packages/react/src/components/FloatingDelayGroup.tsx
+++ b/packages/react/src/components/FloatingDelayGroup.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import useLayoutEffect from 'use-isomorphic-layout-effect';
 
 import {getDelay} from '../hooks/useHover';
 import type {FloatingContext} from '../types';
@@ -68,7 +69,7 @@ export const FloatingDelayGroup = ({
     setState({currentId});
   }, []);
 
-  React.useEffect(() => {
+  useLayoutEffect(() => {
     if (state.currentId) {
       let subFrame: number;
       const frame = requestAnimationFrame(() => {

--- a/packages/react/src/hooks/useTransition.ts
+++ b/packages/react/src/hooks/useTransition.ts
@@ -58,9 +58,11 @@ export function useTransitionStatus<RT extends ReferenceType = ReferenceType>(
   // <FloatingPortal />. This call is necessary to ensure subsequent opens
   // after the initial one allows the correct side animation to play when the
   // placement has changed.
-  if (initiated && !isMounted && status !== 'unmounted') {
-    setStatus('unmounted');
-  }
+  useLayoutEffect(() => {
+    if (initiated && !isMounted) {
+      setStatus('unmounted');
+    }
+  }, [initiated, isMounted]);
 
   useLayoutEffect(() => {
     if (!floating) return;


### PR DESCRIPTION
This allows you to make a transition/animation faster while the open delay is in the instant phase. 

The technique that works for `framer-motion` in the existing CodeSandbox doesn't work with the `useTransition<X>` hooks, but this boolean works with both.

Usage:

```js
const {isInstantPhase} = useDelayGroupContext();

const instantDuration = 0;
const openDuration = 500;
const closeDuration = 200;

const {isMounted, styles} = useTransitionStyles(context, {
  duration: isInstantPhase
    ? {
        open: instantDuration,
        close: currentId === label ? closeDuration : instantDuration,
      }
    : {
        open: openDuration,
        close: closeDuration,
      },
});
```