### PR TITLE
feat(dom): add ability to polyfill `offsetParent` access

### DIFF
--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -44,7 +44,7 @@ export interface Platform {
   }) => Promisable<Rect>;
   getOffsetParent?: (
     element: Element,
-    polyfill?: (element: Element) => Element | null
+    polyfill?: (element: HTMLElement) => Element | null
   ) => Promisable<Element | Window>;
   isElement?: (value: unknown) => Promisable<boolean>;
   getDocumentElement?: (element: Element) => Promisable<HTMLElement>;

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -42,7 +42,10 @@ export interface Platform {
     offsetParent: Element;
     strategy: Strategy;
   }) => Promisable<Rect>;
-  getOffsetParent?: (element: Element) => Promisable<Element | Window>;
+  getOffsetParent?: (
+    element: Element,
+    polyfill?: (element: Element) => Element | null
+  ) => Promisable<Element | Window>;
   isElement?: (value: unknown) => Promisable<boolean>;
   getDocumentElement?: (element: Element) => Promisable<HTMLElement>;
   getClientRects?: (element: Element) => Promisable<Array<ClientRectObject>>;

--- a/packages/dom/src/utils/getOffsetParent.ts
+++ b/packages/dom/src/utils/getOffsetParent.ts
@@ -9,12 +9,21 @@ import {
 } from './is';
 import {getWindow} from './window';
 
-function getTrueOffsetParent(element: Element): Element | null {
+type Polyfill = (element: Element) => Element | null;
+
+function getTrueOffsetParent(
+  element: Element,
+  polyfill?: Polyfill
+): Element | null {
   if (
     !isHTMLElement(element) ||
     getComputedStyle(element).position === 'fixed'
   ) {
     return null;
+  }
+
+  if (polyfill) {
+    return polyfill(element);
   }
 
   return element.offsetParent;
@@ -36,10 +45,13 @@ function getContainingBlock(element: Element) {
 
 // Gets the closest ancestor positioned element. Handles some edge cases,
 // such as table ancestors and cross browser bugs.
-export function getOffsetParent(element: Element): Element | Window {
+export function getOffsetParent(
+  element: Element,
+  polyfill?: (element: Element) => Element | null
+): Element | Window {
   const window = getWindow(element);
 
-  let offsetParent = getTrueOffsetParent(element);
+  let offsetParent = getTrueOffsetParent(element, polyfill);
 
   while (
     offsetParent &&

--- a/packages/dom/src/utils/getOffsetParent.ts
+++ b/packages/dom/src/utils/getOffsetParent.ts
@@ -9,7 +9,7 @@ import {
 } from './is';
 import {getWindow} from './window';
 
-type Polyfill = (element: Element) => Element | null;
+type Polyfill = (element: HTMLElement) => Element | null;
 
 function getTrueOffsetParent(
   element: Element,
@@ -47,7 +47,7 @@ function getContainingBlock(element: Element) {
 // such as table ancestors and cross browser bugs.
 export function getOffsetParent(
   element: Element,
-  polyfill?: (element: Element) => Element | null
+  polyfill?: Polyfill
 ): Element | Window {
   const window = getWindow(element);
 


### PR DESCRIPTION
This enables the ability to add a `composedOffsetParent` polyfill, which can also be used conditionally when perf problems arise.

## Polyfill

```js
function getWindow(node) {
  return node.ownerDocument?.defaultView || window;
}

function isShadowRoot(node) {
  return node instanceof getWindow(node).ShadowRoot;
}

/**
 * Polyfills the old offsetParent behavior from before the spec was changed:
 * https://github.com/w3c/csswg-drafts/issues/159
 */
function composedOffsetParent(element) {
  let {offsetParent} = element;
  let ancestor = element;
  let foundInsideSlot = false;

  while (ancestor && ancestor !== offsetParent) {
    const {assignedSlot} = ancestor;

    if (assignedSlot) {
      let newOffsetParent = assignedSlot.offsetParent;

      if (getComputedStyle(assignedSlot).display === 'contents') {
        const hadStyleAttribute = assignedSlot.hasAttribute('style');
        const oldDisplay = assignedSlot.style.display;
        assignedSlot.style.display = getComputedStyle(ancestor).display;

        newOffsetParent = assignedSlot.offsetParent;

        assignedSlot.style.display = oldDisplay;
        if (!hadStyleAttribute) {
          assignedSlot.removeAttribute('style');
        }
      }

      ancestor = assignedSlot;
      if (offsetParent !== newOffsetParent) {
        offsetParent = newOffsetParent;
        foundInsideSlot = true;
      }
    } else if (isShadowRoot(ancestor) && ancestor.host && foundInsideSlot) {
      break;
    }
    ancestor = ((isShadowRoot(ancestor) && ancestor.host) ||
      ancestor.parentNode);
  }

  return offsetParent;
}
```

## Usage

```js
computePosition(a, b, {
  platform: {
    ...platform,
    getOffsetParent: element => platform.getOffsetParent(element, composedOffsetParent)
  }
});
```