### PR TITLE
feat(detectOverflow): accept virtual `Rect` boundaries

### DIFF
--- a/packages/core/src/detectOverflow.ts
+++ b/packages/core/src/detectOverflow.ts
@@ -14,12 +14,12 @@ const DEBUG_RECTS = false;
 
 export interface Options {
   /**
-   * The clipping element(s) in which overflow will be checked.
+   * The clipping element(s) or area in which overflow will be checked.
    * @default 'clippingAncestors'
    */
   boundary: Boundary;
   /**
-   * The root clipping element in which overflow will be checked.
+   * The root clipping area in which overflow will be checked.
    * @default 'viewport'
    */
   rootBoundary: RootBoundary;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -151,7 +151,7 @@ export interface MiddlewareArguments extends Coords {
 export type ClientRectObject = Rect & SideObject;
 export type Padding = number | Partial<SideObject>;
 export type Boundary = any;
-export type RootBoundary = 'viewport' | 'document';
+export type RootBoundary = 'viewport' | 'document' | Rect;
 export type ElementContext = 'reference' | 'floating';
 
 export {computePosition} from './computePosition';

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -58,7 +58,7 @@ export interface NodeScroll {
   scrollTop: number;
 }
 
-export type Boundary = 'clippingAncestors' | Element | Array<Element>;
+export type Boundary = 'clippingAncestors' | Element | Array<Element> | Rect;
 
 export type DetectOverflowOptions = Omit<
   CoreDetectOverflowOptions,

--- a/packages/dom/src/utils/getBoundingClientRect.ts
+++ b/packages/dom/src/utils/getBoundingClientRect.ts
@@ -1,7 +1,7 @@
 import type {ClientRectObject, VirtualElement} from '@floating-ui/core';
 
 import {FALLBACK_SCALE, getScale} from './getScale';
-import {isElement, isLayoutViewport} from './is';
+import {isClientRectVisualViewportBased, isElement} from './is';
 import {unwrapElement} from './unwrapElement';
 import {getWindow} from './window';
 
@@ -26,7 +26,7 @@ export function getBoundingClientRect(
   }
 
   const win = domElement ? getWindow(domElement) : window;
-  const addVisualOffsets = !isLayoutViewport() && isFixedStrategy;
+  const addVisualOffsets = isClientRectVisualViewportBased() && isFixedStrategy;
 
   let x =
     (clientRect.left +

--- a/packages/dom/src/utils/getClippingRect.ts
+++ b/packages/dom/src/utils/getClippingRect.ts
@@ -18,12 +18,14 @@ import {getParentNode} from './getParentNode';
 import {getScale} from './getScale';
 import {getViewportRect} from './getViewportRect';
 import {
+  isClientRectVisualViewportBased,
   isContainingBlock,
   isElement,
   isHTMLElement,
   isLastTraversableNode,
 } from './is';
 import {max, min} from './math';
+import {getWindow} from './window';
 
 type PlatformWithCache = Platform & {
   _c: Map<ReferenceElement, Element[]>;
@@ -65,7 +67,13 @@ function getClientRectFromClippingAncestor(
   } else if (isElement(clippingAncestor)) {
     rect = getInnerBoundingClientRect(clippingAncestor, strategy);
   } else {
-    rect = clippingAncestor;
+    const mutableRect = {...clippingAncestor};
+    if (isClientRectVisualViewportBased()) {
+      const win = getWindow(element);
+      mutableRect.x -= win.visualViewport?.offsetLeft || 0;
+      mutableRect.y -= win.visualViewport?.offsetTop || 0;
+    }
+    rect = mutableRect;
   }
 
   return rectToClientRect(rect);

--- a/packages/dom/src/utils/getViewportRect.ts
+++ b/packages/dom/src/utils/getViewportRect.ts
@@ -1,7 +1,7 @@
 import type {Rect, Strategy} from '@floating-ui/core';
 
 import {getDocumentElement} from './getDocumentElement';
-import {isLayoutViewport} from './is';
+import {isClientRectVisualViewportBased} from './is';
 import {getWindow} from './window';
 
 export function getViewportRect(element: Element, strategy: Strategy): Rect {
@@ -18,9 +18,9 @@ export function getViewportRect(element: Element, strategy: Strategy): Rect {
     width = visualViewport.width;
     height = visualViewport.height;
 
-    const layoutViewport = isLayoutViewport();
+    const visualViewportBased = isClientRectVisualViewportBased();
 
-    if (layoutViewport || (!layoutViewport && strategy === 'fixed')) {
+    if (!visualViewportBased || (visualViewportBased && strategy === 'fixed')) {
       x = visualViewport.offsetLeft;
       y = visualViewport.offsetTop;
     }

--- a/packages/dom/src/utils/is.ts
+++ b/packages/dom/src/utils/is.ts
@@ -73,15 +73,21 @@ export function isContainingBlock(element: Element): boolean {
   );
 }
 
-export function isLayoutViewport(): boolean {
+/**
+ * Determines whether or not `.getBoundingClientRect()` is affected by visual
+ * viewport offsets. In Safari, the `x`/`y` offsets are values relative to the
+ * visual viewport, while in other engines, they are values relative to the
+ * layout viewport.
+ */
+export function isClientRectVisualViewportBased(): boolean {
   // TODO: Try to use feature detection here instead. Feature detection for
-  // this can fail in various ways, making the userAgent check the most:
+  // this can fail in various ways, making the userAgent check the most
   // reliable:
   // • Always-visible scrollbar or not
   // • Width of <html>
 
-  // Not Safari.
-  return !/^((?!chrome|android).)*safari/i.test(getUAString());
+  // Is Safari.
+  return /^((?!chrome|android).)*safari/i.test(getUAString());
 }
 
 export function isLastTraversableNode(node: Node) {


### PR DESCRIPTION
Closes #2084

This enables "virtual" boundaries, and applies to both `boundary` and `rootBoundary` options.  Useful for more than just the linked issue though.

So if you wanted to use the layout viewport rather than the visual viewport, you could do:

```js
detectOverflow(args, {
  rootBoundary: {
    x: 0,
    y: 0,
    width: document.documentElement.clientWidth,
    height: document.documentElement.clientHeight,
  }
});
```

I think it's best to keep the default `viewport` `rootBoundary` if the visual viewport and layout viewport dimensions aren't the same upon first render of a floating element.  This heuristic isn't perfect, but this way it will correctly re-adjust its position when pinch-zooming out if it was flipped or shifted initially when opening, while preventing it from changing position while pinch-zooming _in_ which is the main issue.

```js
  useEffect(() => {
   if (!isOpen) return;

    const visualWidth = visualViewport?.width;
    const visualHeight = visualViewport?.height;
    const layoutWidth = document.documentElement.clientWidth;
    const layoutHeight = document.documentElement.clientHeight;

    // They aren't pinch-zoomed in / software keyboard is not open, etc, so we
    // use the layout viewport now to prevent the floating element from moving
    // when pinch-zooming around. Could also use a threshold of difference.
    // 
    // I haven't actually tested this on iOS, but seems to work on macOS Chrome.
    if (visualWidth === layoutWidth && visualHeight === layoutHeight) {
      setRootBoundary({
        x: 0,
        y: 0,
        width: layoutWidth,
        height: layoutHeight,
      });
    }
  }, [isOpen]);
```

Going even further, you could also check if `middlewareData.shift` contains coords other than `0`, and if the final `placement` is not the preferred `placement`, etc to determine to use the layout viewport for a given render.
