### PR TITLE
fix: focus management with tabbable elements in between reference and floating element

### DIFF
--- a/packages/react/src/components/FloatingPortal.tsx
+++ b/packages/react/src/components/FloatingPortal.tsx
@@ -7,11 +7,9 @@ import {FloatingContext} from '../types';
 import {
   disableFocusInside,
   enableFocusInside,
-  getNextTabbable,
-  getPreviousTabbable,
   isOutsideEvent,
 } from '../utils/tabbable';
-import {FocusGuard, HIDDEN_STYLES} from './FocusGuard';
+import {HIDDEN_STYLES} from './FocusGuard';
 
 type FocusManagerState =
   | (FloatingContext & {modal: boolean; closeOnFocusOut: boolean})
@@ -23,8 +21,6 @@ const PortalContext = React.createContext<null | {
   setFocusManagerState: React.Dispatch<React.SetStateAction<FocusManagerState>>;
   beforeInsideRef: React.RefObject<HTMLSpanElement>;
   afterInsideRef: React.RefObject<HTMLSpanElement>;
-  beforeOutsideRef: React.RefObject<HTMLSpanElement>;
-  afterOutsideRef: React.RefObject<HTMLSpanElement>;
 }>(null);
 
 export const useFloatingPortalNode = ({
@@ -141,22 +137,6 @@ export const FloatingPortal = ({
       )}
     >
       {shouldRenderGuards && portalNode && (
-        <FocusGuard
-          data-type="outside"
-          ref={beforeOutsideRef}
-          onFocus={(event) => {
-            if (isOutsideEvent(event, portalNode)) {
-              beforeInsideRef.current?.focus();
-            } else {
-              const prevTabbable =
-                getPreviousTabbable() ||
-                focusManagerState?.refs.domReference.current;
-              prevTabbable?.focus();
-            }
-          }}
-        />
-      )}
-      {shouldRenderGuards && portalNode && (
         <span aria-owns={portalNode.id} style={HIDDEN_STYLES} />
       )}
       {root
@@ -164,24 +144,6 @@ export const FloatingPortal = ({
         : portalNode
         ? createPortal(children, portalNode)
         : null}
-      {shouldRenderGuards && portalNode && (
-        <FocusGuard
-          data-type="outside"
-          ref={afterOutsideRef}
-          onFocus={(event) => {
-            if (isOutsideEvent(event, portalNode)) {
-              afterInsideRef.current?.focus();
-            } else {
-              const nextTabbable =
-                getNextTabbable() ||
-                focusManagerState?.refs.domReference.current;
-              nextTabbable?.focus();
-              focusManagerState?.closeOnFocusOut &&
-                focusManagerState?.onOpenChange(false);
-            }
-          }}
-        />
-      )}
     </PortalContext.Provider>
   );
 };

--- a/packages/react/src/utils/enqueueFocus.ts
+++ b/packages/react/src/utils/enqueueFocus.ts
@@ -8,7 +8,7 @@ interface Options {
 
 let rafId = 0;
 export function enqueueFocus(
-  el: FocusableElement | null,
+  el: FocusableElement | null | undefined,
   options: Options = {}
 ) {
   const {preventScroll = false, cancelPrevious = true, sync = false} = options;

--- a/packages/react/src/utils/tabbable.ts
+++ b/packages/react/src/utils/tabbable.ts
@@ -19,7 +19,8 @@ export const getTabbableOptions = () =>
 
 export function getTabbableIn(
   container: HTMLElement,
-  direction: 'next' | 'prev'
+  direction: 'next' | 'prev',
+  from?: HTMLElement | null
 ) {
   const allTabbable = tabbable(container, getTabbableOptions());
 
@@ -27,19 +28,29 @@ export function getTabbableIn(
     allTabbable.reverse();
   }
 
-  const activeIndex = allTabbable.indexOf(
-    activeElement(getDocument(container)) as HTMLElement
-  );
+  const fromElement =
+    from ?? (activeElement(getDocument(container)) as HTMLElement);
+
+  const activeIndex = allTabbable.indexOf(fromElement);
   const nextTabbableElements = allTabbable.slice(activeIndex + 1);
   return nextTabbableElements[0];
 }
 
-export function getNextTabbable() {
-  return getTabbableIn(document.body, 'next');
+export function getNextTabbable(from?: HTMLElement | null) {
+  return getTabbableIn(document.body, 'next', from);
 }
 
-export function getPreviousTabbable() {
-  return getTabbableIn(document.body, 'prev');
+export function getPreviousTabbable(from?: HTMLElement | null) {
+  return getTabbableIn(document.body, 'prev', from);
+}
+
+export function isNextTabbableFrom(from?: HTMLElement | null) {
+  const container = document.body;
+  const allTabbable = tabbable(container, getTabbableOptions());
+  const activeEl = activeElement(getDocument(container)) as HTMLElement;
+  const activeIndex = allTabbable.indexOf(activeEl);
+
+  return allTabbable[activeIndex - 1] === from;
 }
 
 export function isOutsideEvent(


### PR DESCRIPTION
Relates to #2128. This should fix cases where the hook/state is "lifted higher in the component tree", when the reference element and floating element are not directly next to each other in the DOM. Also fixes the external reference usecase, i.e. focus management with external refs should work a lot better.

Crossing my fingers that the existing tests covered enough of the previous logic, so the changes won't break anything. 

Maybe some additional code can be cleaned up after this as well, hints are welcome. I did not want to make too much unnecessary changes unless confirmed.