### PR TITLE
feat(useFloating): add enabled prop

### DIFF
--- a/packages/react/src/hooks/useClick.ts
+++ b/packages/react/src/hooks/useClick.ts
@@ -25,9 +25,15 @@ export interface Props {
  * @see https://floating-ui.com/docs/useClick
  */
 export const useClick = <RT extends ReferenceType = ReferenceType>(
-  {open, onOpenChange, dataRef, refs}: FloatingContext<RT>,
   {
-    enabled = true,
+    enabled: enabledGlobal,
+    open,
+    onOpenChange,
+    dataRef,
+    refs,
+  }: FloatingContext<RT>,
+  {
+    enabled: enabledOption = true,
     event: eventOption = 'click',
     toggle = true,
     ignoreMouse = false,
@@ -35,6 +41,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
   }: Props = {}
 ): ElementProps => {
   const pointerTypeRef = React.useRef<'mouse' | 'pen' | 'touch'>();
+  const enabled = !enabledGlobal ? false : enabledOption;
 
   return React.useMemo(() => {
     if (!enabled) {

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -65,6 +65,7 @@ export interface Props {
  */
 export const useDismiss = <RT extends ReferenceType = ReferenceType>(
   {
+    enabled: enabledGlobal,
     open,
     onOpenChange,
     events,
@@ -73,7 +74,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     dataRef,
   }: FloatingContext<RT>,
   {
-    enabled = true,
+    enabled: enabledOption = true,
     escapeKey = true,
     outsidePress: unstable_outsidePress = true,
     outsidePressEvent = 'pointerdown',
@@ -83,6 +84,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     bubbles = true,
   }: Props = {}
 ): ElementProps => {
+  const enabled = !enabledGlobal ? false : enabledOption;
   const tree = useFloatingTree();
   const nested = useFloatingParentNodeId() != null;
   const outsidePressFn = useEvent(

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -19,14 +19,16 @@ export interface Props {
  */
 export const useFocus = <RT extends ReferenceType = ReferenceType>(
   {
+    enabled: enabledGlobal,
     open,
     onOpenChange,
     dataRef,
     events,
     elements: {domReference, floating},
   }: FloatingContext<RT>,
-  {enabled = true, keyboardOnly = true}: Props = {}
+  {enabled: enabledOption = true, keyboardOnly = true}: Props = {}
 ): ElementProps => {
+  const enabled = !enabledGlobal ? false : enabledOption;
   const pointerTypeRef = React.useRef('');
   const blockFocusRef = React.useRef(false);
   const timeoutRef = React.useRef<any>();

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -56,7 +56,7 @@ export interface Props<RT extends ReferenceType = ReferenceType> {
 export const useHover = <RT extends ReferenceType = ReferenceType>(
   context: FloatingContext<RT>,
   {
-    enabled = true,
+    enabled: enabledOption = true,
     delay = 0,
     handleClose = null,
     mouseOnly = false,
@@ -65,12 +65,14 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
   }: Props<RT> = {}
 ): ElementProps => {
   const {
+    enabled: enabledGlobal,
     open,
     onOpenChange,
     dataRef,
     events,
     elements: {domReference, floating},
   } = context;
+  const enabled = !enabledGlobal ? false : enabledOption;
 
   const tree = useFloatingTree<RT>();
   const handleCloseRef = useLatestRef(handleClose);

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -172,12 +172,17 @@ export interface Props {
  * @see https://floating-ui.com/docs/useListNavigation
  */
 export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
-  {open, onOpenChange, elements: {domReference, floating}}: FloatingContext<RT>,
+  {
+    enabled: enabledGlobal,
+    open,
+    onOpenChange,
+    elements: {domReference, floating},
+  }: FloatingContext<RT>,
   {
     listRef,
     activeIndex,
     onNavigate: unstable_onNavigate = () => {},
-    enabled = true,
+    enabled: enabledOption = true,
     selectedIndex = null,
     allowEscape = false,
     loop = false,
@@ -228,6 +233,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
     }
   }
 
+  const enabled = !enabledGlobal ? false : enabledOption;
   const parentId = useFloatingParentNodeId();
   const tree = useFloatingTree();
 

--- a/packages/react/src/hooks/useRole.ts
+++ b/packages/react/src/hooks/useRole.ts
@@ -20,9 +20,10 @@ export interface Props {
  * @see https://floating-ui.com/docs/useRole
  */
 export const useRole = <RT extends ReferenceType = ReferenceType>(
-  {open}: FloatingContext<RT>,
-  {enabled = true, role = 'dialog'}: Partial<Props> = {}
+  {enabled: enabledGlobal, open}: FloatingContext<RT>,
+  {enabled: enabledOption = true, role = 'dialog'}: Partial<Props> = {}
 ): ElementProps => {
+  const enabled = !enabledGlobal ? false : enabledOption;
   const rootId = useId();
   const referenceId = useId();
 

--- a/packages/react/src/hooks/useTypeahead.ts
+++ b/packages/react/src/hooks/useTypeahead.ts
@@ -32,12 +32,12 @@ export interface Props {
  * @see https://floating-ui.com/docs/useTypeahead
  */
 export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
-  {open, dataRef}: FloatingContext<RT>,
+  {enabled: enabledGlobal, open, dataRef}: FloatingContext<RT>,
   {
     listRef,
     activeIndex,
     onMatch: unstable_onMatch = () => {},
-    enabled = true,
+    enabled: enabledOption = true,
     findMatch = null,
     resetMs = 1000,
     ignoreKeys = [],
@@ -47,6 +47,7 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
     activeIndex: null,
   }
 ): ElementProps => {
+  const enabled = !enabledGlobal ? false : enabledOption;
   const timeoutIdRef = React.useRef<any>();
   const stringRef = React.useRef('');
   const prevIndexRef = React.useRef<number | null>(

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -108,6 +108,7 @@ export interface ContextData {
 
 export interface FloatingContext<RT extends ReferenceType = ReferenceType>
   extends Omit<UsePositionFloatingReturn<RT>, 'refs' | 'elements'> {
+  enabled: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   events: FloatingEvents;
@@ -156,6 +157,7 @@ export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =
   };
 
 export interface UseFloatingProps<RT extends ReferenceType = ReferenceType> {
+  enabled: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   placement: Placement;

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -18,7 +18,12 @@ import {isElement} from './utils/is';
 export function useFloating<RT extends ReferenceType = ReferenceType>(
   options: Partial<UseFloatingProps> = {}
 ): UseFloatingReturn<RT> {
-  const {open = false, onOpenChange: unstable_onOpenChange, nodeId} = options;
+  const {
+    enabled = true,
+    open = false,
+    onOpenChange: unstable_onOpenChange,
+    nodeId,
+  } = options;
 
   const position = usePosition<RT>(options);
   const tree = useFloatingTree<RT>();
@@ -96,8 +101,9 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
       events,
       open,
       onOpenChange,
+      enabled,
     }),
-    [position, nodeId, events, open, onOpenChange, refs, elements]
+    [position, nodeId, events, open, onOpenChange, refs, elements, enabled]
   );
 
   useLayoutEffect(() => {

--- a/website/pages/docs/react.mdx
+++ b/website/pages/docs/react.mdx
@@ -439,6 +439,20 @@ viewport. So the `x{:.const}`, `y{:.const}` and
 `strategy{:.const}` values returned from the hook can be safely
 ignored.
 
+### enabled
+
+default: `true{:js}`
+
+Conditionally enable/disable the hook. This acts as a global
+default value for the `enabled` option on the hooks mentioned
+below.
+
+```js
+useFloating({
+  enabled: false,
+});
+```
+
 ## Hooks
 
 `useInteractions(){:js}` accepts an array of called hooks in the


### PR DESCRIPTION
From https://github.com/floating-ui/floating-ui/issues/2100#issuecomment-1381495128.

Adds a "global" enabled prop on the main hook, which acts as the default value for the same option on all interaction hooks. This is helpful when all of the interaction hooks are disabled on the same condition, lessening the duplication.

Not sure if it needs deeper integration, i.e. if we can bail out of some of the compute work behind the scenes. Feel free to take over this one and make additional changes, you know the core better than me.