### PR TITLE
fix(react): avoid adding `floating` element to interaction props dependency array

### DIFF
--- a/packages/react/src/hooks/useClick.ts
+++ b/packages/react/src/hooks/useClick.ts
@@ -25,7 +25,7 @@ export interface Props {
  * @see https://floating-ui.com/docs/useClick
  */
 export const useClick = <RT extends ReferenceType = ReferenceType>(
-  {open, onOpenChange, dataRef, refs}: FloatingContext<RT>,
+  {open, onOpenChange, dataRef, elements: {domReference}}: FloatingContext<RT>,
   {
     enabled = true,
     event: eventOption = 'click',
@@ -124,7 +124,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
             return;
           }
 
-          if (event.key === ' ' && !isSpaceIgnored(refs.domReference.current)) {
+          if (event.key === ' ' && !isSpaceIgnored(domReference)) {
             // Prevent scrolling
             event.preventDefault();
           }
@@ -144,10 +144,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
             return;
           }
 
-          if (
-            isButtonTarget(event) ||
-            isSpaceIgnored(refs.domReference.current)
-          ) {
+          if (isButtonTarget(event) || isSpaceIgnored(domReference)) {
             return;
           }
 
@@ -169,7 +166,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
     eventOption,
     ignoreMouse,
     keyboardHandlers,
-    refs,
+    domReference,
     toggle,
     open,
     onOpenChange,

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -23,7 +23,8 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
     onOpenChange,
     dataRef,
     events,
-    elements: {domReference, floating},
+    refs,
+    elements: {floating, domReference},
   }: FloatingContext<RT>,
   {enabled = true, keyboardOnly = true}: Props = {}
 ): ElementProps => {
@@ -130,7 +131,7 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
             // clicking into the floating element, prevent it from hiding.
             // Note: it must be focusable, e.g. `tabindex="-1"`.
             if (
-              contains(floating, relatedTarget) ||
+              contains(refs.floating.current, relatedTarget) ||
               contains(domReference, relatedTarget) ||
               movedToFocusGuard
             ) {
@@ -142,5 +143,5 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
         },
       },
     };
-  }, [enabled, keyboardOnly, domReference, floating, dataRef, onOpenChange]);
+  }, [enabled, keyboardOnly, domReference, refs, dataRef, onOpenChange]);
 };

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -172,7 +172,7 @@ export interface Props {
  * @see https://floating-ui.com/docs/useListNavigation
  */
 export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
-  {open, onOpenChange, elements: {domReference, floating}}: FloatingContext<RT>,
+  {open, onOpenChange, refs, elements: {domReference}}: FloatingContext<RT>,
   {
     listRef,
     activeIndex,
@@ -427,7 +427,10 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
       // If the floating element is animating out, ignore navigation. Otherwise,
       // the `activeIndex` gets set to 0 despite not being open so the next time
       // the user ArrowDowns, the first item won't be focused.
-      if (!latestOpenRef.current && event.currentTarget === floating) {
+      if (
+        !latestOpenRef.current &&
+        event.currentTarget === refs.floating.current
+      ) {
         return;
       }
 
@@ -811,7 +814,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
               // This also needs to be sync to prevent fast mouse movements
               // from leaving behind a stale active item when landing on a
               // disabled button item.
-              floating?.focus({preventScroll: true});
+              refs.floating.current?.focus({preventScroll: true});
             }
           },
         }),
@@ -819,7 +822,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
     };
   }, [
     domReference,
-    floating,
+    refs,
     activeId,
     disabledIndicesRef,
     latestOpenRef,

--- a/packages/react/src/hooks/useTransition.ts
+++ b/packages/react/src/hooks/useTransition.ts
@@ -41,7 +41,7 @@ type Status = 'unmounted' | 'initial' | 'open' | 'close';
  * @see https://floating-ui.com/docs/useTransition#usetransitionstatus
  */
 export function useTransitionStatus<RT extends ReferenceType = ReferenceType>(
-  {open, elements: {floating}}: FloatingContext<RT>,
+  {open}: FloatingContext<RT>,
   {duration = 250}: Props = {}
 ): {
   isMounted: boolean;
@@ -65,8 +65,6 @@ export function useTransitionStatus<RT extends ReferenceType = ReferenceType>(
   }, [initiated, isMounted]);
 
   useLayoutEffect(() => {
-    if (!floating) return;
-
     if (open) {
       setStatus('initial');
 
@@ -81,7 +79,7 @@ export function useTransitionStatus<RT extends ReferenceType = ReferenceType>(
       setInitiated(true);
       setStatus('close');
     }
-  }, [open, floating]);
+  }, [open]);
 
   return {
     isMounted,

--- a/packages/react/src/hooks/useTransition.ts
+++ b/packages/react/src/hooks/useTransition.ts
@@ -41,7 +41,7 @@ type Status = 'unmounted' | 'initial' | 'open' | 'close';
  * @see https://floating-ui.com/docs/useTransition#usetransitionstatus
  */
 export function useTransitionStatus<RT extends ReferenceType = ReferenceType>(
-  {open}: FloatingContext<RT>,
+  {open, elements: {floating}}: FloatingContext<RT>,
   {duration = 250}: Props = {}
 ): {
   isMounted: boolean;
@@ -65,6 +65,8 @@ export function useTransitionStatus<RT extends ReferenceType = ReferenceType>(
   }, [initiated, isMounted]);
 
   useLayoutEffect(() => {
+    if (!floating) return;
+
     if (open) {
       setStatus('initial');
 
@@ -79,7 +81,7 @@ export function useTransitionStatus<RT extends ReferenceType = ReferenceType>(
       setInitiated(true);
       setStatus('close');
     }
-  }, [open]);
+  }, [open, floating]);
 
   return {
     isMounted,


### PR DESCRIPTION
Prevents `setState` loops when placing `getFloatingProps` as a dependency of a hook and the `ref` setter is inside. 

Fixes #2129