### PR TITLE
Prevent fixed ancestors from being a clipping ancestor

### DIFF
--- a/packages/dom/src/utils/getClippingRect.ts
+++ b/packages/dom/src/utils/getClippingRect.ts
@@ -105,7 +105,7 @@ function getClippingElementAncestors(
     const computedStyle = getComputedStyle(currentNode);
     const containingBlock = isContainingBlock(currentNode);
 
-    const shouldIgnoreCurrentNode = ['fixed'].includes(computedStyle.position);
+    const shouldIgnoreCurrentNode = computedStyle.position === 'fixed';
     if (shouldIgnoreCurrentNode) {
       currentContainingBlockComputedStyle = null;
     } else {

--- a/packages/dom/src/utils/getClippingRect.ts
+++ b/packages/dom/src/utils/getClippingRect.ts
@@ -105,21 +105,26 @@ function getClippingElementAncestors(
     const computedStyle = getComputedStyle(currentNode);
     const containingBlock = isContainingBlock(currentNode);
 
-    const shouldDropCurrentNode = elementIsFixed
-      ? !containingBlock && !currentContainingBlockComputedStyle
-      : !containingBlock &&
-        computedStyle.position === 'static' &&
-        !!currentContainingBlockComputedStyle &&
-        ['absolute', 'fixed'].includes(
-          currentContainingBlockComputedStyle.position
-        );
-
-    if (shouldDropCurrentNode) {
-      // Drop non-containing blocks.
-      result = result.filter((ancestor) => ancestor !== currentNode);
+    const shouldIgnoreCurrentNode = ['fixed'].includes(computedStyle.position);
+    if (shouldIgnoreCurrentNode) {
+      currentContainingBlockComputedStyle = null;
     } else {
-      // Record last containing block for next iteration.
-      currentContainingBlockComputedStyle = computedStyle;
+      const shouldDropCurrentNode = elementIsFixed
+        ? !containingBlock && !currentContainingBlockComputedStyle
+        : !containingBlock &&
+          computedStyle.position === 'static' &&
+          !!currentContainingBlockComputedStyle &&
+          ['absolute', 'fixed'].includes(
+            currentContainingBlockComputedStyle.position
+          );
+
+      if (shouldDropCurrentNode) {
+        // Drop non-containing blocks.
+        result = result.filter((ancestor) => ancestor !== currentNode);
+      } else {
+        // Record last containing block for next iteration.
+        currentContainingBlockComputedStyle = computedStyle;
+      }
     }
 
     currentNode = getParentNode(currentNode);


### PR DESCRIPTION
fixes #2167

Previously ancestors with `transform` values and interceding decendents with `position: fixed` would errantly count as clipping ancestors. This releases the styles of a `position: fixed` ancestor so that it doesn't allow the `transform` ancestor to join the clipping ancestors array.

Repro in previous context: https://codesandbox.io/s/youthful-wiles-dc6oy4?file=/index.html