### PR TITLE
fix: type exports and comments

### DIFF
--- a/packages/core/src/detectOverflow.ts
+++ b/packages/core/src/detectOverflow.ts
@@ -1,7 +1,7 @@
 import type {
   Boundary,
   ElementContext,
-  MiddlewareArguments,
+  MiddlewareState,
   Padding,
   RootBoundary,
   SideObject,
@@ -47,17 +47,17 @@ export interface Options {
 
 /**
  * Resolves with an object of overflow side offsets that determine how much the
- * element is overflowing a given clipping boundary.
+ * element is overflowing a given clipping boundary on each side.
  * - positive = overflowing the boundary by that number of pixels
  * - negative = how many pixels left before it will overflow
  * - 0 = lies flush with the boundary
  * @see https://floating-ui.com/docs/detectOverflow
  */
 export async function detectOverflow(
-  middlewareArguments: MiddlewareArguments,
+  state: MiddlewareState,
   options: Partial<Options> = {}
 ): Promise<SideObject> {
-  const {x, y, platform, rects, elements, strategy} = middlewareArguments;
+  const {x, y, platform, rects, elements, strategy} = state;
 
   const {
     boundary = 'clippingAncestors',

--- a/packages/core/src/middleware/arrow.ts
+++ b/packages/core/src/middleware/arrow.ts
@@ -21,18 +21,17 @@ export interface Options {
 }
 
 /**
- * A data provider that provides data to position an inner element of the
- * floating element (usually a triangle or caret) so that it is centered to the
- * reference element.
+ * Provides data to position an inner element of the floating element so that it
+ * appears centered to the reference element.
  * @see https://floating-ui.com/docs/arrow
  */
 export const arrow = (options: Options): Middleware => ({
   name: 'arrow',
   options,
-  async fn(middlewareArguments) {
+  async fn(state) {
     // Since `element` is required, we don't Partial<> the type.
     const {element, padding = 0} = options || {};
-    const {x, y, placement, rects, platform} = middlewareArguments;
+    const {x, y, placement, rects, platform} = state;
 
     if (element == null) {
       if (__DEV__) {

--- a/packages/core/src/middleware/autoPlacement.ts
+++ b/packages/core/src/middleware/autoPlacement.ts
@@ -69,7 +69,9 @@ export interface Options {
 }
 
 /**
- * Automatically chooses the `placement` which has the most space available.
+ * Optimizes the visibility of the floating element by choosing the placement
+ * that has the most space available automatically, without needing to specify a
+ * preferred placement. Alternative to `flip`.
  * @see https://floating-ui.com/docs/autoPlacement
  */
 export const autoPlacement = (
@@ -77,9 +79,8 @@ export const autoPlacement = (
 ): Middleware => ({
   name: 'autoPlacement',
   options,
-  async fn(middlewareArguments) {
-    const {rects, middlewareData, placement, platform, elements} =
-      middlewareArguments;
+  async fn(state) {
+    const {rects, middlewareData, placement, platform, elements} = state;
 
     const {
       crossAxis = false,
@@ -94,10 +95,7 @@ export const autoPlacement = (
         ? getPlacementList(alignment || null, autoAlignment, allowedPlacements)
         : allowedPlacements;
 
-    const overflow = await detectOverflow(
-      middlewareArguments,
-      detectOverflowOptions
-    );
+    const overflow = await detectOverflow(state, detectOverflowOptions);
 
     const currentIndex = middlewareData.autoPlacement?.index || 0;
     const currentPlacement = placements[currentIndex];

--- a/packages/core/src/middleware/flip.ts
+++ b/packages/core/src/middleware/flip.ts
@@ -52,12 +52,9 @@ export interface Options {
 }
 
 /**
- * A visibility optimizer that changes the placement of the floating element in
- * order to keep it in view. By default, only the opposite placement is tried.
- *
- * It has the ability to flip to any placement, not just the opposite one. You
- * can use a series of “fallback” placements, where each placement is
- * progressively tried until the one that fits can be used.
+ * Optimizes the visibility of the floating element by flipping the `placement`
+ * in order to keep it in view when the preferred placement(s) will overflow the
+ * clipping boundary. Alternative to `autoPlacement`.
  * @see https://floating-ui.com/docs/flip
  */
 export const flip = (
@@ -65,7 +62,7 @@ export const flip = (
 ): Middleware => ({
   name: 'flip',
   options,
-  async fn(middlewareArguments) {
+  async fn(state) {
     const {
       placement,
       middlewareData,
@@ -73,7 +70,7 @@ export const flip = (
       initialPlacement,
       platform,
       elements,
-    } = middlewareArguments;
+    } = state;
 
     const {
       mainAxis: checkMainAxis = true,
@@ -108,10 +105,7 @@ export const flip = (
 
     const placements = [initialPlacement, ...fallbackPlacements];
 
-    const overflow = await detectOverflow(
-      middlewareArguments,
-      detectOverflowOptions
-    );
+    const overflow = await detectOverflow(state, detectOverflowOptions);
 
     const overflows = [];
     let overflowsData = middlewareData.flip?.overflows || [];

--- a/packages/core/src/middleware/hide.ts
+++ b/packages/core/src/middleware/hide.ts
@@ -26,9 +26,8 @@ export interface Options {
 }
 
 /**
- * A data provider that allows you to hide the floating element in applicable
- * situations, usually when it’s not within the same clipping context as the
- * reference element.
+ * Provides data to hide the floating element in applicable situations, such as
+ * when it is not in the same clipping context as the reference element.
  * @see https://floating-ui.com/docs/hide
  */
 export const hide = (
@@ -36,13 +35,13 @@ export const hide = (
 ): Middleware => ({
   name: 'hide',
   options,
-  async fn(middlewareArguments) {
+  async fn(state) {
     const {strategy = 'referenceHidden', ...detectOverflowOptions} = options;
-    const {rects} = middlewareArguments;
+    const {rects} = state;
 
     switch (strategy) {
       case 'referenceHidden': {
-        const overflow = await detectOverflow(middlewareArguments, {
+        const overflow = await detectOverflow(state, {
           ...detectOverflowOptions,
           elementContext: 'reference',
         });
@@ -55,7 +54,7 @@ export const hide = (
         };
       }
       case 'escaped': {
-        const overflow = await detectOverflow(middlewareArguments, {
+        const overflow = await detectOverflow(state, {
           ...detectOverflowOptions,
           altBoundary: true,
         });

--- a/packages/core/src/middleware/inline.ts
+++ b/packages/core/src/middleware/inline.ts
@@ -33,9 +33,8 @@ export interface Options {
 export const inline = (options: Partial<Options> = {}): Middleware => ({
   name: 'inline',
   options,
-  async fn(middlewareArguments) {
-    const {placement, elements, rects, platform, strategy} =
-      middlewareArguments;
+  async fn(state) {
+    const {placement, elements, rects, platform, strategy} = state;
     // A MouseEvent's client{X,Y} coords can be up to 2 pixels off a
     // ClientRect's bounds, despite the event listener being triggered. A
     // padding of 2 seems to handle this issue.

--- a/packages/core/src/middleware/size.ts
+++ b/packages/core/src/middleware/size.ts
@@ -2,7 +2,7 @@ import {
   detectOverflow,
   Options as DetectOverflowOptions,
 } from '../detectOverflow';
-import type {Middleware, MiddlewareArguments} from '../types';
+import type {Middleware, MiddlewareState} from '../types';
 import {getAlignment} from '../utils/getAlignment';
 import {getMainAxisFromPlacement} from '../utils/getMainAxisFromPlacement';
 import {getSide} from '../utils/getSide';
@@ -15,7 +15,7 @@ export interface Options {
    * @default undefined
    */
   apply(
-    args: MiddlewareArguments & {
+    args: MiddlewareState & {
       availableWidth: number;
       availableHeight: number;
     }
@@ -23,9 +23,9 @@ export interface Options {
 }
 
 /**
- * Provides data to change the size of the floating element. For instance,
- * prevent it from overflowing its clipping boundary or match the width of the
- * reference element.
+ * Provides data that allows you to change the size of the floating element —
+ * for instance, prevent it from overflowing the clipping boundary or match the
+ * width of the reference element.
  * @see https://floating-ui.com/docs/size
  */
 export const size = (
@@ -33,14 +33,11 @@ export const size = (
 ): Middleware => ({
   name: 'size',
   options,
-  async fn(middlewareArguments) {
-    const {placement, rects, platform, elements} = middlewareArguments;
+  async fn(state) {
+    const {placement, rects, platform, elements} = state;
     const {apply = () => {}, ...detectOverflowOptions} = options;
 
-    const overflow = await detectOverflow(
-      middlewareArguments,
-      detectOverflowOptions
-    );
+    const overflow = await detectOverflow(state, detectOverflowOptions);
     const side = getSide(placement);
     const alignment = getAlignment(placement);
     const axis = getMainAxisFromPlacement(placement);
@@ -82,7 +79,7 @@ export const size = (
       );
     }
 
-    if (!middlewareArguments.middlewareData.shift && !alignment) {
+    if (!state.middlewareData.shift && !alignment) {
       const xMin = max(overflow.left, 0);
       const xMax = max(overflow.right, 0);
       const yMin = max(overflow.top, 0);
@@ -105,7 +102,7 @@ export const size = (
       }
     }
 
-    await apply({...middlewareArguments, availableWidth, availableHeight});
+    await apply({...state, availableWidth, availableHeight});
 
     const nextDimensions = await platform.getDimensions(elements.floating);
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -108,9 +108,7 @@ export interface MiddlewareReturn extends Partial<Coords> {
 export type Middleware = {
   name: string;
   options?: any;
-  fn: (
-    middlewareArguments: MiddlewareArguments
-  ) => Promisable<MiddlewareReturn>;
+  fn: (state: MiddlewareState) => Promisable<MiddlewareReturn>;
 };
 
 export type Dimensions = {[key in Length]: number};
@@ -138,7 +136,7 @@ export interface Elements {
   floating: FloatingElement;
 }
 
-export interface MiddlewareArguments extends Coords {
+export interface MiddlewareState extends Coords {
   initialPlacement: Placement;
   placement: Placement;
   strategy: Strategy;
@@ -147,6 +145,10 @@ export interface MiddlewareArguments extends Coords {
   rects: ElementRects;
   platform: Platform;
 }
+/**
+ * @deprecated use `MiddlewareState` instead.
+ */
+export type MiddlewareArguments = MiddlewareState;
 
 export type ClientRectObject = Rect & SideObject;
 export type Padding = number | Partial<SideObject>;

--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -34,6 +34,10 @@ export interface Options {
 
 /**
  * Automatically updates the position of the floating element when necessary.
+ * Should only be called when the floating element is mounted on the DOM or
+ * visible on the screen.
+ * @returns cleanup function that should be invoked when the floating element is
+ * removed from the DOM or hidden from the screen.
  * @see https://floating-ui.com/docs/autoUpdate
  */
 export function autoUpdate(

--- a/packages/react-dom/src/arrow.ts
+++ b/packages/react-dom/src/arrow.ts
@@ -2,6 +2,11 @@ import type {Middleware, SideObject} from '@floating-ui/core';
 import {arrow as arrowCore} from '@floating-ui/dom';
 import * as React from 'react';
 
+export interface Options {
+  element: React.MutableRefObject<Element | null> | Element;
+  padding?: number | SideObject;
+}
+
 /**
  * A data provider that provides data to position an inner element of the
  * floating element (usually a triangle or caret) so that it is centered to the
@@ -9,10 +14,7 @@ import * as React from 'react';
  * This wraps the core `arrow` middleware to allow React refs as the element.
  * @see https://floating-ui.com/docs/arrow
  */
-export const arrow = (options: {
-  element: React.MutableRefObject<Element | null> | Element;
-  padding?: number | SideObject;
-}): Middleware => {
+export const arrow = (options: Options): Middleware => {
   const {element, padding} = options;
 
   function isRef(value: unknown): value is React.MutableRefObject<unknown> {

--- a/packages/react-dom/src/types.ts
+++ b/packages/react-dom/src/types.ts
@@ -5,11 +5,12 @@ import type {
 } from '@floating-ui/dom';
 import * as React from 'react';
 
-export {arrow} from './arrow';
+export {arrow, Options as ArrowOptions} from './arrow';
 export {useFloating} from './useFloating';
 export type {
   AlignedPlacement,
   Alignment,
+  AutoPlacementOptions,
   AutoUpdateOptions,
   Axis,
   Boundary,
@@ -22,19 +23,25 @@ export type {
   ElementContext,
   ElementRects,
   Elements,
+  FlipOptions,
   FloatingElement,
+  HideOptions,
+  InlineOptions,
   Length,
   Middleware,
   MiddlewareArguments,
   MiddlewareData,
   MiddlewareReturn,
+  MiddlewareState,
   NodeScroll,
+  OffsetOptions,
   Padding,
   Placement,
   Platform,
   Rect,
   ReferenceElement,
   RootBoundary,
+  ShiftOptions,
   Side,
   SideObject,
   SizeOptions,
@@ -57,39 +64,58 @@ export {
   size,
 } from '@floating-ui/dom';
 
-export type UseFloatingData = Omit<ComputePositionReturn, 'x' | 'y'> & {
-  x: number | null;
-  y: number | null;
-  isPositioned: boolean;
-};
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+  // eslint-disable-next-line @typescript-eslint/ban-types
+} & {};
+
+export type UseFloatingData = Prettify<
+  Omit<ComputePositionReturn, 'x' | 'y'> & {
+    x: number | null;
+    y: number | null;
+    isPositioned: boolean;
+  }
+>;
 
 export type ReferenceType = Element | VirtualElement;
 
 export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =
-  UseFloatingData & {
-    update: () => void;
-    reference: (node: RT | null) => void;
-    floating: (node: HTMLElement | null) => void;
-    refs: {
-      reference: React.MutableRefObject<RT | null>;
-      floating: React.MutableRefObject<HTMLElement | null>;
-      setReference: (node: RT | null) => void;
-      setFloating: (node: HTMLElement | null) => void;
-    };
-    elements: {
-      reference: RT | null;
-      floating: HTMLElement | null;
-    };
-  };
+  Prettify<
+    UseFloatingData & {
+      /**
+       * Update the position of the floating element, re-rendering the component
+       * if required.
+       */
+      update: () => void;
+      /**
+       * @deprecated use `refs.setReference` instead.
+       */
+      reference: (node: RT | null) => void;
+      /**
+       * @deprecated use `refs.setFloating` instead.
+       */
+      floating: (node: HTMLElement | null) => void;
+      refs: {
+        reference: React.MutableRefObject<RT | null>;
+        floating: React.MutableRefObject<HTMLElement | null>;
+        setReference: (node: RT | null) => void;
+        setFloating: (node: HTMLElement | null) => void;
+      };
+      elements: {
+        reference: RT | null;
+        floating: HTMLElement | null;
+      };
+    }
+  >;
 
-export type UseFloatingProps<RT extends ReferenceType = ReferenceType> = Omit<
-  Partial<ComputePositionConfig>,
-  'platform'
-> & {
-  whileElementsMounted?: (
-    reference: RT,
-    floating: HTMLElement,
-    update: () => void
-  ) => void | (() => void);
-  open?: boolean;
-};
+export type UseFloatingProps<RT extends ReferenceType = ReferenceType> =
+  Prettify<
+    Omit<Partial<ComputePositionConfig>, 'platform'> & {
+      whileElementsMounted?: (
+        reference: RT,
+        floating: HTMLElement,
+        update: () => void
+      ) => void | (() => void);
+      open?: boolean;
+    }
+  >;

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -15,6 +15,7 @@ export type {
   MiddlewareArguments,
   MiddlewareData,
   MiddlewareReturn,
+  MiddlewareState,
   Padding,
   Placement,
   Platform,

--- a/packages/react/src/inner.ts
+++ b/packages/react/src/inner.ts
@@ -8,21 +8,21 @@ import type {
   ElementProps,
   FloatingContext,
   Middleware,
-  MiddlewareArguments,
+  MiddlewareState,
   SideObject,
 } from './types';
 import {getUserAgent} from './utils/getPlatform';
 
 function getArgsWithCustomFloatingHeight(
-  args: MiddlewareArguments,
+  state: MiddlewareState,
   height: number
 ) {
   return {
-    ...args,
+    ...state,
     rects: {
-      ...args.rects,
+      ...state.rects,
       floating: {
-        ...args.rects.floating,
+        ...state.rects.floating,
         height,
       },
     },
@@ -50,7 +50,7 @@ export const inner = (
 ): Middleware => ({
   name: 'inner',
   options: props,
-  async fn(middlewareArguments) {
+  async fn(state) {
     const {
       listRef,
       overflowRef,
@@ -66,12 +66,12 @@ export const inner = (
     const {
       rects,
       elements: {floating},
-    } = middlewareArguments;
+    } = state;
 
     const item = listRef.current[index];
 
     if (__DEV__) {
-      if (!middlewareArguments.placement.startsWith('bottom')) {
+      if (!state.placement.startsWith('bottom')) {
         console.warn(
           [
             'Floating UI: `placement` side must be "bottom" when using the',
@@ -86,13 +86,13 @@ export const inner = (
     }
 
     const nextArgs = {
-      ...middlewareArguments,
+      ...state,
       ...(await offset(
         -item.offsetTop -
           rects.reference.height / 2 -
           item.offsetHeight / 2 -
           innerOffset
-      ).fn(middlewareArguments)),
+      ).fn(state)),
     };
 
     const el = scrollRef?.current || floating;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -26,6 +26,8 @@ export {InnerProps, UseInnerOffsetProps} from './inner';
 export type {
   AlignedPlacement,
   Alignment,
+  ArrowOptions,
+  AutoPlacementOptions,
   AutoUpdateOptions,
   Axis,
   Boundary,
@@ -38,19 +40,25 @@ export type {
   ElementContext,
   ElementRects,
   Elements,
+  FlipOptions,
   FloatingElement,
+  HideOptions,
+  InlineOptions,
   Length,
   Middleware,
   MiddlewareArguments,
   MiddlewareData,
   MiddlewareReturn,
+  MiddlewareState,
   NodeScroll,
+  OffsetOptions,
   Padding,
   Placement,
   Platform,
   Rect,
   ReferenceElement,
   RootBoundary,
+  ShiftOptions,
   Side,
   SideObject,
   SizeOptions,
@@ -73,6 +81,11 @@ export {
   shift,
   size,
 } from '@floating-ui/react-dom';
+
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+  // eslint-disable-next-line @typescript-eslint/ban-types
+} & {};
 
 export type NarrowedElement<T> = T extends Element ? T : Element;
 
@@ -106,16 +119,18 @@ export interface ContextData {
   [key: string]: any;
 }
 
-export interface FloatingContext<RT extends ReferenceType = ReferenceType>
-  extends Omit<UsePositionFloatingReturn<RT>, 'refs' | 'elements'> {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  events: FloatingEvents;
-  dataRef: React.MutableRefObject<ContextData>;
-  nodeId: string | undefined;
-  refs: ExtendedRefs<RT>;
-  elements: ExtendedElements<RT>;
-}
+export type FloatingContext<RT extends ReferenceType = ReferenceType> =
+  Prettify<
+    Omit<UsePositionFloatingReturn<RT>, 'refs' | 'elements'> & {
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+      events: FloatingEvents;
+      dataRef: React.MutableRefObject<ContextData>;
+      nodeId: string | undefined;
+      refs: ExtendedRefs<RT>;
+      elements: ExtendedElements<RT>;
+    }
+  >;
 
 export interface FloatingNodeType<RT extends ReferenceType = ReferenceType> {
   id: string;
@@ -138,22 +153,35 @@ export interface ElementProps {
 
 export type ReferenceType = Element | VirtualElement;
 
-export type UseFloatingData = Omit<ComputePositionReturn, 'x' | 'y'> & {
-  x: number | null;
-  y: number | null;
-};
+export type UseFloatingData = Prettify<
+  Omit<ComputePositionReturn, 'x' | 'y'> & {
+    x: number | null;
+    y: number | null;
+  }
+>;
 
 export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =
-  UseFloatingData & {
-    update: () => void;
-    reference: (node: RT | null) => void;
-    floating: (node: HTMLElement | null) => void;
-    positionReference: (node: ReferenceType | null) => void;
-    context: FloatingContext<RT>;
-    refs: ExtendedRefs<RT>;
-    elements: ExtendedElements<RT>;
-    isPositioned: boolean;
-  };
+  Prettify<
+    UseFloatingData & {
+      update: () => void;
+      /**
+       * @deprecated use `refs.setReference` instead.
+       */
+      reference: (node: RT | null) => void;
+      /**
+       * @deprecated use `refs.setFloating` instead.
+       */
+      floating: (node: HTMLElement | null) => void;
+      /**
+       * @deprecated use `refs.setPositionReference` instead.
+       */
+      positionReference: (node: ReferenceType | null) => void;
+      context: FloatingContext<RT>;
+      refs: ExtendedRefs<RT>;
+      elements: ExtendedElements<RT>;
+      isPositioned: boolean;
+    }
+  >;
 
 export interface UseFloatingProps<RT extends ReferenceType = ReferenceType> {
   open: boolean;

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -9,7 +9,64 @@ import type {
 } from '@floating-ui/dom';
 import type {ComponentPublicInstance, Ref} from 'vue-demi';
 
-export * from '.';
+export {arrow} from './arrow';
+export {useFloating} from './useFloating';
+export type {
+  AlignedPlacement,
+  Alignment,
+  AutoPlacementOptions,
+  AutoUpdateOptions,
+  Axis,
+  Boundary,
+  ClientRectObject,
+  ComputePositionConfig,
+  ComputePositionReturn,
+  Coords,
+  DetectOverflowOptions,
+  Dimensions,
+  ElementContext,
+  ElementRects,
+  Elements,
+  FlipOptions,
+  FloatingElement,
+  HideOptions,
+  InlineOptions,
+  Length,
+  Middleware,
+  MiddlewareArguments,
+  MiddlewareData,
+  MiddlewareReturn,
+  MiddlewareState,
+  NodeScroll,
+  OffsetOptions,
+  Padding,
+  Placement,
+  Platform,
+  Rect,
+  ReferenceElement,
+  RootBoundary,
+  ShiftOptions,
+  Side,
+  SideObject,
+  SizeOptions,
+  Strategy,
+  VirtualElement,
+} from '@floating-ui/dom';
+export {
+  autoPlacement,
+  autoUpdate,
+  computePosition,
+  detectOverflow,
+  flip,
+  getOverflowAncestors,
+  hide,
+  inline,
+  limitShift,
+  offset,
+  platform,
+  shift,
+  size,
+} from '@floating-ui/dom';
 
 export type MaybeReadonlyRef<T> = T | Readonly<Ref<T>>;
 


### PR DESCRIPTION
Several issues:

- Middleware option types weren't being re-exported from dependent packages (fixes #2169)
- Some of the comments were outdated, not descriptive, or not matching the wrapped types correctly
- Some of the wrapped DOM types look bad when hovering over types, I used the [`Prettify` util found here](https://twitter.com/mattpocockuk/status/1622730173446557697)
- `MiddlewareArguments` has been deprecated in favor of `MiddlewareState` as it's shorter, cleaner, and is more descriptive
- Added `@deprecated` comment to `reference`, `floating`, and `positionReference` values returned from `useFloating`