### PR TITLE
fix(safePolygon): improve blocking, consider pointer speed option

### DIFF
--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -87,7 +87,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
   const unbindMouseMoveRef = React.useRef(() => {});
   const cleanupInitialBlockingElementsRef = React.useRef(() => {});
   const initialElementsCreatedRef = React.useRef(false);
-  const isCursorMovingFastRef = React.useRef(false);
+  const hasIntentRef = React.useRef(false);
   const prevTimeRef = React.useRef(0);
   const prevCoordsRef = React.useRef({x: -1, y: -1});
 
@@ -317,7 +317,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
           ...context,
           tree,
           polygonRef,
-          ignoreTriangle: !isCursorMovingFastRef.current,
+          ignoreTriangle: !hasIntentRef.current,
           x: event.clientX,
           y: event.clientY,
           onClose() {
@@ -359,7 +359,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         polygonRef,
         x: event.clientX,
         y: event.clientY,
-        ignoreTriangle: !isCursorMovingFastRef.current,
+        ignoreTriangle: !hasIntentRef.current,
         onClose() {
           cleanupMouseMoveHandler();
           closeWithDelay();
@@ -373,7 +373,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       const safePolygonOptions = handleCloseRef.current.__options;
 
       if (!safePolygonOptions.blockPointerEvents) {
-        isCursorMovingFastRef.current = true;
+        hasIntentRef.current = true;
         return;
       }
 
@@ -390,11 +390,11 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       prevCoordsRef.current = currentCoords;
       prevTimeRef.current = now;
 
-      isCursorMovingFastRef.current = safePolygonOptions.requireIntent
+      hasIntentRef.current = safePolygonOptions.requireIntent
         ? speed >= 0.15
         : true;
 
-      if (isCursorMovingFastRef.current && !initialElementsCreatedRef.current) {
+      if (hasIntentRef.current && !initialElementsCreatedRef.current) {
         const cleanup = createInitialBlockingElements(event);
         if (cleanup) {
           initialElementsCreatedRef.current = true;

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -183,9 +183,10 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       const {top, right, bottom, left, width} =
         domReference.getBoundingClientRect();
 
+      const vV = getDocument(domReference).defaultView?.visualViewport;
       const addVisualOffsets = isSafari();
-      const leftOffset = addVisualOffsets ? visualViewport?.offsetLeft || 0 : 0;
-      const topOffset = addVisualOffsets ? visualViewport?.offsetTop || 0 : 0;
+      const leftOffset = addVisualOffsets ? vV?.offsetLeft || 0 : 0;
+      const topOffset = addVisualOffsets ? vV?.offsetTop || 0 : 0;
 
       if (
         event.clientY <= top ||

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -20,7 +20,7 @@ export interface HandleCloseFn<RT extends ReferenceType = ReferenceType> {
       tree?: FloatingTreeType<RT> | null;
       leave?: boolean;
       polygonRef: React.MutableRefObject<SVGElement | null>;
-      ignoreTriangle: boolean;
+      ignore: boolean;
     }
   ): (event: MouseEvent) => void;
   __options: SafePolygonOptions;
@@ -317,7 +317,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
           ...context,
           tree,
           polygonRef,
-          ignoreTriangle: !hasIntentRef.current,
+          ignore: !hasIntentRef.current,
           x: event.clientX,
           y: event.clientY,
           onClose() {
@@ -359,7 +359,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         polygonRef,
         x: event.clientX,
         y: event.clientY,
-        ignoreTriangle: !hasIntentRef.current,
+        ignore: !hasIntentRef.current,
         onClose() {
           cleanupMouseMoveHandler();
           closeWithDelay();

--- a/packages/react/src/safePolygon.ts
+++ b/packages/react/src/safePolygon.ts
@@ -97,7 +97,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>(
     nodeId,
     tree,
     polygonRef,
-    ignoreTriangle,
+    ignore,
   }) => {
     return function onMouseMove(event: MouseEvent) {
       function close() {
@@ -414,12 +414,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>(
 
       const poly = isInsideRect ? rectPoly : getPolygon([x, y]);
 
-      if (
-        !polygonRef.current &&
-        blockPointerEvents &&
-        isLeave &&
-        !ignoreTriangle
-      ) {
+      if (!polygonRef.current && blockPointerEvents && isLeave && !ignore) {
         const doc = getDocument(elements.floating);
         polygonRef.current = createPolygonElement(poly, doc, isInsideRect);
         doc.body.appendChild(polygonRef.current);
@@ -427,7 +422,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>(
 
       if (isInsideRect) {
         return;
-      } else if ((hasLanded && !restMs) || ignoreTriangle) {
+      } else if ((hasLanded && !restMs) || ignore) {
         return close();
       }
 

--- a/packages/react/src/safePolygon.ts
+++ b/packages/react/src/safePolygon.ts
@@ -144,6 +144,10 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>(
         hasLanded = true;
       }
 
+      if (isOverReference) {
+        hasLanded = false;
+      }
+
       if (!isLeave && isOverReference) {
         destroyPolygon(polygonRef);
         return;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -23,6 +23,7 @@ export {
 } from './hooks/useTransition';
 export {Props as UseTypeaheadProps} from './hooks/useTypeahead';
 export {InnerProps, UseInnerOffsetProps} from './inner';
+export type {SafePolygonOptions} from './safePolygon';
 export type {
   AlignedPlacement,
   Alignment,

--- a/packages/react/test/unit/useInteractions.test.tsx
+++ b/packages/react/test/unit/useInteractions.test.tsx
@@ -89,6 +89,12 @@ test('prop getters are memoized', () => {
     c;
 
     const handleClose = () => () => {};
+    handleClose.__options = {
+      buffer: 0.5,
+      restMs: 0,
+      blockPointerEvents: true,
+      requireIntent: false,
+    };
 
     const listRef = useRef([]);
     const overflowRef = useRef({top: 0, left: 0, bottom: 0, right: 0});

--- a/packages/react/test/visual/index.css
+++ b/packages/react/test/visual/index.css
@@ -162,7 +162,7 @@ body {
   border: 1px solid #d7dce5;
 }
 
-.RootMenu.open,
+.RootMenu[data-open],
 .RootMenu:hover {
   background: #d7dce5;
 }
@@ -192,10 +192,11 @@ body {
   outline: 0;
 }
 
-.MenuItem.open {
+.MenuItem[data-open][data-landed] {
   background: #d7dce5;
 }
 
+.MenuItem[data-open]:not([data-landed]),
 .MenuItem:focus,
 .MenuItem:not([disabled]):active {
   background: royalblue;


### PR DESCRIPTION
Three enhancements/fixes:

1. Fixes https://github.com/floating-ui/floating-ui/issues/2124 by using a mask around the reference element upon open.

2. Adds new `requireIntent` option for `safePolygon` (default `false`). This considers the pointer's speed — if it's moving slow, then don't create the triangle. This improves UX when menu items have submenus attached directly beneath each other to prevent blocking too frequently.

3. Ensure polygon is destroyed properly after entering the floating element, so traversing back in the same direction does not continue keeping it open.