### PR TITLE
fix(safePolygon): use `pointer-events` blocking

### DIFF
--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -235,6 +235,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
           x: event.clientX,
           y: event.clientY,
           onClose() {
+            clearPointerEvents();
             cleanupMouseMoveHandler();
             closeWithDelay();
           },
@@ -298,6 +299,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     move,
     closeWithDelay,
     cleanupMouseMoveHandler,
+    clearPointerEvents,
     onOpenChange,
     open,
     tree,

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
 
-import {useFloatingTree} from '../components/FloatingTree';
-import {destroyPolygon} from '../safePolygon';
+import {
+  useFloatingParentNodeId,
+  useFloatingTree,
+} from '../components/FloatingTree';
 import type {
   ElementProps,
   FloatingContext,
@@ -13,15 +15,19 @@ import {getDocument} from '../utils/getDocument';
 import {isElement, isMouseLikePointerType} from '../utils/is';
 import {useLatestRef} from './utils/useLatestRef';
 
+const safePolygonIdentifier = 'data-floating-ui-safe-polygon';
+
 export interface HandleCloseFn<RT extends ReferenceType = ReferenceType> {
   (
     context: FloatingContext<RT> & {
       onClose: () => void;
       tree?: FloatingTreeType<RT> | null;
       leave?: boolean;
-      polygonRef: React.MutableRefObject<SVGElement | null>;
     }
   ): (event: MouseEvent) => void;
+  __options: {
+    blockPointerEvents: boolean;
+  };
 }
 
 export function getDelay(
@@ -70,9 +76,11 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     dataRef,
     events,
     elements: {domReference, floating},
+    refs,
   } = context;
 
   const tree = useFloatingTree<RT>();
+  const parentId = useFloatingParentNodeId();
   const handleCloseRef = useLatestRef(handleClose);
   const delayRef = useLatestRef(delay);
 
@@ -81,7 +89,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
   const handlerRef = React.useRef<(event: MouseEvent) => void>();
   const restTimeoutRef = React.useRef<any>();
   const blockMouseMoveRef = React.useRef(true);
-  const polygonRef = React.useRef<SVGElement | null>(null);
+  const performedPointerEventsMutationRef = React.useRef(false);
   const unbindMouseMoveRef = React.useRef(() => {});
 
   const isHoverOpen = React.useCallback(() => {
@@ -157,6 +165,15 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     handlerRef.current = undefined;
   }, []);
 
+  const clearPointerEvents = React.useCallback(() => {
+    if (performedPointerEventsMutationRef.current) {
+      const body = getDocument(refs.floating.current).body;
+      body.style.pointerEvents = '';
+      body.removeAttribute(safePolygonIdentifier);
+      performedPointerEventsMutationRef.current = false;
+    }
+  }, [refs]);
+
   // Registering the mouse events on the reference directly to bypass React's
   // delegation system. If the cursor was on a disabled element and then entered
   // the reference (no gap), `mouseenter` doesn't fire in the delegation system.
@@ -215,7 +232,6 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         handlerRef.current = handleCloseRef.current({
           ...context,
           tree,
-          polygonRef,
           x: event.clientX,
           y: event.clientY,
           onClose() {
@@ -248,7 +264,6 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       handleCloseRef.current?.({
         ...context,
         tree,
-        polygonRef,
         x: event.clientX,
         y: event.clientY,
         onClose() {
@@ -291,22 +306,73 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     dataRef,
   ]);
 
+  // Block pointer-events of every element other than the reference and floating
+  // while the floating element is open and has a `handleClose` handler. Also
+  // handles nested floating elements.
+  // https://github.com/floating-ui/floating-ui/issues/1722
+  useLayoutEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (
+      open &&
+      handleCloseRef.current?.__options.blockPointerEvents &&
+      isHoverOpen()
+    ) {
+      const body = getDocument(floating).body;
+      body.setAttribute(safePolygonIdentifier, '');
+      body.style.pointerEvents = 'none';
+      performedPointerEventsMutationRef.current = true;
+
+      if (isElement(domReference) && floating) {
+        const ref = domReference as unknown as HTMLElement | SVGSVGElement;
+
+        const parentFloating = tree?.nodesRef.current.find(
+          (node) => node.id === parentId
+        )?.context?.elements.floating;
+
+        if (parentFloating) {
+          parentFloating.style.pointerEvents = '';
+        }
+
+        ref.style.pointerEvents = 'auto';
+        floating.style.pointerEvents = 'auto';
+
+        return () => {
+          ref.style.pointerEvents = '';
+          floating.style.pointerEvents = '';
+        };
+      }
+    }
+  }, [
+    enabled,
+    open,
+    parentId,
+    floating,
+    domReference,
+    tree,
+    handleCloseRef,
+    dataRef,
+    isHoverOpen,
+  ]);
+
   useLayoutEffect(() => {
     if (!open) {
       pointerTypeRef.current = undefined;
       cleanupMouseMoveHandler();
-      destroyPolygon(polygonRef);
+      clearPointerEvents();
     }
-  }, [open, cleanupMouseMoveHandler]);
+  }, [open, cleanupMouseMoveHandler, clearPointerEvents]);
 
   React.useEffect(() => {
     return () => {
       cleanupMouseMoveHandler();
       clearTimeout(timeoutRef.current);
       clearTimeout(restTimeoutRef.current);
-      destroyPolygon(polygonRef);
+      clearPointerEvents();
     };
-  }, [enabled, cleanupMouseMoveHandler]);
+  }, [enabled, cleanupMouseMoveHandler, clearPointerEvents]);
 
   return React.useMemo(() => {
     if (!enabled) {

--- a/packages/react/src/safePolygon.ts
+++ b/packages/react/src/safePolygon.ts
@@ -38,7 +38,7 @@ function isInside(point: Point, rect: Rect) {
 export function safePolygon<RT extends ReferenceType = ReferenceType>({
   restMs = 0,
   buffer = 0.5,
-  blockPointerEvents = true,
+  blockPointerEvents = false,
 }: Partial<{
   restMs: number;
   buffer: number;

--- a/packages/react/src/safePolygon.ts
+++ b/packages/react/src/safePolygon.ts
@@ -4,9 +4,8 @@ import type {HandleCloseFn} from './hooks/useHover';
 import type {ReferenceType} from './types';
 import {contains} from './utils/contains';
 import {getChildren} from './utils/getChildren';
-import {getDocument} from './utils/getDocument';
 import {getTarget} from './utils/getTarget';
-import {isElement, isSafari} from './utils/is';
+import {isElement} from './utils/is';
 
 type Point = [number, number];
 type Polygon = Point[];
@@ -36,43 +35,6 @@ function isInside(point: Point, rect: Rect) {
   );
 }
 
-const svgNs = 'http://www.w3.org/2000/svg';
-
-function createPolygonElement(points: Point[], doc: Document, isRect: boolean) {
-  const addVisualOffsets = isSafari();
-  const win = doc.defaultView || window;
-  const svg = doc.createElementNS(svgNs, 'svg');
-  Object.assign(svg.style, {
-    position: 'fixed',
-    left: `${addVisualOffsets ? win.visualViewport?.offsetLeft || 0 : 0}px`,
-    top: `${addVisualOffsets ? win.visualViewport?.offsetTop || 0 : 0}px`,
-    width: '100%',
-    height: '100%',
-    pointerEvents: 'none',
-    zIndex: 2147483647,
-  });
-  svg.setAttribute('data-type', isRect ? 'rect' : 'triangle');
-
-  const polygon = doc.createElementNS(svgNs, 'polygon');
-  polygon.setAttribute('points', points.map(([x, y]) => `${x},${y}`).join(' '));
-  Object.assign(polygon.style, {
-    pointerEvents: 'auto',
-    fill: 'transparent',
-    opacity: 0,
-  });
-
-  svg.appendChild(polygon);
-
-  return svg;
-}
-
-export function destroyPolygon(ref: React.MutableRefObject<SVGElement | null>) {
-  if (ref.current) {
-    ref.current.remove();
-    ref.current = null;
-  }
-}
-
 export function safePolygon<RT extends ReferenceType = ReferenceType>({
   restMs = 0,
   buffer = 0.5,
@@ -94,11 +56,9 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
     onClose,
     nodeId,
     tree,
-    polygonRef,
   }) => {
     return function onMouseMove(event: MouseEvent) {
       function close() {
-        destroyPolygon(polygonRef);
         clearTimeout(timeoutId);
         onClose();
       }
@@ -126,15 +86,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
       const side = placement.split('-')[0] as Side;
       const cursorLeaveFromRight = x > rect.right - rect.width / 2;
       const cursorLeaveFromBottom = y > rect.bottom - rect.height / 2;
-      const isOverFloatingRect =
-        // Account for the polygon blocking pointer-events.
-        isInside(clientPoint, rect);
       const isOverReferenceRect = isInside(clientPoint, refRect);
-
-      // The cursor landed, so we destroy the polygon logic.
-      if (isOverFloatingRect && polygonRef.current?.dataset.type !== 'rect') {
-        destroyPolygon(polygonRef);
-      }
 
       if (isOverFloatingEl) {
         hasLanded = true;
@@ -145,15 +97,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
       }
 
       if (isOverReferenceEl && !isLeave) {
-        destroyPolygon(polygonRef);
-        return;
-      }
-
-      if (
-        !isLeave &&
-        (isOverReferenceEl ||
-          (isInsideRect && contains(polygonRef.current, target)))
-      ) {
+        hasLanded = true;
         return;
       }
 
@@ -414,12 +358,6 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
 
       const poly = isInsideRect ? rectPoly : getPolygon([x, y]);
 
-      if (!polygonRef.current && blockPointerEvents && isLeave) {
-        const doc = getDocument(elements.floating);
-        polygonRef.current = createPolygonElement(poly, doc, isInsideRect);
-        doc.body.appendChild(polygonRef.current);
-      }
-
       if (isInsideRect) {
         return;
       } else if (hasLanded && !isOverReferenceRect) {
@@ -432,6 +370,10 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
         timeoutId = setTimeout(close, restMs);
       }
     };
+  };
+
+  fn.__options = {
+    blockPointerEvents,
   };
 
   return fn;

--- a/packages/react/test/unit/useInteractions.test.tsx
+++ b/packages/react/test/unit/useInteractions.test.tsx
@@ -89,6 +89,7 @@ test('prop getters are memoized', () => {
     c;
 
     const handleClose = () => () => {};
+    handleClose.__options = {blockPointerEvents: true};
 
     const listRef = useRef([]);
     const overflowRef = useRef({top: 0, left: 0, bottom: 0, right: 0});


### PR DESCRIPTION
Fixes #2124

This reverts the polygon technique and goes back to the old `pointer-events` blocking technique. This does have side-effects, so I'm going to prominently display a warning about how to disable it and how to work around these side-effects. 

This PR adds an attribute to the `<body>` called `data-floating-ui-safe-polygon` which allows the user to target it in their CSS.

Both these two issues for scrolling containers (not the main `window`):

- Not being able to scroll while the cursor rests over the reference element while the floating element is open
- macOS' auto-hiding scrollbars forcefully appearing in Chrome

Can be solved like this:

```js
function ScrollContainer({children}) {
  return (
    <div data-scroll>
      <div>
        {children}
      </div>
    </div>
  );
}
```

```css
[data-floating-ui-safe-polygon] [data-scroll] {
  pointer-events: auto;
}

[data-floating-ui-safe-polygon] [data-scroll] > div {
  pointer-events: none;
}
```

Obviously, this requires setup, ensuring the user applies this attribute and the wrapping div to all relevant scrolling containers, and as a result isn't automagic, but I really cannot think of any other good solution to this problem. At least they can disable all blocking if necessary.

@mihkeleidast maybe any other ideas?