### PR TITLE
fix(size): take into account `shift()` for center aligned placements

### DIFF
--- a/packages/core/src/middleware/flip.ts
+++ b/packages/core/src/middleware/flip.ts
@@ -134,10 +134,11 @@ export const flip = (
         };
       }
 
-      // First, try to use the one that fits on mainAxis side of overflow.
-      let resetPlacement = overflowsData.find(
-        (d) => d.overflows[0] <= 0
-      )?.placement;
+      // First, find the candidates that fit on the mainAxis side of overflow,
+      // then find the placement that fits the best on the main crossAxis side.
+      let resetPlacement = overflowsData
+        .filter((d) => d.overflows[0] <= 0)
+        .sort((a, b) => a.overflows[1] - b.overflows[1])[0]?.placement;
 
       // Otherwise fallback.
       if (!resetPlacement) {


### PR DESCRIPTION
The `crossAxis` of `size()`, i.e. the y-axis for left/right placements, or x-axis for top/bottom placements poses some problems.

For center aligned placements, this PR considers whole viewport space when `shift()` appears before `size()`, which fixes #1897.

For edge aligned placements (`start` / `end`), I found the following:

- It's not desirable to use `shift()` **before** `size()`, because then the placement loses its alignment. Placing it after works fine with desirable behavior. Perhaps should be documented.
- When using `flip()`, which is much more useful, it "resets" at a point when it overflows on both sides, which looks like it was caused by https://github.com/floating-ui/floating-ui/pull/2151. Will try to include a fix for that in this PR also.