### PR TITLE
feat(FloatingPortal): allow to override FloatingPortal root node

### DIFF
--- a/packages/react/src/components/FloatingPortal.tsx
+++ b/packages/react/src/components/FloatingPortal.tsx
@@ -66,10 +66,12 @@ export const useFloatingPortalNode = ({
   id,
   root,
   enabled = true,
+  direct = false,
 }: {
   id?: string;
   root?: HTMLElement | null | string;
   enabled?: boolean;
+  direct?: boolean;
 } = {}) => {
   const [portalEl, setPortalEl] = React.useState<HTMLElement | null>(null);
   const uniqueId = useId();
@@ -81,12 +83,16 @@ export const useFloatingPortalNode = ({
     if (!enabled) {
       return;
     }
+    const getContainer = () =>
+      portalContext?.portalNode || resolveRootContainer(portalRootNode);
 
     const rootNode = id ? document.getElementById(id) : null;
 
     if (rootNode) {
       rootNode.setAttribute('data-floating-ui-portal', '');
       setPortalEl(rootNode);
+    } else if (direct) {
+      setPortalEl(getContainer());
     } else {
       const newPortalEl = document.createElement('div');
       if (id !== '') {
@@ -95,15 +101,14 @@ export const useFloatingPortalNode = ({
       newPortalEl.setAttribute('data-floating-ui-portal', '');
       setPortalEl(newPortalEl);
 
-      const container =
-        portalContext?.portalNode || resolveRootContainer(portalRootNode);
+      const container = getContainer();
 
       container.appendChild(newPortalEl);
       return () => {
         container.removeChild(newPortalEl);
       };
     }
-  }, [id, portalContext, portalRootNode, uniqueId, enabled]);
+  }, [id, portalContext, portalRootNode, uniqueId, enabled, direct]);
 
   return portalEl;
 };
@@ -118,6 +123,7 @@ export const FloatingPortal = ({
   id,
   root = null,
   preserveTabOrder = true,
+  direct,
 }: {
   children?: React.ReactNode;
   /**
@@ -126,8 +132,9 @@ export const FloatingPortal = ({
   id?: string;
   root?: HTMLElement | null | string;
   preserveTabOrder?: boolean;
+  direct?: boolean;
 }) => {
-  const portalNode = useFloatingPortalNode({id, root});
+  const portalNode = useFloatingPortalNode({id, root, direct});
   const [focusManagerState, setFocusManagerState] =
     React.useState<FocusManagerState>(null);
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,6 +8,7 @@ export {FloatingFocusManager} from './components/FloatingFocusManager';
 export {FloatingOverlay} from './components/FloatingOverlay';
 export {
   FloatingPortal,
+  FloatingPortalRoot,
   useFloatingPortalNode,
 } from './components/FloatingPortal';
 export {

--- a/packages/react/test/unit/FloatingPortal.test.tsx
+++ b/packages/react/test/unit/FloatingPortal.test.tsx
@@ -1,7 +1,7 @@
 import {cleanup, fireEvent, render, screen} from '@testing-library/react';
 import {useState} from 'react';
 
-import {FloatingPortal, useFloating} from '../../src';
+import {FloatingPortal, FloatingPortalRoot, useFloating} from '../../src';
 
 function App(props: {root?: HTMLElement | null; id?: string}) {
   const [open, setOpen] = useState(false);
@@ -24,24 +24,44 @@ function App(props: {root?: HTMLElement | null; id?: string}) {
   );
 }
 
-test('creates a custom id node', () => {
-  render(<App id="custom-id" />);
-  expect(document.querySelector('#custom-id')).toBeInTheDocument();
-  cleanup();
-});
-
-test('allows direct roots', () => {
-  render(<App root={document.body} />);
+test('use document.body as default portal container', () => {
+  render(<App />);
   fireEvent.click(screen.getByTestId('reference'));
-  expect(screen.getByTestId('floating').parentNode).toBe(document.body);
-  cleanup();
-});
-
-test('empty id string does not add id attribute', () => {
-  render(<App id="" />);
-  fireEvent.click(screen.getByTestId('reference'));
-  expect(screen.getByTestId('floating').parentElement?.hasAttribute('id')).toBe(
-    false
+  expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(
+    document.body
   );
+  cleanup();
+});
+
+test('allow to override portal container', () => {
+  const id = 'portalContainer';
+  const portalRoot = document.createElement('div');
+  portalRoot.setAttribute('id', id);
+  document.body.appendChild(portalRoot);
+
+  render(
+    <FloatingPortalRoot root={document.getElementById(id)}>
+      <App />
+    </FloatingPortalRoot>
+  );
+  fireEvent.click(screen.getByTestId('reference'));
+  expect(screen.getByTestId('floating').parentElement?.parentElement).toBe(
+    portalRoot
+  );
+  cleanup();
+});
+
+test('allow to override portal container with string', () => {
+  render(
+    <FloatingPortalRoot root={'portalContainer'}>
+      <App />
+    </FloatingPortalRoot>
+  );
+  fireEvent.click(screen.getByTestId('reference'));
+  expect(
+    screen
+      .getByTestId('floating')
+      .parentElement?.parentElement?.getAttribute('id')
+  ).toBe('portalContainer');
   cleanup();
 });

--- a/packages/react/test/unit/FloatingPortal.test.tsx
+++ b/packages/react/test/unit/FloatingPortal.test.tsx
@@ -3,7 +3,11 @@ import {useState} from 'react';
 
 import {FloatingPortal, FloatingPortalRoot, useFloating} from '../../src';
 
-function App(props: {root?: HTMLElement | null | string; id?: string}) {
+function App(props: {
+  root?: HTMLElement | null | string;
+  id?: string;
+  direct?: boolean;
+}) {
   const [open, setOpen] = useState(false);
   const {reference, floating} = useFloating({
     open,
@@ -23,6 +27,28 @@ function App(props: {root?: HTMLElement | null | string; id?: string}) {
     </>
   );
 }
+
+test('creates a custom id node', () => {
+  render(<App id="custom-id" />);
+  expect(document.querySelector('#custom-id')).toBeInTheDocument();
+  cleanup();
+});
+
+test('allows direct roots', () => {
+  render(<App root={document.body} direct />);
+  fireEvent.click(screen.getByTestId('reference'));
+  expect(screen.getByTestId('floating').parentNode).toBe(document.body);
+  cleanup();
+});
+
+test('empty id string does not add id attribute', () => {
+  render(<App id="" />);
+  fireEvent.click(screen.getByTestId('reference'));
+  expect(screen.getByTestId('floating').parentElement?.hasAttribute('id')).toBe(
+    false
+  );
+  cleanup();
+});
 
 test('use document.body as default portal container', () => {
   render(<App />);
@@ -78,5 +104,14 @@ test('allow to override portal container with FloatingPortal', () => {
       .getByTestId('floating')
       .parentElement?.parentElement?.getAttribute('id')
   ).toBe('portalContainer2');
+  cleanup();
+});
+
+test('direct append to portal container', () => {
+  render(<App root={'portalContainer'} direct />);
+  fireEvent.click(screen.getByTestId('reference'));
+  expect(screen.getByTestId('floating').parentElement?.getAttribute('id')).toBe(
+    'portalContainer'
+  );
   cleanup();
 });

--- a/packages/react/test/unit/FloatingPortal.test.tsx
+++ b/packages/react/test/unit/FloatingPortal.test.tsx
@@ -3,7 +3,7 @@ import {useState} from 'react';
 
 import {FloatingPortal, FloatingPortalRoot, useFloating} from '../../src';
 
-function App(props: {root?: HTMLElement | null; id?: string}) {
+function App(props: {root?: HTMLElement | null | string; id?: string}) {
   const [open, setOpen] = useState(false);
   const {reference, floating} = useFloating({
     open,
@@ -63,5 +63,20 @@ test('allow to override portal container with string', () => {
       .getByTestId('floating')
       .parentElement?.parentElement?.getAttribute('id')
   ).toBe('portalContainer');
+  cleanup();
+});
+
+test('allow to override portal container with FloatingPortal', () => {
+  render(
+    <FloatingPortalRoot root={'rootContainer1'}>
+      <App root={'portalContainer2'} />
+    </FloatingPortalRoot>
+  );
+  fireEvent.click(screen.getByTestId('reference'));
+  expect(
+    screen
+      .getByTestId('floating')
+      .parentElement?.parentElement?.getAttribute('id')
+  ).toBe('portalContainer2');
   cleanup();
 });

--- a/packages/react/test/visual/components/Drawer.tsx
+++ b/packages/react/test/visual/components/Drawer.tsx
@@ -2,6 +2,7 @@ import {
   FloatingFocusManager,
   FloatingOverlay,
   FloatingPortal,
+  FloatingPortalRoot,
   useClick,
   useDismiss,
   useFloating,
@@ -96,19 +97,21 @@ export function Drawer({children, render}: Props) {
     <>
       {isValidElement(children) &&
         cloneElement(children, getReferenceProps({ref: refs.setReference}))}
-      <FloatingPortal id="drawer-root">
-        {open &&
-          (modal ? (
-            <FloatingOverlay
-              lockScroll
-              style={{background: 'rgba(0, 0, 0, 0.8)', zIndex: 1}}
-            >
-              {content}
-            </FloatingOverlay>
-          ) : (
-            content
-          ))}
-      </FloatingPortal>
+      <FloatingPortalRoot root="drawer-root">
+        <FloatingPortal>
+          {open &&
+            (modal ? (
+              <FloatingOverlay
+                lockScroll
+                style={{background: 'rgba(0, 0, 0, 0.8)', zIndex: 1}}
+              >
+                {content}
+              </FloatingOverlay>
+            ) : (
+              content
+            ))}
+        </FloatingPortal>
+      </FloatingPortalRoot>
     </>
   );
 }

--- a/packages/react/test/visual/components/Drawer.tsx
+++ b/packages/react/test/visual/components/Drawer.tsx
@@ -2,7 +2,6 @@ import {
   FloatingFocusManager,
   FloatingOverlay,
   FloatingPortal,
-  FloatingPortalRoot,
   useClick,
   useDismiss,
   useFloating,
@@ -97,21 +96,19 @@ export function Drawer({children, render}: Props) {
     <>
       {isValidElement(children) &&
         cloneElement(children, getReferenceProps({ref: refs.setReference}))}
-      <FloatingPortalRoot root="drawer-root">
-        <FloatingPortal>
-          {open &&
-            (modal ? (
-              <FloatingOverlay
-                lockScroll
-                style={{background: 'rgba(0, 0, 0, 0.8)', zIndex: 1}}
-              >
-                {content}
-              </FloatingOverlay>
-            ) : (
-              content
-            ))}
-        </FloatingPortal>
-      </FloatingPortalRoot>
+      <FloatingPortal root="drawer-root">
+        {open &&
+          (modal ? (
+            <FloatingOverlay
+              lockScroll
+              style={{background: 'rgba(0, 0, 0, 0.8)', zIndex: 1}}
+            >
+              {content}
+            </FloatingOverlay>
+          ) : (
+            content
+          ))}
+      </FloatingPortal>
     </>
   );
 }

--- a/website/pages/docs/FloatingPortal.mdx
+++ b/website/pages/docs/FloatingPortal.mdx
@@ -24,9 +24,15 @@ function Tooltip() {
 
 ```ts
 interface Props {
+  root?: HTMLElement | null | string;
   preserveTabOrder?: boolean;
+  direct?: boolean;
 }
 ```
+
+### root
+
+Same as `FloatingPortalRoot` root
 
 ### preserveTabOrder
 
@@ -35,6 +41,12 @@ default: `true{:js}`
 When using non-modal focus management using
 `<FloatingFocusManager />{:js}`, this will preserve the tab order
 context based on the React tree instead of the DOM tree.
+
+### direct
+
+default: `false{:js}`
+
+Allow to directly append, floating cotent
 
 ```js
 <FloatingPortal preserveTabOrder={false}>

--- a/website/pages/docs/FloatingPortal.mdx
+++ b/website/pages/docs/FloatingPortal.mdx
@@ -24,40 +24,8 @@ function Tooltip() {
 
 ```ts
 interface Props {
-  id?: string;
-  root?: HTMLElement | null;
   preserveTabOrder?: boolean;
 }
-```
-
-### id
-
-default: `undefined{:js}`
-
-If this node does not exist on the document, it will be created
-for you and will be appended to the end of the `<body>{:html}`. A
-unique React id is assigned to it. Context is provided so that
-portals nested in one another are appended to their respective
-parent.
-
-By specifying a string, it assumes the container is being
-controlled externally or is static.
-
-```js
-<FloatingPortal id="custom-root-id">
-  {isOpen && <div>Tooltip</div>}
-</FloatingPortal>
-```
-
-### root
-
-Alternatively, you may pass the root element itself, which
-supports shadow roots.
-
-```js
-<FloatingPortal root={shadowRootNode}>
-  {isOpen && <div>Tooltip</div>}
-</FloatingPortal>
 ```
 
 ### preserveTabOrder
@@ -73,6 +41,37 @@ context based on the React tree instead of the DOM tree.
   {isOpen && <div>Tooltip</div>}
 </FloatingPortal>
 ```
+
+## FloatingPortalRoot
+
+Using FloatingPortalRoot default portal container (body) can be
+overridden by root prop.
+
+```js
+import {FloatingPortalRoot} from '@floating-ui/react';
+
+function App() {
+  return (
+    <FloatingPortalRoot root="root">
+      <Tooltip />
+    </FloatingPortalRoot>
+  );
+}
+```
+
+## Props
+
+```ts
+interface Props {
+  root: HTMLElement | null | string;
+}
+```
+
+### root
+
+You may pass the element or id as a string, By specifying a
+string, if node does not exist on the document, it will be
+created and appended to body.
 
 ## useFloatingPortalNode
 


### PR DESCRIPTION
Having structure like below, react will render to stage element. With this we would allow render `all portals` to `rootContainer` via FloatingPortalRootNodeContext.

```jsx
<body>
  <div id="before" />
  <div id="rootContainer">
    <div id="stage" />
  </div>
</body>
```
