### PR TITLE
Move imports and exports from `@floating-ui/dom` to `@floating-ui/react-dom` in package `@floating-ui/react` to resolve dependency issue.

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -31,6 +31,7 @@ export {safePolygon} from './safePolygon';
 export {useFloating} from './useFloating';
 export {useInteractions} from './useInteractions';
 export {
+  arrow,
   autoPlacement,
   autoUpdate,
   computePosition,
@@ -44,5 +45,4 @@ export {
   platform,
   shift,
   size,
-} from '@floating-ui/dom';
-export {arrow} from '@floating-ui/react-dom';
+} from '@floating-ui/react-dom';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -3,9 +3,9 @@ import type {
   Middleware,
   Placement,
   Strategy,
+  UseFloatingReturn as UsePositionFloatingReturn,
   VirtualElement,
-} from '@floating-ui/dom';
-import type {UseFloatingReturn as UsePositionFloatingReturn} from '@floating-ui/react-dom';
+} from '@floating-ui/react-dom';
 import * as React from 'react';
 
 import type {DismissPayload} from './hooks/useDismiss';
@@ -56,8 +56,9 @@ export type {
   SizeOptions,
   Strategy,
   VirtualElement,
-} from '@floating-ui/dom';
+} from '@floating-ui/react-dom';
 export {
+  arrow,
   autoPlacement,
   autoUpdate,
   computePosition,
@@ -71,8 +72,7 @@ export {
   platform,
   shift,
   size,
-} from '@floating-ui/dom';
-export {arrow} from '@floating-ui/react-dom';
+} from '@floating-ui/react-dom';
 
 export type NarrowedElement<T> = T extends Element ? T : Element;
 


### PR DESCRIPTION
Fixes #2156