### PR TITLE
fix: share root id via context

### DIFF
--- a/packages/react/src/hooks/useRole.ts
+++ b/packages/react/src/hooks/useRole.ts
@@ -21,10 +21,9 @@ export interface Props {
  * @see https://floating-ui.com/docs/useRole
  */
 export const useRole = <RT extends ReferenceType = ReferenceType>(
-  {open}: FloatingContext<RT>,
+  {open, rootId}: FloatingContext<RT>,
   {enabled = true, role = 'dialog'}: Partial<Props> = {}
 ): ElementProps => {
-  const rootId = useId();
   const referenceId = useId();
 
   return React.useMemo(() => {

--- a/packages/react/src/hooks/useRole.ts
+++ b/packages/react/src/hooks/useRole.ts
@@ -21,13 +21,13 @@ export interface Props {
  * @see https://floating-ui.com/docs/useRole
  */
 export const useRole = <RT extends ReferenceType = ReferenceType>(
-  {open, rootId}: FloatingContext<RT>,
+  {open, floatingId}: FloatingContext<RT>,
   {enabled = true, role = 'dialog'}: Partial<Props> = {}
 ): ElementProps => {
   const referenceId = useId();
 
   return React.useMemo(() => {
-    const floatingProps = {id: rootId, role};
+    const floatingProps = {id: floatingId, role};
 
     if (!enabled) {
       return {};
@@ -36,7 +36,7 @@ export const useRole = <RT extends ReferenceType = ReferenceType>(
     if (role === 'tooltip') {
       return {
         reference: {
-          'aria-describedby': open ? rootId : undefined,
+          'aria-describedby': open ? floatingId : undefined,
         },
         floating: floatingProps,
       };
@@ -46,7 +46,7 @@ export const useRole = <RT extends ReferenceType = ReferenceType>(
       reference: {
         'aria-expanded': open ? 'true' : 'false',
         'aria-haspopup': role === 'alertdialog' ? 'dialog' : role,
-        'aria-controls': open ? rootId : undefined,
+        'aria-controls': open ? floatingId : undefined,
         ...(role === 'listbox' && {
           role: 'combobox',
         }),
@@ -61,5 +61,5 @@ export const useRole = <RT extends ReferenceType = ReferenceType>(
         }),
       },
     };
-  }, [enabled, role, open, rootId, referenceId]);
+  }, [enabled, role, open, floatingId, referenceId]);
 };

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -129,6 +129,7 @@ export type FloatingContext<RT extends ReferenceType = ReferenceType> =
       events: FloatingEvents;
       dataRef: React.MutableRefObject<ContextData>;
       nodeId: string | undefined;
+      rootId: string;
       refs: ExtendedRefs<RT>;
       elements: ExtendedElements<RT>;
     }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -129,7 +129,7 @@ export type FloatingContext<RT extends ReferenceType = ReferenceType> =
       events: FloatingEvents;
       dataRef: React.MutableRefObject<ContextData>;
       nodeId: string | undefined;
-      rootId: string;
+      floatingId: string;
       refs: ExtendedRefs<RT>;
       elements: ExtendedElements<RT>;
     }

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -3,8 +3,9 @@ import * as React from 'react';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
 
 import {useFloatingTree} from './components/FloatingTree';
+import {useId} from './hooks/useId';
 import {useEvent} from './hooks/utils/useEvent';
-import type {
+import {
   ContextData,
   FloatingContext,
   NarrowedElement,
@@ -29,6 +30,8 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
   const domReferenceRef = React.useRef<NarrowedElement<RT> | null>(null);
   const dataRef = React.useRef<ContextData>({});
   const events = React.useState(() => createPubSub())[0];
+
+  const rootId = useId();
 
   const [domReference, setDomReference] =
     React.useState<NarrowedElement<RT> | null>(null);
@@ -97,11 +100,12 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
       elements,
       dataRef,
       nodeId,
+      rootId,
       events,
       open,
       onOpenChange,
     }),
-    [position, nodeId, events, open, onOpenChange, refs, elements]
+    [position, nodeId, rootId, events, open, onOpenChange, refs, elements]
   );
 
   useLayoutEffect(() => {

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -5,7 +5,7 @@ import useLayoutEffect from 'use-isomorphic-layout-effect';
 import {useFloatingTree} from './components/FloatingTree';
 import {useId} from './hooks/useId';
 import {useEvent} from './hooks/utils/useEvent';
-import {
+import type {
   ContextData,
   FloatingContext,
   NarrowedElement,

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -31,7 +31,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
   const dataRef = React.useRef<ContextData>({});
   const events = React.useState(() => createPubSub())[0];
 
-  const rootId = useId();
+  const floatingId = useId();
 
   const [domReference, setDomReference] =
     React.useState<NarrowedElement<RT> | null>(null);
@@ -100,12 +100,12 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
       elements,
       dataRef,
       nodeId,
-      rootId,
+      floatingId,
       events,
       open,
       onOpenChange,
     }),
-    [position, nodeId, rootId, events, open, onOpenChange, refs, elements]
+    [position, nodeId, floatingId, events, open, onOpenChange, refs, elements]
   );
 
   useLayoutEffect(() => {

--- a/packages/react/test/unit/useRole.test.tsx
+++ b/packages/react/test/unit/useRole.test.tsx
@@ -117,7 +117,7 @@ describe('dialog', () => {
     cleanup();
   });
 
-  test('sets correct aria attributs with external ref, multiple useRole calls', () => {
+  test('sets correct aria attributes with external ref, multiple useRole calls', () => {
     render(<AppWithExternalRef role="dialog" />);
 
     const button = screen.getByRole('button');

--- a/packages/react/test/unit/useRole.test.tsx
+++ b/packages/react/test/unit/useRole.test.tsx
@@ -1,11 +1,14 @@
 import {cleanup, fireEvent, render, screen} from '@testing-library/react';
 import {useState} from 'react';
 
-import {useFloating, useInteractions, useRole} from '../../src';
+import {useFloating, useId, useInteractions, useRole} from '../../src';
 import type {Props} from '../../src/hooks/useRole';
 
-function App(props: Props & {initiallyOpen?: boolean}) {
-  const [open, setOpen] = useState(props.initiallyOpen ?? false);
+function App({
+  initiallyOpen = false,
+  ...props
+}: Props & {initiallyOpen?: boolean}) {
+  const [open, setOpen] = useState(initiallyOpen);
   const {reference, floating, context} = useFloating({
     open,
     onOpenChange: setOpen,
@@ -13,6 +16,39 @@ function App(props: Props & {initiallyOpen?: boolean}) {
   const {getReferenceProps, getFloatingProps} = useInteractions([
     useRole(context, props),
   ]);
+
+  return (
+    <>
+      <button
+        {...getReferenceProps({
+          ref: reference,
+          onClick() {
+            setOpen(!open);
+          },
+        })}
+      />
+      {open && (
+        <div
+          {...getFloatingProps({
+            ref: floating,
+          })}
+        />
+      )}
+    </>
+  );
+}
+
+function AppWithExternalRef(props: Props & {initiallyOpen?: boolean}) {
+  const [open, setOpen] = useState(props.initiallyOpen ?? false);
+  const nodeId = useId();
+  const {reference, floating, context} = useFloating({
+    nodeId,
+    open,
+    onOpenChange: setOpen,
+  });
+  // External ref can use it's own set of interactions hooks, but share context
+  const {getFloatingProps} = useInteractions([useRole(context, props)]);
+  const {getReferenceProps} = useInteractions([useRole(context, props)]);
 
   return (
     <>
@@ -56,6 +92,33 @@ describe('tooltip', () => {
 describe('dialog', () => {
   test('sets correct aria attributes based on the open state', () => {
     render(<App role="dialog" />);
+
+    const button = screen.getByRole('button');
+
+    expect(button.getAttribute('aria-haspopup')).toBe('dialog');
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(button);
+
+    expect(screen.queryByRole('dialog')).toBeInTheDocument();
+    expect(button.getAttribute('aria-controls')).toBe(
+      screen.getByRole('dialog').getAttribute('id')
+    );
+    expect(button.hasAttribute('aria-describedby')).toBe(false);
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+
+    fireEvent.click(button);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(button.hasAttribute('aria-controls')).toBe(false);
+    expect(button.hasAttribute('aria-describedby')).toBe(false);
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+
+    cleanup();
+  });
+
+  test('sets correct aria attributs with external ref, multiple useRole calls', () => {
+    render(<AppWithExternalRef role="dialog" />);
 
     const button = screen.getByRole('button');
 


### PR DESCRIPTION
Relates to this: https://github.com/floating-ui/floating-ui/issues/2128#issuecomment-1452077329

When an external reference is using its own set of interactions hooks because it needs to configure them differently per reference, they should still use the same floating element ID reference throughout.