### PR TITLE
Export `composedOffsetParent()` as a convenience function

### DIFF
--- a/packages/dom/src/utils/getOffsetParent.ts
+++ b/packages/dom/src/utils/getOffsetParent.ts
@@ -5,6 +5,7 @@ import {
   isContainingBlock,
   isHTMLElement,
   isLastTraversableNode,
+  isShadowRoot,
   isTableElement,
 } from './is';
 import {getWindow} from './window';
@@ -60,4 +61,52 @@ export function getOffsetParent(element: Element): Element | Window {
   }
 
   return offsetParent || getContainingBlock(element) || window;
+}
+
+/**
+ * Polyfills the old offsetParent behavior from before the spec was changed:
+ * https://github.com/w3c/csswg-drafts/issues/159
+ *
+ * This is exported as a convenience function for consumers that want to opt
+ * into the more accurate old behavior. Note that using this function in some
+ * DOM configurations may introduce performance issues.
+ */
+export function composedOffsetParent(element: HTMLElement): Element | null {
+  let {offsetParent} = element;
+
+  let ancestor: Element = element;
+  let foundInsideSlot = false;
+
+  while (ancestor && ancestor !== offsetParent) {
+    const {assignedSlot} = ancestor;
+
+    if (assignedSlot) {
+      let newOffsetParent = assignedSlot.offsetParent;
+
+      if (getComputedStyle(assignedSlot).display === 'contents') {
+        const hadStyleAttribute = assignedSlot.hasAttribute('style');
+        const oldDisplay = assignedSlot.style.display;
+        assignedSlot.style.display = getComputedStyle(ancestor).display;
+
+        newOffsetParent = assignedSlot.offsetParent;
+
+        assignedSlot.style.display = oldDisplay;
+        if (!hadStyleAttribute) {
+          assignedSlot.removeAttribute('style');
+        }
+      }
+
+      ancestor = assignedSlot;
+      if (offsetParent !== newOffsetParent) {
+        offsetParent = newOffsetParent;
+        foundInsideSlot = true;
+      }
+    } else if (isShadowRoot(ancestor) && ancestor.host && foundInsideSlot) {
+      break;
+    }
+    ancestor = ((isShadowRoot(ancestor) && ancestor.host) ||
+      ancestor.parentNode) as Element;
+  }
+
+  return offsetParent;
 }


### PR DESCRIPTION
Per @atomiks' comment [in this issue](https://github.com/shoelace-style/shoelace/issues/1135#issuecomment-1401017841), this PR restores the `composedOffsetParent()` function that [was previously removed](https://github.com/floating-ui/floating-ui/pull/1894/files) as an opt in convenience function for those using Floating UI in shadow roots.

The proposed usage is:

```ts
import { composedOffsetParent, computePosition, platform } from '@floating-ui/dom';

computePosition(anchor, popup, {
  // ...
  platform: {
    ...platform,
    getOffsetParent: composedOffsetParent
});
```

I suspect you'll see a lot of issues from the web component community like [this one](https://github.com/shoelace-style/shoelace/issues/1135) and [this one](https://github.com/Esri/calcite-components/issues/6300), so it couldn't hurt to add usage and a short explainer to the docs. I wasn't sure where you wanted that — [perhaps as a tip/note under this section?](https://floating-ui.com/docs/platform#getoffsetparent)

Also, I noticed three failing tests locally, but they don't seem to be related.

Let me know what you think!