### PR TITLE
perf: make `getItemProps` change less frequently

### DIFF
--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -415,7 +415,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
 
   const hasActiveIndex = activeIndex != null;
 
-  const getItemProps = React.useMemo(() => {
+  const item = React.useMemo(() => {
     function syncCurrentTarget(currentTarget: HTMLElement | null) {
       if (!open) return;
       const index = listRef.current.indexOf(currentTarget);
@@ -825,7 +825,7 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
           isPointerModalityRef.current = true;
         },
       },
-      item: getItemProps,
+      item,
     };
   }, [
     domReference,
@@ -849,6 +849,6 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
     focusItemOnOpen,
     onNavigate,
     onOpenChange,
-    getItemProps,
+    item,
   ]);
 };

--- a/packages/react/src/useInteractions.ts
+++ b/packages/react/src/useInteractions.ts
@@ -65,11 +65,12 @@ export const useInteractions = (propsList: Array<ElementProps | void> = []) => {
   const getItemProps = React.useCallback(
     (userProps?: React.HTMLProps<HTMLElement>) =>
       mergeProps(userProps, propsList, 'item'),
-    // `activeIndex` can change frequently, this allows the consumer to avoid
-    // re-rendering all list items when memo'ing item components and placing
-    // `getItemProps` as a dependency.
+    // Granularly check for `item` changes, because the `getItemProps` getter
+    // should be as referentially stable as possible since it may be passed as
+    // a prop to many components. All `item` key values must therefore be
+    // memoized.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    deps.map((props) => props?.item)
+    propsList.map((key) => key?.item)
   );
 
   return React.useMemo(

--- a/packages/react/src/useInteractions.ts
+++ b/packages/react/src/useInteractions.ts
@@ -65,8 +65,11 @@ export const useInteractions = (propsList: Array<ElementProps | void> = []) => {
   const getItemProps = React.useCallback(
     (userProps?: React.HTMLProps<HTMLElement>) =>
       mergeProps(userProps, propsList, 'item'),
+    // `activeIndex` can change frequently, this allows the consumer to avoid
+    // re-rendering all list items when memo'ing item components and placing
+    // `getItemProps` as a dependency.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    deps
+    deps.map((props) => props?.item)
   );
 
   return React.useMemo(


### PR DESCRIPTION
The `reference` and `floating` keys can't be memoized like the `item` one due to `onNavigate(null)` in `onPointerLeave`, so only the `item` deps are granularly checked as it doesn't depend on `activeIndex`. 

Only the item getter is usually the one that needs memo'ing because it can affect a large number of components, and this reduces re-renders of the items in the Select example when hovering fast by 90%.

Fixes #2144 by allowing this to work by default:

```js
const ListItem = React.memo(function ListItem({active, getItemProps}) {
  // This component will NOT be-rendered unless the `active` prop changes 
  // (i.e. matches the activeIndex)
  return <div {...getItemProps()} />;
});
```