### PR TITLE
fix(useTransitionStyles): apply initial styles in `unmounted` status

### DIFF
--- a/packages/react/src/hooks/useTransition.ts
+++ b/packages/react/src/hooks/useTransition.ts
@@ -151,7 +151,7 @@ export function useTransitionStyles<RT extends ReferenceType = ReferenceType>(
         return acc;
       }, {});
 
-    if (status === 'initial') {
+    if (status === 'initial' || status === 'unmounted') {
       setStyles((styles) => ({
         transitionProperty: styles.transitionProperty,
         ...commonStyles,


### PR DESCRIPTION
Allows `transition-delay` to work on first render