### PR TITLE
refactor: allow SVG elements as the arrow

### DIFF
--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -34,7 +34,7 @@ export interface Platform {
     rootBoundary: RootBoundary;
     strategy: Strategy;
   }) => Promisable<Rect>;
-  getDimensions: (element: HTMLElement) => Promisable<Dimensions>;
+  getDimensions: (element: Element) => Promisable<Dimensions>;
 
   // Optional
   convertOffsetParentRelativeRectToViewportRelativeRect?: (args: {
@@ -153,7 +153,7 @@ declare const size: (
  * @see https://floating-ui.com/docs/arrow
  */
 declare const arrow: (options: {
-  element: HTMLElement;
+  element: Element;
   padding?: Padding;
 }) => Middleware;
 

--- a/packages/dom/src/utils/getDimensions.ts
+++ b/packages/dom/src/utils/getDimensions.ts
@@ -1,7 +1,12 @@
 import type {Dimensions} from '@floating-ui/core';
 
 import {getCssDimensions} from './getCssDimensions';
+import {isHTMLElement} from './is';
 
-export function getDimensions(element: HTMLElement): Dimensions {
-  return getCssDimensions(element);
+export function getDimensions(element: Element): Dimensions {
+  if (isHTMLElement(element)) {
+    return getCssDimensions(element);
+  }
+
+  return element.getBoundingClientRect();
 }

--- a/packages/react-dom/src/arrow.ts
+++ b/packages/react-dom/src/arrow.ts
@@ -9,7 +9,7 @@ import * as React from 'react';
  * @see https://floating-ui.com/docs/arrow
  */
 export const arrow = (options: {
-  element: React.MutableRefObject<HTMLElement | null> | HTMLElement;
+  element: React.MutableRefObject<Element | null> | Element;
   padding?: number | SideObject;
 }): Middleware => {
   const {element, padding} = options;


### PR DESCRIPTION
SVG arrows were working prior to `dom@1.1.0`, but the types didn't allow it - this adds explicit support for it in the types and makes it work again

Closes #2137 