### PR TITLE
feat(react): `FloatingArrow` component

### DIFF
--- a/packages/react-dom/src/arrow.ts
+++ b/packages/react-dom/src/arrow.ts
@@ -8,9 +8,8 @@ export interface Options {
 }
 
 /**
- * A data provider that provides data to position an inner element of the
- * floating element (usually a triangle or caret) so that it is centered to the
- * reference element.
+ * Provides data to position an inner element of the floating element so that it
+ * appears centered to the reference element.
  * This wraps the core `arrow` middleware to allow React refs as the element.
  * @see https://floating-ui.com/docs/arrow
  */

--- a/packages/react/index.test-d.tsx
+++ b/packages/react/index.test-d.tsx
@@ -1,8 +1,8 @@
 import {useRef} from 'react';
 
 import {
-  Arrow,
   arrow,
+  FloatingArrow,
   platform,
   safePolygon,
   shift,
@@ -79,8 +79,8 @@ function App() {
 
   return (
     <div ref={ref}>
-      <Arrow context={context} />
-      <Arrow
+      <FloatingArrow context={context} />
+      <FloatingArrow
         context={context}
         stroke="black"
         strokeWidth={2}

--- a/packages/react/index.test-d.tsx
+++ b/packages/react/index.test-d.tsx
@@ -1,6 +1,7 @@
 import {useRef} from 'react';
 
 import {
+  Arrow,
   arrow,
   platform,
   safePolygon,
@@ -21,20 +22,22 @@ App;
 function App() {
   const arrowRef = useRef(null);
   useFloating();
-  const {reference, floating, positionReference, update} = useFloating({
-    placement: 'right',
-    middleware: [
-      shift(),
-      arrow({element: arrowRef}),
-      false && shift(),
-      null,
-      undefined,
-    ],
-    strategy: 'fixed',
-    platform: {
-      ...platform,
-    },
-  });
+  const {reference, floating, positionReference, update, context} = useFloating(
+    {
+      placement: 'right',
+      middleware: [
+        shift(),
+        arrow({element: arrowRef}),
+        false && shift(),
+        null,
+        undefined,
+      ],
+      strategy: 'fixed',
+      platform: {
+        ...platform,
+      },
+    }
+  );
   reference(null);
   reference({
     getBoundingClientRect() {
@@ -74,7 +77,20 @@ function App() {
   const ref2 = useRef<HTMLDivElement>(null);
   const ref = useMergeRefs([ref1, ref2, arrowRef, null]);
 
-  return <div ref={ref} />;
+  return (
+    <div ref={ref}>
+      <Arrow context={context} />
+      <Arrow
+        context={context}
+        stroke="black"
+        strokeWidth={2}
+        fill="black"
+        width={14}
+        height={14}
+        roundness={50}
+      />
+    </div>
+  );
 }
 
 NarrowRefType;

--- a/packages/react/index.test-d.tsx
+++ b/packages/react/index.test-d.tsx
@@ -87,7 +87,7 @@ function App() {
         fill="black"
         width={14}
         height={14}
-        roundness={50}
+        tipRadius={50}
       />
     </div>
   );

--- a/packages/react/src/components/Arrow.tsx
+++ b/packages/react/src/components/Arrow.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+
+import {platform} from '../';
+import type {Alignment, FloatingContext, Side} from '../types';
+
+export interface Props extends React.SVGAttributes<SVGSVGElement> {
+  context: FloatingContext;
+
+  /**
+   * Width of the arrow.
+   * @default 14
+   */
+  width?: number;
+
+  /**
+   * Height of the arrow.
+   * @default 7
+   */
+  height?: number;
+
+  /**
+   * The roundness of the arrow (0 - 100+)
+   * @default 0 (sharp)
+   */
+  roundness?: number;
+
+  /**
+   * Forces a static offset over dynamic positioning under a certain condition.
+   */
+  staticOffset?: string | number | null;
+
+  /**
+   * Custom path string.
+   */
+  d?: string;
+
+  /**
+   * Stroke (border) color of the arrow.
+   */
+  stroke?: string;
+
+  /**
+   * Stroke (border) width of the arrow.
+   */
+  strokeWidth?: number;
+}
+
+/**
+ * Renders a pointing arrow triangle.
+ * @see https://floating-ui.com/docs/ArrowComponent
+ */
+export const Arrow = React.forwardRef(function Arrow(
+  {
+    context: {
+      placement,
+      elements: {floating},
+      middlewareData: {arrow},
+    },
+    width = 14,
+    height = 7,
+    roundness = 0,
+    strokeWidth = 0,
+    staticOffset,
+    stroke,
+    d,
+    ...rest
+  }: Props,
+  ref: React.Ref<SVGSVGElement>
+): JSX.Element {
+  if (__DEV__) {
+    if (!ref) {
+      console.warn(
+        'Floating UI: The `ref` prop is required for the `Arrow` component.'
+      );
+    }
+  }
+
+  const svgX = (width / 2) * (-0.54 * (roundness / 100 - 0.02) + 1);
+  const svgY = (height / 2) * (roundness / 100 - 0.02);
+
+  const [side, alignment] = placement.split('-') as [Side, Alignment];
+  const isRTL = floating ? platform.isRTL(floating) : false;
+  const isCustomShape = !!d;
+  const isVerticalSide = side === 'top' || side === 'bottom';
+
+  const yOffsetProp = staticOffset && alignment === 'end' ? 'bottom' : 'top';
+  let xOffsetProp = staticOffset && alignment === 'end' ? 'right' : 'left';
+  if (staticOffset && isRTL) {
+    xOffsetProp = alignment === 'end' ? 'left' : 'right';
+  }
+
+  const arrowX = arrow?.x != null ? staticOffset || arrow.x : '';
+  const arrowY = arrow?.y != null ? staticOffset || arrow.y : '';
+
+  const dValue =
+    d ||
+    'M0,0' +
+      ` H${width}` +
+      ` L${width - svgX},${height - svgY}` +
+      ` Q${width / 2},${height} ${svgX},${height - svgY}` +
+      ' Z';
+
+  const rotation = {
+    top: isCustomShape ? 'rotate(180deg)' : '',
+    left: isCustomShape ? 'rotate(90deg)' : 'rotate(-90deg)',
+    bottom: isCustomShape ? '' : 'rotate(180deg)',
+    right: isCustomShape ? 'rotate(-90deg)' : 'rotate(90deg)',
+  }[side];
+
+  return (
+    <svg
+      {...rest}
+      aria-hidden
+      ref={ref}
+      width={isCustomShape ? width : width + (isVerticalSide ? strokeWidth : 0)}
+      height={width}
+      viewBox={
+        isCustomShape
+          ? `0 0 ${width} ${width}`
+          : `0 0 ${width} ${width + (!isVerticalSide ? strokeWidth : 0)}`
+      }
+      style={{
+        ...rest.style,
+        position: 'absolute',
+        pointerEvents: 'none',
+        [xOffsetProp]: arrowX ?? '',
+        [yOffsetProp]: arrowY ?? '',
+        [side]: '100%',
+        transform: `${rotation}${
+          rest.style?.transform ? ` ${rest.style.transform}` : ''
+        }`,
+      }}
+    >
+      <path fill="none" stroke={stroke} strokeWidth={strokeWidth} d={dValue} />
+      <path stroke="none" d={dValue} />
+    </svg>
+  );
+});

--- a/packages/react/src/components/FloatingArrow.tsx
+++ b/packages/react/src/components/FloatingArrow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {platform} from '../';
+import {platform} from '..';
 import type {Alignment, FloatingContext, Side} from '../types';
 
 export interface Props extends React.SVGAttributes<SVGSVGElement> {
@@ -47,9 +47,9 @@ export interface Props extends React.SVGAttributes<SVGSVGElement> {
 
 /**
  * Renders a pointing arrow triangle.
- * @see https://floating-ui.com/docs/ArrowComponent
+ * @see https://floating-ui.com/docs/FloatingArrow
  */
-export const Arrow = React.forwardRef(function Arrow(
+export const FloatingArrow = React.forwardRef(function FloatingArrow(
   {
     context: {
       placement,

--- a/packages/react/src/components/FloatingArrow.tsx
+++ b/packages/react/src/components/FloatingArrow.tsx
@@ -70,7 +70,8 @@ export const FloatingArrow = React.forwardRef(function FloatingArrow(
   if (__DEV__) {
     if (!ref) {
       console.warn(
-        'Floating UI: The `ref` prop is required for the `Arrow` component.'
+        'Floating UI: The `ref` prop is required for the `FloatingArrow`',
+        'component.'
       );
     }
   }

--- a/packages/react/src/components/FloatingArrow.tsx
+++ b/packages/react/src/components/FloatingArrow.tsx
@@ -19,10 +19,10 @@ export interface Props extends React.SVGAttributes<SVGSVGElement> {
   height?: number;
 
   /**
-   * The roundness of the arrow (0 - 100+)
+   * The corner radius (rounding) of the arrow tip.
    * @default 0 (sharp)
    */
-  roundness?: number;
+  tipRadius?: number;
 
   /**
    * Forces a static offset over dynamic positioning under a certain condition.
@@ -58,7 +58,7 @@ export const FloatingArrow = React.forwardRef(function FloatingArrow(
     },
     width = 14,
     height = 7,
-    roundness = 0,
+    tipRadius = 0,
     strokeWidth = 0,
     staticOffset,
     stroke,
@@ -76,8 +76,8 @@ export const FloatingArrow = React.forwardRef(function FloatingArrow(
     }
   }
 
-  const svgX = (width / 2) * (-0.54 * (roundness / 100 - 0.02) + 1);
-  const svgY = (height / 2) * (roundness / 100 - 0.02);
+  const svgX = (width / 2) * (tipRadius / -8 + 1);
+  const svgY = ((height / 2) * tipRadius) / 4;
 
   const [side, alignment] = placement.split('-') as [Side, Alignment];
   const isRTL = floating ? platform.isRTL(floating) : false;

--- a/packages/react/src/components/FloatingArrow.tsx
+++ b/packages/react/src/components/FloatingArrow.tsx
@@ -132,8 +132,18 @@ export const FloatingArrow = React.forwardRef(function FloatingArrow(
         }`,
       }}
     >
-      <path fill="none" stroke={stroke} strokeWidth={strokeWidth} d={dValue} />
-      <path stroke="none" d={dValue} />
+      {strokeWidth > 0 && (
+        <path
+          fill="none"
+          stroke={stroke}
+          // Account for the stroke on the fill path rendered below.
+          strokeWidth={strokeWidth + (d ? 0 : 1)}
+          d={dValue}
+        />
+      )}
+      {/* In Firefox, for left/right placements there's a ~0.5px gap where the
+      border can show through. Adding a stroke on the fill removes it. */}
+      <path stroke={strokeWidth && !d ? rest.fill : 'none'} d={dValue} />
     </svg>
   );
 });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,4 @@
+export {Arrow, Props as ArrowProps} from './components/Arrow';
 export {
   FloatingDelayGroup,
   useDelayGroup,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,4 @@
-export {
-  FloatingArrow,
-  Props as FloatingArrowProps,
-} from './components/FloatingArrow';
+export {FloatingArrow} from './components/FloatingArrow';
 export {
   FloatingDelayGroup,
   useDelayGroup,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,7 @@
-export {Arrow, Props as ArrowProps} from './components/Arrow';
+export {
+  FloatingArrow,
+  Props as FloatingArrowProps,
+} from './components/FloatingArrow';
 export {
   FloatingDelayGroup,
   useDelayGroup,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -12,6 +12,7 @@ import * as React from 'react';
 import type {DismissPayload} from './hooks/useDismiss';
 
 export * from '.';
+export {Props as ArrowProps} from './components/Arrow';
 export {Props as UseClickProps} from './hooks/useClick';
 export {Props as UseDismissProps} from './hooks/useDismiss';
 export {Props as UseFocusProps} from './hooks/useFocus';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -12,7 +12,7 @@ import * as React from 'react';
 import type {DismissPayload} from './hooks/useDismiss';
 
 export * from '.';
-export {Props as ArrowProps} from './components/FloatingArrow';
+export {Props as FloatingArrowProps} from './components/FloatingArrow';
 export {Props as UseClickProps} from './hooks/useClick';
 export {Props as UseDismissProps} from './hooks/useDismiss';
 export {Props as UseFocusProps} from './hooks/useFocus';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -12,7 +12,7 @@ import * as React from 'react';
 import type {DismissPayload} from './hooks/useDismiss';
 
 export * from '.';
-export {Props as ArrowProps} from './components/Arrow';
+export {Props as ArrowProps} from './components/FloatingArrow';
 export {Props as UseClickProps} from './hooks/useClick';
 export {Props as UseDismissProps} from './hooks/useDismiss';
 export {Props as UseFocusProps} from './hooks/useFocus';

--- a/packages/react/test/visual/components/Arrow.tsx
+++ b/packages/react/test/visual/components/Arrow.tsx
@@ -1,0 +1,154 @@
+import {
+  Arrow,
+  arrow,
+  autoUpdate,
+  offset,
+  Placement,
+  useFloating,
+} from '@floating-ui/react';
+import {useRef, useState} from 'react';
+
+import type {Props} from '../../../src/components/Arrow';
+
+const ROUND_D =
+  'M0 20C0 20 2.06906 19.9829 5.91817 15.4092C7.49986 13.5236 8.97939 12.3809 10.0002 12.3809C11.0202 12.3809 12.481 13.6451 14.0814 15.5472C17.952 20.1437 20 20 20 20H0Z';
+
+function Demo({
+  placement,
+  arrowProps,
+  floatingStyle,
+}: {
+  placement: Placement;
+  arrowProps: Partial<React.SVGAttributes<SVGSVGElement> & Props>;
+  floatingStyle?: React.CSSProperties;
+}) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const arrowRef = useRef<SVGSVGElement>(null);
+
+  const {x, y, strategy, refs, context} = useFloating({
+    placement,
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    whileElementsMounted: autoUpdate,
+    middleware: [offset(8), arrow({element: arrowRef})],
+  });
+
+  const edgeAlignment = placement.split('-')[1];
+
+  return (
+    <div>
+      <span
+        ref={refs.setReference}
+        style={{
+          background: 'royalblue',
+          padding: 5,
+          color: 'white',
+        }}
+      >
+        {placement}
+      </span>
+      {isOpen && (
+        <div
+          ref={refs.setFloating}
+          style={{
+            position: strategy,
+            top: y ?? 0,
+            left: x ?? 0,
+            background: 'black',
+            color: 'white',
+            padding: 10,
+            ...floatingStyle,
+          }}
+        >
+          Tooltip
+          <Arrow
+            context={context}
+            ref={arrowRef}
+            staticOffset={edgeAlignment ? '15%' : null}
+            {...arrowProps}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+const allPlacements = ['top', 'bottom', 'right', 'left']
+  .map(
+    (placement) =>
+      [placement, `${placement}-start`, `${placement}-end`] as Array<Placement>
+  )
+  .flat();
+
+export const Main = () => {
+  return (
+    <>
+      <h1>Arrow</h1>
+      <p></p>
+      <div className="container" style={{gridTemplateColumns: '1fr 1fr 1fr'}}>
+        {allPlacements.map((placement) => (
+          <Demo key={placement} placement={placement} arrowProps={{}} />
+        ))}
+      </div>
+      <div className="container" style={{gridTemplateColumns: '1fr 1fr 1fr'}}>
+        {allPlacements.map((placement) => (
+          <Demo
+            key={placement}
+            placement={placement}
+            arrowProps={{roundness: 50}}
+          />
+        ))}
+      </div>
+      <div className="container" style={{gridTemplateColumns: '1fr 1fr 1fr'}}>
+        {allPlacements.map((placement) => (
+          <Demo
+            key={placement}
+            placement={placement}
+            arrowProps={{roundness: 100}}
+          />
+        ))}
+      </div>
+      <div className="container" style={{gridTemplateColumns: '1fr 1fr 1fr'}}>
+        {allPlacements.map((placement) => (
+          <Demo
+            key={placement}
+            placement={placement}
+            arrowProps={{
+              fill: 'white',
+              stroke: 'black',
+              strokeWidth: 2,
+              roundness: 25,
+            }}
+            floatingStyle={{
+              border: '1px solid black',
+              color: 'black',
+              background: 'white',
+            }}
+          />
+        ))}
+      </div>
+      <div className="container" style={{gridTemplateColumns: '1fr 1fr 1fr'}}>
+        {allPlacements.map((placement) => (
+          <Demo
+            key={placement}
+            placement={placement}
+            arrowProps={{
+              width: 20,
+              height: 20,
+              fill: 'white',
+              stroke: 'black',
+              strokeWidth: 4,
+              d: ROUND_D,
+            }}
+            floatingStyle={{
+              border: '2px solid black',
+              color: 'black',
+              background: 'white',
+            }}
+          />
+        ))}
+      </div>
+    </>
+  );
+};

--- a/packages/react/test/visual/components/Arrow.tsx
+++ b/packages/react/test/visual/components/Arrow.tsx
@@ -96,7 +96,7 @@ export const Main = () => {
           <Demo
             key={placement}
             placement={placement}
-            arrowProps={{roundness: 50}}
+            arrowProps={{tipRadius: 2}}
           />
         ))}
       </div>
@@ -105,7 +105,7 @@ export const Main = () => {
           <Demo
             key={placement}
             placement={placement}
-            arrowProps={{roundness: 100}}
+            arrowProps={{tipRadius: 5}}
           />
         ))}
       </div>
@@ -118,7 +118,7 @@ export const Main = () => {
               fill: 'white',
               stroke: 'black',
               strokeWidth: 2,
-              roundness: 25,
+              tipRadius: 1,
             }}
             floatingStyle={{
               border: '1px solid black',

--- a/packages/react/test/visual/components/Arrow.tsx
+++ b/packages/react/test/visual/components/Arrow.tsx
@@ -1,14 +1,14 @@
 import {
-  Arrow,
   arrow,
   autoUpdate,
+  FloatingArrow,
   offset,
   Placement,
   useFloating,
 } from '@floating-ui/react';
 import {useRef, useState} from 'react';
 
-import type {Props} from '../../../src/components/Arrow';
+import type {Props} from '../../../src/components/FloatingArrow';
 
 const ROUND_D =
   'M0 20C0 20 2.06906 19.9829 5.91817 15.4092C7.49986 13.5236 8.97939 12.3809 10.0002 12.3809C11.0202 12.3809 12.481 13.6451 14.0814 15.5472C17.952 20.1437 20 20 20 20H0Z';
@@ -62,7 +62,7 @@ function Demo({
           }}
         >
           Tooltip
-          <Arrow
+          <FloatingArrow
             context={context}
             ref={arrowRef}
             staticOffset={edgeAlignment ? '15%' : null}

--- a/packages/react/test/visual/index.tsx
+++ b/packages/react/test/visual/index.tsx
@@ -11,6 +11,7 @@ import {
   useLocation,
 } from 'react-router-dom';
 
+import {Main as Arrow} from './components/Arrow';
 import {Main as Autocomplete} from './components/Autocomplete';
 import {Main as Drawer} from './components/Drawer';
 import {Main as EmojiPicker} from './components/EmojiPicker';
@@ -34,6 +35,7 @@ const ROUTES = [
   {path: 'autocomplete', component: Autocomplete},
   {path: 'navigation', component: Navigation},
   {path: 'drawer', component: Drawer},
+  {path: 'arrow', component: Arrow},
 ];
 
 function App() {


### PR DESCRIPTION
Partially solves #2078

This component is designed to be flexible and support the vast majority of use cases.

- **Simple to setup**: it renders out a 14x7px black-filled SVG arrow by default. 

Placing this inside your tooltip will position everything without any styling required:

```js
<FloatingArrow ref={arrowRef} context={context} />
```

- **Customizable width and height (and therefore `angle`)** via `width` and `height` attributes.
- **Rounded tip**: the `tipRadius` prop accepts a number similar to `border-radius`.
- **Borders**: the `stroke`/`strokeWidth` props can add a border to the arrow.
- **Custom shapes**: the `d` prop accepts a custom path string to create more fancy rounding - the docs will have an example that can be edited via Figma or similar
- **Static offsets**: the `staticOffset` prop allows the dynamic position to be overridden by a static offset under any condition, usually when the floating element is smaller than the reference element along the relevant axis and has an edge alignment.
- **Transparency**: possible as it's a real triangle not a rotated square which would cause overlap darkening.

---

What it doesn't solve but could in the future:

- Skewing via `centerOffset` or even `edgeOffset` when using `staticOffset`, etc.
- Advanced `clip-path` use cases to create an arrow out of a `polygon()` (Wikipedia's hovercards)
- Other things I haven't thought of?


## Caveats

- A gap can appear in Safari when the `x`/`y` coords aren't integers (or placed evenly on the device's subpixel grid). Will document this.
- In Firefox, there's a 0.5px gap that needs a stroke on the "fill" triangle, which I've added as a fix, though it makes it 1px bigger than the value specified when using a stroke.