### PR TITLE
React/Vue v1

### DIFF
--- a/packages/react-dom/src/types.ts
+++ b/packages/react-dom/src/types.ts
@@ -70,9 +70,7 @@ type Prettify<T> = {
 } & {};
 
 export type UseFloatingData = Prettify<
-  Omit<ComputePositionReturn, 'x' | 'y'> & {
-    x: number | null;
-    y: number | null;
+  ComputePositionReturn & {
     isPositioned: boolean;
   }
 >;
@@ -115,7 +113,7 @@ export type UseFloatingProps<RT extends ReferenceType = ReferenceType> =
         reference: RT,
         floating: HTMLElement,
         update: () => void
-      ) => void | (() => void);
+      ) => () => void;
       open?: boolean;
     }
   >;

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -30,8 +30,8 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
   } = options;
 
   const [data, setData] = React.useState<UseFloatingData>({
-    x: null,
-    y: null,
+    x: 0,
+    y: 0,
     strategy,
     placement,
     middlewareData: {},

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -31,7 +31,7 @@ export {
 
 const ORIGIN = {x: 0, y: 0};
 
-type UseFloatingReturn = Data & {
+type UseFloatingReturn = ComputePositionReturn & {
   update: () => void;
   offsetParent: (node: any) => void;
   floating: (node: any) => void;
@@ -59,11 +59,6 @@ type UseFloatingReturn = Data & {
   };
 };
 
-type Data = Omit<ComputePositionReturn, 'x' | 'y'> & {
-  x: number | null;
-  y: number | null;
-};
-
 export const useFloating = ({
   placement = 'bottom',
   middleware = [],
@@ -81,9 +76,9 @@ export const useFloating = ({
   const floatingRef = useRef<any>(null);
   const offsetParentRef = useRef<any>(null);
 
-  const [data, setData] = useState<Data>({
-    x: null,
-    y: null,
+  const [data, setData] = useState<ComputePositionReturn>({
+    x: 0,
+    y: 0,
     placement,
     strategy: 'absolute',
     middlewareData: {},

--- a/packages/react/index.test-d.tsx
+++ b/packages/react/index.test-d.tsx
@@ -75,7 +75,7 @@ function App() {
 
   const ref1 = useRef<HTMLDivElement>(null);
   const ref2 = useRef<HTMLDivElement>(null);
-  const ref = useMergeRefs([ref1, ref2, arrowRef, null]);
+  const ref = useMergeRefs(ref1, ref2, arrowRef, null);
 
   return (
     <div ref={ref}>
@@ -98,7 +98,7 @@ function NarrowRefType() {
   const floating1 = useFloating();
   const floating2 = useFloating<HTMLButtonElement>();
   const floating3 = useFloating<HTMLAnchorElement>();
-  useInteractions([
+  useInteractions(
     useClick(floating2.context),
     useDismiss(floating2.context),
     useFocus(floating2.context),
@@ -107,8 +107,8 @@ function NarrowRefType() {
     }),
     useListNavigation(floating2.context),
     useRole(floating2.context),
-    useTypeahead(floating2.context),
-  ]);
+    useTypeahead(floating2.context)
+  );
 
   // @ts-expect-error
   floating1.refs.reference.current?.contains(document.body);

--- a/packages/react/src/components/FloatingBackdrop.tsx
+++ b/packages/react/src/components/FloatingBackdrop.tsx
@@ -6,15 +6,15 @@ import {getPlatform} from '../utils/getPlatform';
 const identifier = 'data-floating-ui-scroll-lock';
 
 /**
- * Provides base styling for a fixed overlay element to dim content or block
+ * Provides base styling for a fixed backdrop element to dim content or block
  * pointer events behind a floating element.
  * It's a regular `<div>`, so it can be styled via any CSS solution you prefer.
- * @see https://floating-ui.com/docs/FloatingOverlay
+ * @see https://floating-ui.com/docs/FloatingBackdrop
  */
-export const FloatingOverlay = React.forwardRef<
+export const FloatingBackdrop = React.forwardRef<
   HTMLDivElement,
   React.HTMLProps<HTMLDivElement> & {lockScroll?: boolean}
->(function FloatingOverlay({lockScroll = false, ...rest}, ref) {
+>(function FloatingBackdrop({lockScroll = false, ...rest}, ref) {
   useLayoutEffect(() => {
     if (!lockScroll) {
       return;

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -73,7 +73,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     nodeId,
     onOpenChange,
     events,
-    dataRef,
+    data,
     elements: {domReference, floating},
   } = context;
 
@@ -212,12 +212,12 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
         contains(portalContext?.portalNode, relatedTarget) ||
         relatedTarget?.hasAttribute('data-floating-ui-focus-guard') ||
         (tree &&
-          (getChildren(tree.nodesRef.current, nodeId).find(
+          (getChildren(tree.nodes, nodeId).find(
             (node) =>
               contains(node.context?.elements.floating, relatedTarget) ||
               contains(node.context?.elements.domReference, relatedTarget)
           ) ||
-            getAncestors(tree.nodesRef.current, nodeId).find(
+            getAncestors(tree.nodes, nodeId).find(
               (node) =>
                 node.context?.elements.floating === relatedTarget ||
                 node.context?.elements.domReference === relatedTarget
@@ -336,7 +336,6 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
 
     let preventReturnFocusScroll = false;
     const previouslyFocusedElement = activeElement(doc);
-    const contextData = dataRef.current;
     const initialFocusValue = initialFocusRef.current;
 
     previouslyFocusedElementRef.current = previouslyFocusedElement;
@@ -405,7 +404,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
           // re-open it, unless they call `event.preventDefault()` in the
           // `keydown` listener. This helps keep backwards compatibility with
           // older examples.
-          contextData.__syncReturnFocus = true;
+          data.__syncReturnFocus = true;
 
           // In Safari, `useListNavigation` moves focus sync, so making this
           // sync ensures the initial item remains focused despite this being
@@ -420,7 +419,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
           setTimeout(() => {
             // This isn't an actual property the user should access, make sure
             // it doesn't persist.
-            delete contextData.__syncReturnFocus;
+            delete data.__syncReturnFocus;
           });
         }
       }
@@ -430,7 +429,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     getTabbableElements,
     returnFocusRef,
     initialFocusRef,
-    dataRef,
+    data,
     refs,
     events,
     ignoreInitialFocus,

--- a/packages/react/src/components/FloatingGroup.tsx
+++ b/packages/react/src/components/FloatingGroup.tsx
@@ -19,7 +19,7 @@ interface GroupContext extends GroupState {
   setState: React.Dispatch<Partial<GroupState>>;
 }
 
-const FloatingDelayGroupContext = React.createContext<
+const FloatingGroupContext = React.createContext<
   GroupState & {
     setCurrentId: (currentId: any) => void;
     setState: React.Dispatch<Partial<GroupState>>;
@@ -34,23 +34,24 @@ const FloatingDelayGroupContext = React.createContext<
   isInstantPhase: false,
 });
 
-export const useDelayGroupContext = (): GroupContext =>
-  React.useContext(FloatingDelayGroupContext);
+export const useGroupContext = (): GroupContext =>
+  React.useContext(FloatingGroupContext);
+
+interface FloatingGroupProps {
+  children?: React.ReactNode;
+  delay?: Delay;
+  timeoutMs?: number;
+}
 
 /**
- * Provides context for a group of floating elements that should share a
- * `delay`.
- * @see https://floating-ui.com/docs/FloatingDelayGroup
+ * Provides context for a group of floating elements.
+ * @see https://floating-ui.com/docs/FloatingGroup
  */
-export const FloatingDelayGroup = ({
+export const FloatingGroup = ({
   children,
-  delay,
+  delay = 0,
   timeoutMs = 0,
-}: {
-  children?: React.ReactNode;
-  delay: Delay;
-  timeoutMs?: number;
-}): JSX.Element => {
+}: FloatingGroupProps): JSX.Element => {
   const [state, setState] = React.useReducer(
     (prev: GroupState, next: Partial<GroupState>): GroupState => ({
       ...prev,
@@ -85,14 +86,14 @@ export const FloatingDelayGroup = ({
   }, [state.currentId]);
 
   return (
-    <FloatingDelayGroupContext.Provider
+    <FloatingGroupContext.Provider
       value={React.useMemo(
         () => ({...state, setState, setCurrentId}),
         [state, setState, setCurrentId]
       )}
     >
       {children}
-    </FloatingDelayGroupContext.Provider>
+    </FloatingGroupContext.Provider>
   );
 };
 
@@ -100,12 +101,12 @@ interface UseGroupOptions {
   id: any;
 }
 
-export const useDelayGroup = (
+export const useGroup = (
   {open, onOpenChange}: FloatingContext,
   {id}: UseGroupOptions
 ) => {
   const {currentId, setCurrentId, initialDelay, setState, timeoutMs} =
-    useDelayGroupContext();
+    useGroupContext();
 
   React.useEffect(() => {
     if (currentId) {

--- a/packages/react/src/components/FloatingTree.tsx
+++ b/packages/react/src/components/FloatingTree.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import useLayoutEffect from 'use-isomorphic-layout-effect';
 
 import {useId} from '../hooks/useId';
+import {useInstance} from '../hooks/utils/useInstance';
 import type {FloatingNodeType, FloatingTreeType, ReferenceType} from '../types';
 import {createPubSub} from '../utils/createPubSub';
 
@@ -68,30 +69,19 @@ export const FloatingTree = ({
 }: {
   children?: React.ReactNode;
 }): JSX.Element => {
-  const nodesRef = React.useRef<Array<FloatingNodeType>>([]);
-
-  const addNode = React.useCallback((node: FloatingNodeType) => {
-    nodesRef.current = [...nodesRef.current, node];
-  }, []);
-
-  const removeNode = React.useCallback((node: FloatingNodeType) => {
-    nodesRef.current = nodesRef.current.filter((n) => n !== node);
-  }, []);
-
-  const events = React.useState(() => createPubSub())[0];
+  const tree = useInstance(() => ({
+    nodes: [] as Array<FloatingNodeType>,
+    addNode(node: FloatingNodeType) {
+      tree.nodes.push(node);
+    },
+    removeNode(node: FloatingNodeType) {
+      tree.nodes = tree.nodes.filter((n) => n !== node);
+    },
+    events: createPubSub(),
+  }));
 
   return (
-    <FloatingTreeContext.Provider
-      value={React.useMemo(
-        () => ({
-          nodesRef,
-          addNode,
-          removeNode,
-          events,
-        }),
-        [nodesRef, addNode, removeNode, events]
-      )}
-    >
+    <FloatingTreeContext.Provider value={tree}>
       {children}
     </FloatingTreeContext.Provider>
   );

--- a/packages/react/src/hooks/useClick.ts
+++ b/packages/react/src/hooks/useClick.ts
@@ -25,7 +25,7 @@ export interface Props {
  * @see https://floating-ui.com/docs/useClick
  */
 export const useClick = <RT extends ReferenceType = ReferenceType>(
-  {open, onOpenChange, dataRef, elements: {domReference}}: FloatingContext<RT>,
+  {open, onOpenChange, data, elements: {domReference}}: FloatingContext<RT>,
   {
     enabled = true,
     event: eventOption = 'click',
@@ -67,9 +67,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
           if (open) {
             if (
               toggle &&
-              (dataRef.current.openEvent
-                ? dataRef.current.openEvent.type === 'mousedown'
-                : true)
+              (data.openEvent ? data.openEvent.type === 'mousedown' : true)
             ) {
               onOpenChange(false);
             }
@@ -79,10 +77,10 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
             onOpenChange(true);
           }
 
-          dataRef.current.openEvent = event.nativeEvent;
+          data.openEvent = event.nativeEvent;
         },
         onClick(event) {
-          if (dataRef.current.__syncReturnFocus) {
+          if (data.__syncReturnFocus) {
             return;
           }
 
@@ -101,9 +99,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
           if (open) {
             if (
               toggle &&
-              (dataRef.current.openEvent
-                ? dataRef.current.openEvent.type === 'click'
-                : true)
+              (data.openEvent ? data.openEvent.type === 'click' : true)
             ) {
               onOpenChange(false);
             }
@@ -111,7 +107,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
             onOpenChange(true);
           }
 
-          dataRef.current.openEvent = event.nativeEvent;
+          data.openEvent = event.nativeEvent;
         },
         onKeyDown(event) {
           pointerTypeRef.current = undefined;
@@ -162,7 +158,7 @@ export const useClick = <RT extends ReferenceType = ReferenceType>(
     };
   }, [
     enabled,
-    dataRef,
+    data,
     eventOption,
     ignoreMouse,
     keyboardHandlers,

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -71,7 +71,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     events,
     nodeId,
     elements: {reference, domReference, floating},
-    dataRef,
+    data,
   }: FloatingContext<RT>,
   {
     enabled = true,
@@ -104,7 +104,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
         return;
       }
 
-      const children = tree ? getChildren(tree.nodesRef.current, nodeId) : [];
+      const children = tree ? getChildren(tree.nodes, nodeId) : [];
 
       if (!escapeKeyBubbles) {
         event.stopPropagation();
@@ -113,10 +113,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
           let shouldDismiss = true;
 
           children.forEach((child) => {
-            if (
-              child.context?.open &&
-              !child.context.dataRef.current.__escapeKeyBubbles
-            ) {
+            if (child.context?.open && !child.context.data.__escapeKeyBubbles) {
               shouldDismiss = false;
               return;
             }
@@ -182,7 +179,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
 
     const targetIsInsideChildren =
       tree &&
-      getChildren(tree.nodesRef.current, nodeId).some((node) =>
+      getChildren(tree.nodes, nodeId).some((node) =>
         isEventTargetWithin(event, node.context?.elements.floating)
       );
 
@@ -194,15 +191,12 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
       return;
     }
 
-    const children = tree ? getChildren(tree.nodesRef.current, nodeId) : [];
+    const children = tree ? getChildren(tree.nodes, nodeId) : [];
     if (children.length > 0) {
       let shouldDismiss = true;
 
       children.forEach((child) => {
-        if (
-          child.context?.open &&
-          !child.context.dataRef.current.__outsidePressBubbles
-        ) {
+        if (child.context?.open && !child.context.data.__outsidePressBubbles) {
           shouldDismiss = false;
           return;
         }
@@ -231,8 +225,8 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
       return;
     }
 
-    dataRef.current.__escapeKeyBubbles = escapeKeyBubbles;
-    dataRef.current.__outsidePressBubbles = outsidePressBubbles;
+    data.__escapeKeyBubbles = escapeKeyBubbles;
+    data.__outsidePressBubbles = outsidePressBubbles;
 
     function onScroll() {
       onOpenChange(false);
@@ -279,7 +273,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
       });
     };
   }, [
-    dataRef,
+    data,
     floating,
     domReference,
     reference,

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -22,7 +22,7 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
   {
     open,
     onOpenChange,
-    dataRef,
+    data,
     events,
     refs,
     elements: {floating, domReference},
@@ -106,14 +106,14 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
           // but only if the click originated inside the reference element.
           if (
             event.type === 'focus' &&
-            dataRef.current.openEvent?.type === 'mousedown' &&
-            dataRef.current.openEvent &&
-            isEventTargetWithin(dataRef.current.openEvent, domReference)
+            data.openEvent?.type === 'mousedown' &&
+            data.openEvent &&
+            isEventTargetWithin(data.openEvent, domReference)
           ) {
             return;
           }
 
-          dataRef.current.openEvent = event.nativeEvent;
+          data.openEvent = event.nativeEvent;
           onOpenChange(true);
         },
         onBlur(event) {
@@ -145,5 +145,5 @@ export const useFocus = <RT extends ReferenceType = ReferenceType>(
         },
       },
     };
-  }, [enabled, keyboardOnly, domReference, refs, dataRef, onOpenChange]);
+  }, [enabled, keyboardOnly, domReference, refs, data, onOpenChange]);
 };

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -74,7 +74,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
   const {
     open,
     onOpenChange,
-    dataRef,
+    data,
     events,
     elements: {domReference, floating},
     refs,
@@ -94,9 +94,9 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
   const unbindMouseMoveRef = React.useRef(() => {});
 
   const isHoverOpen = React.useCallback(() => {
-    const type = dataRef.current.openEvent?.type;
+    const type = data.openEvent?.type;
     return type?.includes('mouse') && type !== 'mousedown';
-  }, [dataRef]);
+  }, [data]);
 
   // When dismissing before opening, clear the delay timeouts to cancel it
   // from showing.
@@ -139,7 +139,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     onOpenChange,
     enabled,
     handleCloseRef,
-    dataRef,
+    data,
     isHoverOpen,
   ]);
 
@@ -184,8 +184,8 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     }
 
     function isClickLikeOpenEvent() {
-      return dataRef.current.openEvent
-        ? ['click', 'mousedown'].includes(dataRef.current.openEvent.type)
+      return data.openEvent
+        ? ['click', 'mousedown'].includes(data.openEvent.type)
         : false;
     }
 
@@ -200,7 +200,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
         return;
       }
 
-      dataRef.current.openEvent = event;
+      data.openEvent = event;
 
       const openDelay = getDelay(
         delayRef.current,
@@ -310,7 +310,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     tree,
     delayRef,
     handleCloseRef,
-    dataRef,
+    data,
   ]);
 
   // Block pointer-events of every element other than the reference and floating
@@ -335,9 +335,8 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       if (isElement(domReference) && floating) {
         const ref = domReference as unknown as HTMLElement | SVGSVGElement;
 
-        const parentFloating = tree?.nodesRef.current.find(
-          (node) => node.id === parentId
-        )?.context?.elements.floating;
+        const parentFloating = tree?.nodes.find((node) => node.id === parentId)
+          ?.context?.elements.floating;
 
         if (parentFloating) {
           parentFloating.style.pointerEvents = '';
@@ -360,7 +359,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     domReference,
     tree,
     handleCloseRef,
-    dataRef,
+    data,
     isHoverOpen,
   ]);
 

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -51,7 +51,7 @@ export interface Props<RT extends ReferenceType = ReferenceType> {
   handleClose?: HandleCloseFn<RT> | null;
   restMs?: number;
   delay?: number | Partial<{open: number; close: number}>;
-  mouseOnly?: boolean;
+  ignoreTouch?: boolean;
   move?: boolean;
 }
 
@@ -66,7 +66,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     enabled = true,
     delay = 0,
     handleClose = null,
-    mouseOnly = false,
+    ignoreTouch = false,
     restMs = 0,
     move = true,
   }: Props<RT> = {}
@@ -194,7 +194,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
       blockMouseMoveRef.current = false;
 
       if (
-        (mouseOnly && !isMouseLikePointerType(pointerTypeRef.current)) ||
+        (ignoreTouch && !isMouseLikePointerType(pointerTypeRef.current)) ||
         (restMs > 0 && getDelay(delayRef.current, 'open') === 0)
       ) {
         return;
@@ -299,7 +299,7 @@ export const useHover = <RT extends ReferenceType = ReferenceType>(
     floating,
     enabled,
     context,
-    mouseOnly,
+    ignoreTouch,
     restMs,
     move,
     closeWithDelay,

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -400,9 +400,8 @@ export const useListNavigation = <RT extends ReferenceType = ReferenceType>(
     }
 
     if (previousMountedRef.current && !floating) {
-      const parentFloating = tree?.nodesRef.current.find(
-        (node) => node.id === parentId
-      )?.context?.elements.floating;
+      const parentFloating = tree?.nodes.find((node) => node.id === parentId)
+        ?.context?.elements.floating;
 
       if (
         parentFloating &&

--- a/packages/react/src/hooks/useMergeRefs.ts
+++ b/packages/react/src/hooks/useMergeRefs.ts
@@ -5,7 +5,7 @@ import * as React from 'react';
  * @see https://floating-ui.com/docs/useMergeRefs
  */
 export function useMergeRefs<Instance>(
-  refs: Array<React.Ref<Instance>>
+  ...refs: Array<React.Ref<Instance>>
 ): React.RefCallback<Instance> | null {
   return React.useMemo(() => {
     if (refs.every((ref) => ref == null)) {

--- a/packages/react/src/hooks/useTypeahead.ts
+++ b/packages/react/src/hooks/useTypeahead.ts
@@ -32,7 +32,7 @@ export interface Props {
  * @see https://floating-ui.com/docs/useTypeahead
  */
 export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
-  {open, dataRef, refs}: FloatingContext<RT>,
+  {open, data, refs}: FloatingContext<RT>,
   {
     listRef,
     activeIndex,
@@ -98,7 +98,7 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
       }
 
       if (stringRef.current.length > 0 && stringRef.current[0] !== ' ') {
-        dataRef.current.typing = true;
+        data.typing = true;
 
         if (event.key === ' ') {
           stopEvent(event);
@@ -143,7 +143,7 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
       timeoutIdRef.current = setTimeout(() => {
         stringRef.current = '';
         prevIndexRef.current = matchIndexRef.current;
-        dataRef.current.typing = false;
+        data.typing = false;
       }, resetMs);
 
       const prevIndex = prevIndexRef.current;
@@ -176,7 +176,7 @@ export const useTypeahead = <RT extends ReferenceType = ReferenceType>(
     };
   }, [
     enabled,
-    dataRef,
+    data,
     listRef,
     resetMs,
     ignoreKeysRef,

--- a/packages/react/src/hooks/utils/useInstance.ts
+++ b/packages/react/src/hooks/utils/useInstance.ts
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export function useInstance<T>(value: T | (() => T)): T {
+  return React.useState(value)[0];
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,11 +1,11 @@
 export {FloatingArrow} from './components/FloatingArrow';
-export {
-  FloatingDelayGroup,
-  useDelayGroup,
-  useDelayGroupContext,
-} from './components/FloatingDelayGroup';
+export {FloatingBackdrop} from './components/FloatingBackdrop';
 export {FloatingFocusManager} from './components/FloatingFocusManager';
-export {FloatingOverlay} from './components/FloatingOverlay';
+export {
+  FloatingGroup,
+  useGroup,
+  useGroupContext,
+} from './components/FloatingGroup';
 export {
   FloatingPortal,
   useFloatingPortalNode,

--- a/packages/react/src/safePolygon.ts
+++ b/packages/react/src/safePolygon.ts
@@ -118,9 +118,7 @@ export function safePolygon<RT extends ReferenceType = ReferenceType>({
       // If any nested child is open, abort.
       if (
         tree &&
-        getChildren(tree.nodesRef.current, nodeId).some(
-          ({context}) => context?.open
-        )
+        getChildren(tree.nodes, nodeId).some(({context}) => context?.open)
       ) {
         return;
       }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -198,5 +198,5 @@ export interface UseFloatingProps<RT extends ReferenceType = ReferenceType> {
     reference: RT,
     floating: HTMLElement,
     update: () => void
-  ) => void | (() => void);
+  ) => () => void;
 }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -156,12 +156,7 @@ export interface ElementProps {
 
 export type ReferenceType = Element | VirtualElement;
 
-export type UseFloatingData = Prettify<
-  Omit<ComputePositionReturn, 'x' | 'y'> & {
-    x: number | null;
-    y: number | null;
-  }
->;
+export type UseFloatingData = Prettify<ComputePositionReturn>;
 
 export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =
   Prettify<

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -127,7 +127,7 @@ export type FloatingContext<RT extends ReferenceType = ReferenceType> =
       open: boolean;
       onOpenChange: (open: boolean) => void;
       events: FloatingEvents;
-      dataRef: React.MutableRefObject<ContextData>;
+      data: ContextData;
       nodeId: string | undefined;
       floatingId: string;
       refs: ExtendedRefs<RT>;
@@ -142,7 +142,7 @@ export interface FloatingNodeType<RT extends ReferenceType = ReferenceType> {
 }
 
 export interface FloatingTreeType<RT extends ReferenceType = ReferenceType> {
-  nodesRef: React.MutableRefObject<Array<FloatingNodeType<RT>>>;
+  nodes: Array<FloatingNodeType<RT>>;
   events: FloatingEvents;
   addNode: (node: FloatingNodeType) => void;
   removeNode: (node: FloatingNodeType) => void;

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -5,6 +5,7 @@ import useLayoutEffect from 'use-isomorphic-layout-effect';
 import {useFloatingTree} from './components/FloatingTree';
 import {useId} from './hooks/useId';
 import {useEvent} from './hooks/utils/useEvent';
+import {useInstance} from './hooks/utils/useInstance';
 import type {
   ContextData,
   FloatingContext,
@@ -28,8 +29,8 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
   const position = usePosition<RT>(options);
   const tree = useFloatingTree<RT>();
   const domReferenceRef = React.useRef<NarrowedElement<RT> | null>(null);
-  const dataRef = React.useRef<ContextData>({});
-  const events = React.useState(() => createPubSub())[0];
+  const data = useInstance<ContextData>({});
+  const events = useInstance(() => createPubSub());
 
   const floatingId = useId();
 
@@ -92,18 +93,28 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
       ...position,
       refs,
       elements,
-      dataRef,
+      data,
       nodeId,
       floatingId,
       events,
       open,
       onOpenChange,
     }),
-    [position, nodeId, floatingId, events, open, onOpenChange, refs, elements]
+    [
+      position,
+      nodeId,
+      floatingId,
+      data,
+      events,
+      open,
+      onOpenChange,
+      refs,
+      elements,
+    ]
   );
 
   useLayoutEffect(() => {
-    const node = tree?.nodesRef.current.find((node) => node.id === nodeId);
+    const node = tree?.nodes.find((node) => node.id === nodeId);
     if (node) {
       node.context = context;
     }

--- a/packages/react/src/useFloating.ts
+++ b/packages/react/src/useFloating.ts
@@ -57,15 +57,9 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
         setDomReference(node as NarrowedElement<RT> | null);
       }
 
-      // Backwards-compatibility for passing a virtual element to `reference`
-      // after it has set the DOM reference.
       if (
         isElement(position.refs.reference.current) ||
-        position.refs.reference.current === null ||
-        // Don't allow setting virtual elements using the old technique back to
-        // `null` to support `positionReference` + an unstable `reference`
-        // callback ref.
-        (node !== null && !isElement(node))
+        position.refs.reference.current === null
       ) {
         position.refs.setReference(node);
       }

--- a/packages/react/src/useInteractions.ts
+++ b/packages/react/src/useInteractions.ts
@@ -43,7 +43,7 @@ function mergeProps(
   };
 }
 
-export const useInteractions = (propsList: Array<ElementProps | void> = []) => {
+export function useInteractions(...propsList: Array<ElementProps | void>) {
   // The dependencies are a dynamic array, so we can't use the linter's
   // suggestion to add it to the deps array.
   const deps = propsList;
@@ -77,4 +77,4 @@ export const useInteractions = (propsList: Array<ElementProps | void> = []) => {
     () => ({getReferenceProps, getFloatingProps, getItemProps}),
     [getReferenceProps, getFloatingProps, getItemProps]
   );
-};
+}

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -136,10 +136,10 @@ describe('returnFocus', () => {
         nodeId,
       });
 
-      const {getReferenceProps, getFloatingProps} = useInteractions([
+      const {getReferenceProps, getFloatingProps} = useInteractions(
         useClick(context),
-        useDismiss(context, {bubbles: false}),
-      ]);
+        useDismiss(context, {bubbles: false})
+      );
 
       return (
         <FloatingNode id={nodeId}>

--- a/packages/react/test/unit/FloatingGroup.test.tsx
+++ b/packages/react/test/unit/FloatingGroup.test.tsx
@@ -3,10 +3,10 @@ import {act} from '@testing-library/react-hooks';
 import {cloneElement, useState} from 'react';
 
 import {
-  FloatingDelayGroup,
-  useDelayGroup,
-  useDelayGroupContext,
+  FloatingGroup,
   useFloating,
+  useGroup,
+  useGroupContext,
   useHover,
   useInteractions,
 } from '../../src';
@@ -19,7 +19,7 @@ interface Props {
 }
 
 export const Tooltip = ({children, label}: Props) => {
-  const {delay} = useDelayGroupContext();
+  const {delay} = useGroupContext();
   const [open, setOpen] = useState(false);
 
   const {x, y, reference, floating, strategy, context} = useFloating({
@@ -27,10 +27,10 @@ export const Tooltip = ({children, label}: Props) => {
     onOpenChange: setOpen,
   });
 
-  const {getReferenceProps} = useInteractions([
+  const {getReferenceProps} = useInteractions(
     useHover(context, {delay}),
-    useDelayGroup(context, {id: label}),
-  ]);
+    useGroup(context, {id: label})
+  );
 
   return (
     <>
@@ -60,7 +60,7 @@ export const Tooltip = ({children, label}: Props) => {
 
 function App() {
   return (
-    <FloatingDelayGroup delay={{open: 1000, close: 200}}>
+    <FloatingGroup delay={{open: 1000, close: 200}}>
       <Tooltip label="one">
         <button data-testid="reference-one" />
       </Tooltip>
@@ -70,7 +70,7 @@ function App() {
       <Tooltip label="three">
         <button data-testid="reference-three" />
       </Tooltip>
-    </FloatingDelayGroup>
+    </FloatingGroup>
   );
 }
 
@@ -127,7 +127,7 @@ test('groups delays correctly', async () => {
 test('timeoutMs', async () => {
   function App() {
     return (
-      <FloatingDelayGroup delay={{open: 1000, close: 100}} timeoutMs={500}>
+      <FloatingGroup delay={{open: 1000, close: 100}} timeoutMs={500}>
         <Tooltip label="one">
           <button data-testid="reference-one" />
         </Tooltip>
@@ -137,7 +137,7 @@ test('timeoutMs', async () => {
         <Tooltip label="three">
           <button data-testid="reference-three" />
         </Tooltip>
-      </FloatingDelayGroup>
+      </FloatingGroup>
     );
   }
 

--- a/packages/react/test/unit/useClick.test.tsx
+++ b/packages/react/test/unit/useClick.test.tsx
@@ -15,9 +15,9 @@ function App({
     open,
     onOpenChange: setOpen,
   });
-  const {getReferenceProps, getFloatingProps} = useInteractions([
-    useClick(context, props),
-  ]);
+  const {getReferenceProps, getFloatingProps} = useInteractions(
+    useClick(context, props)
+  );
 
   const Tag = typeable ? 'input' : button ? 'button' : 'div';
 

--- a/packages/react/test/unit/useDismiss.test.tsx
+++ b/packages/react/test/unit/useDismiss.test.tsx
@@ -320,13 +320,13 @@ describe('bubbles', () => {
           onOpenChange: setTooltipOpen,
         });
 
-        const popoverInteractions = useInteractions([
-          useDismiss(popover.context),
-        ]);
-        const tooltipInteractions = useInteractions([
+        const popoverInteractions = useInteractions(
+          useDismiss(popover.context)
+        );
+        const tooltipInteractions = useInteractions(
           useFocus(tooltip.context),
-          useDismiss(tooltip.context),
-        ]);
+          useDismiss(tooltip.context)
+        );
 
         return (
           <>

--- a/packages/react/test/unit/useDismiss.test.tsx
+++ b/packages/react/test/unit/useDismiss.test.tsx
@@ -22,9 +22,9 @@ function App(props: Props) {
     open,
     onOpenChange: setOpen,
   });
-  const {getReferenceProps, getFloatingProps} = useInteractions([
-    useDismiss(context, props),
-  ]);
+  const {getReferenceProps, getFloatingProps} = useInteractions(
+    useDismiss(context, props)
+  );
 
   return (
     <>
@@ -108,9 +108,9 @@ describe('false', () => {
         onOpenChange: setOpen,
       });
 
-      const {getReferenceProps, getFloatingProps} = useInteractions([
-        useDismiss(context),
-      ]);
+      const {getReferenceProps, getFloatingProps} = useInteractions(
+        useDismiss(context)
+      );
 
       return (
         <>
@@ -160,9 +160,9 @@ describe('bubbles', () => {
       nodeId,
     });
 
-    const {getReferenceProps, getFloatingProps} = useInteractions([
-      useDismiss(context, props),
-    ]);
+    const {getReferenceProps, getFloatingProps} = useInteractions(
+      useDismiss(context, props)
+    );
 
     return (
       <FloatingNode id={nodeId}>

--- a/packages/react/test/unit/useFloating.test.tsx
+++ b/packages/react/test/unit/useFloating.test.tsx
@@ -122,12 +122,12 @@ describe('#2129: interactions.getFloatingProps as a dep does not cause setState 
       open: true,
     });
 
-    const interactions = useInteractions([
+    const interactions = useInteractions(
       useHover(context),
       useClick(context),
       useFocus(context),
-      useDismiss(context),
-    ]);
+      useDismiss(context)
+    );
 
     const Tooltip = useCallback(() => {
       return (

--- a/packages/react/test/unit/useFloating.test.tsx
+++ b/packages/react/test/unit/useFloating.test.tsx
@@ -11,21 +11,23 @@ import {
 } from '../../src';
 import {isElement} from '../../src/utils/is';
 
-describe('positionReference', () => {
+describe('setPositionReference', () => {
   test('sets separate refs', () => {
     function App() {
-      const {reference, positionReference, refs} =
-        useFloating<HTMLDivElement>();
+      const {refs, elements} = useFloating<HTMLDivElement>();
 
       return (
         <>
-          <div ref={reference} data-testid="reference" />
-          <div ref={positionReference} data-testid="position-reference" />
+          <div ref={refs.setReference} data-testid="reference" />
+          <div
+            ref={refs.setPositionReference}
+            data-testid="position-reference"
+          />
           <div data-testid="reference-text">
-            {String(refs.domReference.current?.getAttribute('data-testid'))}
+            {String(elements.domReference?.getAttribute('data-testid'))}
           </div>
           <div data-testid="position-reference-text">
-            {String(isElement(refs.reference.current))}
+            {String(isElement(elements.reference))}
           </div>
         </>
       );
@@ -44,18 +46,23 @@ describe('positionReference', () => {
 
   test('handles unstable reference prop', () => {
     function App() {
-      const {reference, positionReference, refs} =
-        useFloating<HTMLDivElement>();
+      const {refs, elements} = useFloating();
 
       return (
         <>
-          <div ref={(node) => reference(node)} data-testid="reference" />
-          <div ref={positionReference} data-testid="position-reference" />
+          <div
+            ref={(node) => refs.setReference(node)}
+            data-testid="reference"
+          />
+          <div
+            ref={refs.setPositionReference}
+            data-testid="position-reference"
+          />
           <div data-testid="reference-text">
-            {String(refs.domReference.current?.getAttribute('data-testid'))}
+            {String(elements.domReference?.getAttribute('data-testid'))}
           </div>
           <div data-testid="position-reference-text">
-            {String(isElement(refs.reference.current))}
+            {String(isElement(elements.reference))}
           </div>
         </>
       );
@@ -74,10 +81,10 @@ describe('positionReference', () => {
 
   test('handles real virtual element', () => {
     function App() {
-      const {reference, positionReference, refs} = useFloating();
+      const {refs, elements} = useFloating();
 
       useLayoutEffect(() => {
-        positionReference({
+        refs.setPositionReference({
           getBoundingClientRect: () => ({
             x: 218,
             y: 0,
@@ -89,16 +96,16 @@ describe('positionReference', () => {
             bottom: 0,
           }),
         });
-      }, [positionReference]);
+      }, [refs]);
 
       return (
         <>
-          <div ref={(node) => reference(node)} data-testid="reference" />
+          <div ref={refs.setReference} data-testid="reference" />
           <div data-testid="reference-text">
-            {String(refs.domReference.current?.getAttribute('data-testid'))}
+            {String(elements.domReference?.getAttribute('data-testid'))}
           </div>
           <div data-testid="position-reference-text">
-            {refs.reference.current?.getBoundingClientRect().x}
+            {elements.reference?.getBoundingClientRect().x}
           </div>
         </>
       );

--- a/packages/react/test/unit/useFocus.test.tsx
+++ b/packages/react/test/unit/useFocus.test.tsx
@@ -21,11 +21,11 @@ function App(props: Props & {dismiss?: boolean; hover?: boolean}) {
     open,
     onOpenChange: setOpen,
   });
-  const {getReferenceProps, getFloatingProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps} = useInteractions(
     useFocus(context, props),
     useDismiss(context, {enabled: !!props.dismiss, referencePress: true}),
-    useHover(context, {enabled: !!props.hover}),
-  ]);
+    useHover(context, {enabled: !!props.hover})
+  );
 
   return (
     <>
@@ -79,9 +79,9 @@ test('blurs when hitting an "inside" focus guard', async () => {
       onOpenChange: setOpen,
     });
 
-    const {getReferenceProps, getFloatingProps} = useInteractions([
-      useFocus(context),
-    ]);
+    const {getReferenceProps, getFloatingProps} = useInteractions(
+      useFocus(context)
+    );
 
     return (
       <>
@@ -103,9 +103,9 @@ test('blurs when hitting an "inside" focus guard', async () => {
       onOpenChange: setOpen,
     });
 
-    const {getReferenceProps, getFloatingProps} = useInteractions([
-      useClick(context),
-    ]);
+    const {getReferenceProps, getFloatingProps} = useInteractions(
+      useClick(context)
+    );
 
     return (
       <>

--- a/packages/react/test/unit/useHover.test.tsx
+++ b/packages/react/test/unit/useHover.test.tsx
@@ -15,9 +15,9 @@ function App({
     open,
     onOpenChange: setOpen,
   });
-  const {getReferenceProps, getFloatingProps} = useInteractions([
-    useHover(context, props),
-  ]);
+  const {getReferenceProps, getFloatingProps} = useInteractions(
+    useHover(context, props)
+  );
 
   return (
     <>

--- a/packages/react/test/unit/useInteractions.test.tsx
+++ b/packages/react/test/unit/useInteractions.test.tsx
@@ -21,15 +21,15 @@ test('correctly merges functions', () => {
   const userOnClick = jest.fn();
 
   function App() {
-    const {getReferenceProps} = useInteractions([
+    const {getReferenceProps} = useInteractions(
       {reference: {onClick: firstInteractionOnClick}},
       {
         reference: {
           onClick: secondInteractionOnClick,
           onKeyDown: secondInteractionOnKeyDown,
         },
-      },
-    ]);
+      }
+    );
 
     const {onClick, onKeyDown} = getReferenceProps({onClick: userOnClick});
 
@@ -51,7 +51,7 @@ test('correctly merges functions', () => {
 
 test('does not error with undefined user supplied functions', () => {
   function App() {
-    const {getReferenceProps} = useInteractions([{reference: {onClick() {}}}]);
+    const {getReferenceProps} = useInteractions({reference: {onClick() {}}});
     return null;
 
     expect(() =>
@@ -65,7 +65,7 @@ test('does not error with undefined user supplied functions', () => {
 
 test('does not break props that start with `on`', () => {
   function App() {
-    const {getReferenceProps} = useInteractions([]);
+    const {getReferenceProps} = useInteractions();
 
     const props = getReferenceProps({
       // @ts-expect-error
@@ -99,30 +99,28 @@ test('prop getters are memoized', () => {
     // an infinite loop as they must be memoized externally (as done by React).
     // Other non-primitives like functions and arrays get memoized by the hooks.
     const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions(
-      [
-        useHover(context, {handleClose}),
-        useFocus(context),
-        useClick(context),
-        useRole(context),
-        useDismiss(context),
-        useListNavigation(context, {
-          listRef,
-          activeIndex: 0,
-          onNavigate: () => {},
-          disabledIndices: [],
-        }),
-        useTypeahead(context, {
-          listRef,
-          activeIndex: 0,
-          ignoreKeys: [],
-          onMatch: () => {},
-          findMatch: () => '',
-        }),
-        useInnerOffset(context, {
-          onChange: () => {},
-          overflowRef,
-        }),
-      ]
+      useHover(context, {handleClose}),
+      useFocus(context),
+      useClick(context),
+      useRole(context),
+      useDismiss(context),
+      useListNavigation(context, {
+        listRef,
+        activeIndex: 0,
+        onNavigate: () => {},
+        disabledIndices: [],
+      }),
+      useTypeahead(context, {
+        listRef,
+        activeIndex: 0,
+        ignoreKeys: [],
+        onMatch: () => {},
+        findMatch: () => '',
+      }),
+      useInnerOffset(context, {
+        onChange: () => {},
+        overflowRef,
+      })
     );
 
     useEffect(() => {

--- a/packages/react/test/unit/useListNavigation.test.tsx
+++ b/packages/react/test/unit/useListNavigation.test.tsx
@@ -20,7 +20,7 @@ function App(props: Omit<Partial<Props>, 'listRef'>) {
     open,
     onOpenChange: setOpen,
   });
-  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions(
     useClick(context),
     useListNavigation(context, {
       ...props,
@@ -30,8 +30,8 @@ function App(props: Omit<Partial<Props>, 'listRef'>) {
         setActiveIndex(index);
         props.onNavigate?.(index);
       },
-    }),
-  ]);
+    })
+  );
 
   return (
     <>
@@ -136,16 +136,14 @@ test('resets indexRef to -1 upon close', async () => {
       });
 
     const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions(
-      [
-        useDismiss(context),
-        useListNavigation(context, {
-          listRef,
-          activeIndex,
-          onNavigate: setActiveIndex,
-          virtual: true,
-          loop: true,
-        }),
-      ]
+      useDismiss(context),
+      useListNavigation(context, {
+        listRef,
+        activeIndex,
+        onNavigate: setActiveIndex,
+        virtual: true,
+        loop: true,
+      })
     );
 
     function onChange(event: React.ChangeEvent<HTMLInputElement>) {

--- a/packages/react/test/unit/useMergeRefs.test.tsx
+++ b/packages/react/test/unit/useMergeRefs.test.tsx
@@ -10,7 +10,7 @@ test('merges refs and cleans up', () => {
   function App({show}: {show: boolean}) {
     const ref1 = React.useRef<HTMLDivElement>(null);
     const ref2 = React.useCallback(callbackSpy, []);
-    const ref = useMergeRefs([ref1, ref2]);
+    const ref = useMergeRefs(ref1, ref2);
 
     React.useLayoutEffect(() => {
       refSpy = ref1.current;
@@ -41,7 +41,7 @@ test('conditional refs', () => {
     const ref1 = React.useCallback(callbackSpy, []);
     const ref2 = React.useCallback(callbackSpy2, []);
     const ref3 = React.useCallback(callbackSpy3, []);
-    const ref = useMergeRefs([ref1, change ? ref3 : ref2]);
+    const ref = useMergeRefs(ref1, change ? ref3 : ref2);
 
     return <div id="test" ref={ref} />;
   }

--- a/packages/react/test/unit/useRole.test.tsx
+++ b/packages/react/test/unit/useRole.test.tsx
@@ -13,9 +13,9 @@ function App({
     open,
     onOpenChange: setOpen,
   });
-  const {getReferenceProps, getFloatingProps} = useInteractions([
-    useRole(context, props),
-  ]);
+  const {getReferenceProps, getFloatingProps} = useInteractions(
+    useRole(context, props)
+  );
 
   return (
     <>

--- a/packages/react/test/unit/useRole.test.tsx
+++ b/packages/react/test/unit/useRole.test.tsx
@@ -47,8 +47,8 @@ function AppWithExternalRef(props: Props & {initiallyOpen?: boolean}) {
     onOpenChange: setOpen,
   });
   // External ref can use it's own set of interactions hooks, but share context
-  const {getFloatingProps} = useInteractions([useRole(context, props)]);
-  const {getReferenceProps} = useInteractions([useRole(context, props)]);
+  const {getFloatingProps} = useInteractions(useRole(context, props));
+  const {getReferenceProps} = useInteractions(useRole(context, props));
 
   return (
     <>

--- a/packages/react/test/unit/useTypeahead.test.tsx
+++ b/packages/react/test/unit/useTypeahead.test.tsx
@@ -16,7 +16,7 @@ const useImpl = (props: Pick<Props, 'onMatch'> & {list?: Array<string>}) => {
     onOpenChange: setOpen,
   });
   const listRef = useRef(props.list ?? ['one', 'two', 'three']);
-  const {getReferenceProps, getFloatingProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps} = useInteractions(
     useTypeahead(context, {
       listRef,
       activeIndex,
@@ -24,8 +24,8 @@ const useImpl = (props: Pick<Props, 'onMatch'> & {list?: Array<string>}) => {
         setActiveIndex(index);
         props.onMatch?.(index);
       },
-    }),
-  ]);
+    })
+  );
   return {
     activeIndex,
     open,

--- a/packages/react/test/visual/components/Autocomplete.tsx
+++ b/packages/react/test/visual/components/Autocomplete.tsx
@@ -203,7 +203,7 @@ export function Main() {
     ],
   });
 
-  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions(
     useRole(context, {role: 'listbox'}),
     useDismiss(context),
     useListNavigation(context, {
@@ -213,8 +213,8 @@ export function Main() {
       virtual: true,
       loop: true,
       allowEscape: true,
-    }),
-  ]);
+    })
+  );
 
   function onChange(event: React.ChangeEvent<HTMLInputElement>) {
     const value = event.target.value;

--- a/packages/react/test/visual/components/Drawer.tsx
+++ b/packages/react/test/visual/components/Drawer.tsx
@@ -1,4 +1,5 @@
 import {
+  FloatingBackdrop,
   FloatingFocusManager,
   FloatingPortal,
   useClick,

--- a/packages/react/test/visual/components/Drawer.tsx
+++ b/packages/react/test/visual/components/Drawer.tsx
@@ -1,6 +1,5 @@
 import {
   FloatingFocusManager,
-  FloatingOverlay,
   FloatingPortal,
   useClick,
   useDismiss,
@@ -61,14 +60,14 @@ export function Drawer({children, render}: Props) {
 
   const modal = !isLargeScreen;
 
-  const {getReferenceProps, getFloatingProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps} = useInteractions(
     useClick(context),
     useRole(context),
     useDismiss(context, {
       outsidePress: modal,
       outsidePressEvent: 'mousedown',
-    }),
-  ]);
+    })
+  );
 
   const content = (
     <FloatingFocusManager
@@ -99,12 +98,12 @@ export function Drawer({children, render}: Props) {
       <FloatingPortal id="drawer-root">
         {open &&
           (modal ? (
-            <FloatingOverlay
+            <FloatingBackdrop
               lockScroll
               style={{background: 'rgba(0, 0, 0, 0.8)', zIndex: 1}}
             >
               {content}
-            </FloatingOverlay>
+            </FloatingBackdrop>
           ) : (
             content
           ))}

--- a/packages/react/test/visual/components/EmojiPicker.tsx
+++ b/packages/react/test/visual/components/EmojiPicker.tsx
@@ -131,11 +131,11 @@ export const Main = () => {
   });
 
   // Handles opening the floating element via the Choose Emoji button.
-  const {getReferenceProps, getFloatingProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps} = useInteractions(
     useClick(context),
     useDismiss(context),
-    useRole(context, {role: 'menu'}),
-  ]);
+    useRole(context, {role: 'menu'})
+  );
 
   // Handles the list navigation where the reference is the inner input, not
   // the button that opens the floating element.
@@ -143,7 +143,7 @@ export const Main = () => {
     getReferenceProps: getInputProps,
     getFloatingProps: getListFloatingProps,
     getItemProps,
-  } = useInteractions([
+  } = useInteractions(
     useListNavigation(context, {
       listRef,
       onNavigate: open ? setActiveIndex : undefined,
@@ -154,8 +154,8 @@ export const Main = () => {
       focusItemOnOpen: false,
       virtual: true,
       allowEscape: true,
-    }),
-  ]);
+    })
+  );
 
   useEffect(() => {
     if (open) {

--- a/packages/react/test/visual/components/Grid.tsx
+++ b/packages/react/test/visual/components/Grid.tsx
@@ -27,7 +27,7 @@ export const Main = ({orientation = 'horizontal', loop = false}: Props) => {
 
   const disabledIndices = [0, 1, 2, 3, 4, 5, 6, 7, 10, 15, 45, 48];
 
-  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions(
     useClick(context),
     useListNavigation(context, {
       listRef,
@@ -39,8 +39,8 @@ export const Main = ({orientation = 'horizontal', loop = false}: Props) => {
       openOnArrowKeyDown: false,
       disabledIndices,
     }),
-    useDismiss(context),
-  ]);
+    useDismiss(context)
+  );
 
   return (
     <>

--- a/packages/react/test/visual/components/MacSelect.tsx
+++ b/packages/react/test/visual/components/MacSelect.tsx
@@ -259,7 +259,7 @@ export function Main() {
         ],
   });
 
-  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions(
     useClick(context, {event: 'mousedown'}),
     useDismiss(context),
     useRole(context, {role: 'listbox'}),
@@ -279,8 +279,8 @@ export function Main() {
       listRef: listContentRef,
       activeIndex,
       onMatch: open ? setActiveIndex : setSelectedIndex,
-    }),
-  ]);
+    })
+  );
 
   useLayoutEffect(() => {
     if (open) {

--- a/packages/react/test/visual/components/MacSelect.tsx
+++ b/packages/react/test/visual/components/MacSelect.tsx
@@ -1,8 +1,8 @@
 import {
   autoUpdate,
   flip,
+  FloatingBackdrop,
   FloatingFocusManager,
-  FloatingOverlay,
   inner,
   offset,
   shift,
@@ -347,8 +347,12 @@ export function Main() {
         </Button>
         <FloatingPortal>
           {open && (
-            <FloatingOverlay lockScroll={!touch} style={{zIndex: 1}}>
-              <FloatingFocusManager context={context} modal={false}>
+            <FloatingBackdrop lockScroll={!touch} style={{zIndex: 1}}>
+              <FloatingFocusManager
+                context={context}
+                initialFocus={-1}
+                modal={false}
+              >
                 <div
                   ref={refs.setFloating}
                   style={{
@@ -452,7 +456,7 @@ export function Main() {
                     ))}
                 </div>
               </FloatingFocusManager>
-            </FloatingOverlay>
+            </FloatingBackdrop>
           )}
         </FloatingPortal>
       </div>

--- a/packages/react/test/visual/components/Menu.tsx
+++ b/packages/react/test/visual/components/Menu.tsx
@@ -126,14 +126,14 @@ export const MenuComponent = React.forwardRef<
     activeIndex,
   });
 
-  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions(
     hover,
     click,
     role,
     dismiss,
     listNavigation,
-    typeahead,
-  ]);
+    typeahead
+  );
 
   // Event emitter allows you to communicate across tree components.
   // This effect closes all menus when an item gets clicked anywhere
@@ -197,7 +197,7 @@ export const MenuComponent = React.forwardRef<
     duration: 100,
   });
 
-  const referenceRef = useMergeRefs([refs.setReference, forwardedRef]);
+  const referenceRef = useMergeRefs(refs.setReference, forwardedRef);
   const referenceProps = getReferenceProps({
     ref: referenceRef,
     ...props,

--- a/packages/react/test/visual/components/Navigation.tsx
+++ b/packages/react/test/visual/components/Navigation.tsx
@@ -56,7 +56,7 @@ export const NavigationItem = React.forwardRef<
     placement: 'right-start',
   });
 
-  const {getReferenceProps, getFloatingProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps} = useInteractions(
     useHover(context, {
       handleClose: safePolygon(),
       enabled: hasChildren,
@@ -66,8 +66,8 @@ export const NavigationItem = React.forwardRef<
     }),
     useDismiss(context, {
       enabled: hasChildren,
-    }),
-  ]);
+    })
+  );
 
   const mergedReferenceRef = React.useMemo(
     () => mergeRefs([ref, refs.setReference]),

--- a/packages/react/test/visual/components/Popover.tsx
+++ b/packages/react/test/visual/components/Popover.tsx
@@ -141,13 +141,13 @@ function PopoverComponent({
   const labelId = `${id}-label`;
   const descriptionId = `${id}-description`;
 
-  const {getReferenceProps, getFloatingProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps} = useInteractions(
     useClick(context),
     useRole(context),
     useDismiss(context, {
       bubbles,
-    }),
-  ]);
+    })
+  );
 
   return (
     <FloatingNode id={nodeId}>

--- a/packages/react/test/visual/components/Select.tsx
+++ b/packages/react/test/visual/components/Select.tsx
@@ -173,10 +173,7 @@ export function Main() {
                         }
 
                         // Only if not using typeahead.
-                        if (
-                          event.key === ' ' &&
-                          !context.dataRef.current.typing
-                        ) {
+                        if (event.key === ' ' && !context.data.typing) {
                           event.preventDefault();
                           handleSelect(i);
                         }

--- a/packages/react/test/visual/components/Select.tsx
+++ b/packages/react/test/visual/components/Select.tsx
@@ -89,13 +89,13 @@ export function Main() {
     onMatch: open ? setActiveIndex : setSelectedIndex,
   });
 
-  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions(
     click,
     dismiss,
     role,
     listNav,
-    typeahead,
-  ]);
+    typeahead
+  );
 
   const handleSelect = (index: number) => {
     setSelectedIndex(index);

--- a/packages/react/test/visual/components/Tooltip.tsx
+++ b/packages/react/test/visual/components/Tooltip.tsx
@@ -1,16 +1,16 @@
 import {
   autoUpdate,
   flip,
-  FloatingDelayGroup,
+  FloatingGroup,
   FloatingPortal,
   offset,
   Placement,
   shift,
-  useDelayGroup,
-  useDelayGroupContext,
   useDismiss,
   useFloating,
   useFocus,
+  useGroup,
+  useGroupContext,
   useHover,
   useInteractions,
   useRole,
@@ -50,7 +50,7 @@ export const Main = () => {
             <Tooltip label="My tooltip 3">
               <Button>My button</Button>
             </Tooltip>
-          </FloatingDelayGroup>
+          </FloatingGroup>
         </div>
       </div>
     </>
@@ -63,7 +63,7 @@ export function Tooltip({
   placement = 'top',
   delay = 0,
 }: Props) {
-  const {delay: groupDelay, currentId, isInstantPhase} = useDelayGroupContext();
+  const {delay: groupDelay, currentId, isInstantPhase} = useGroupContext();
   const [open, setOpen] = useState(false);
   const id = useId();
 
@@ -75,17 +75,17 @@ export function Tooltip({
     whileElementsMounted: autoUpdate,
   });
 
-  const {getReferenceProps, getFloatingProps} = useInteractions([
+  const {getReferenceProps, getFloatingProps} = useInteractions(
     useHover(context, {
       delay: groupDelay === 0 ? delay : groupDelay,
       move: false,
     }),
     useFocus(context),
     useRole(context, {role: 'tooltip'}),
-    useDismiss(context),
-  ]);
+    useDismiss(context)
+  );
 
-  useDelayGroup(context, {id});
+  useGroup(context, {id});
 
   const instantDuration = 0;
   const openDuration = 750;

--- a/packages/react/test/visual/components/Tooltip.tsx
+++ b/packages/react/test/visual/components/Tooltip.tsx
@@ -40,7 +40,7 @@ export const Main = () => {
       </div>
       <div className="grid place-items-center border border-slate-400 rounded lg:w-[40rem] h-[20rem] mb-4">
         <div className="flex gap-1">
-          <FloatingDelayGroup delay={{open: 500, close: 200}} timeoutMs={200}>
+          <FloatingGroup delay={{open: 500, close: 200}} timeoutMs={200}>
             <Tooltip label="My tooltip">
               <Button>My button</Button>
             </Tooltip>

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -102,7 +102,7 @@ export type UseFloatingOptions<T extends ReferenceElement = ReferenceElement> =
       reference: T,
       floating: FloatingElement,
       update: () => void
-    ) => void | (() => void);
+    ) => () => void;
   };
 
 export type UseFloatingReturn = {

--- a/packages/vue/src/useFloating.ts
+++ b/packages/vue/src/useFloating.ts
@@ -42,14 +42,14 @@ export function useFloating<T extends ReferenceElement = ReferenceElement>(
   const strategyOption = computed(() => unref(options.strategy) ?? 'absolute');
   const referenceElement = computed(() => unwrapElement(reference.value));
   const floatingElement = computed(() => unwrapElement(floating.value));
-  const x = ref<number | null>(null);
-  const y = ref<number | null>(null);
+  const x = ref(0);
+  const y = ref(0);
   const strategy = ref(strategyOption.value);
   const placement = ref(placementOption.value);
   const middlewareData = shallowRef<MiddlewareData>({});
   const isPositioned = ref(false);
 
-  let whileElementsMountedCleanup: void | (() => void);
+  let whileElementsMountedCleanup: (() => void) | undefined;
 
   function update() {
     if (referenceElement.value == null || floatingElement.value == null) {


### PR DESCRIPTION
Opening this for discussion, it's not ready for merging. /cc @mihkeleidast

The positioning parts here also apply to the `react-native` and `vue` packages, everything else is for `react`. 

As Mihkel pointed out, we need to make sure features like singletons and other things he pointed out don't require the API to break to work in the future, so let's make sure we future-proof this 😅 

---

## `x`/`y` default to `0` instead of `null`

`isPositioned` is a better way of checking if the floating element has been positioned. 

This removes the need to do `?? 0` although that will still work anyway, so not breaking for many use cases.

```js
const {x, y, strategy} = useFloating();
<div 
  style={{
    position: strategy,
    left: x,
    top: y,
  }} 
/>
```

## Enforce a cleanup function for `whileElementsMounted` type

Many people accidentally omitted the cleanup function for `autoUpdate` so I had to highlight it strongly in the docs — I don't know if you ever want to use it without a cleanup function. If there are complaints I can easily re-allow it without any breakage anyway.

## Renamed `FloatingOverlay` to `FloatingBackdrop`

More descriptive of its function, matches `::backdrop` CSS selector.

## Renamed `FloatingDelayGroup` to `FloatingGroup`

As discovered by @mihkeleidast it has some useful properties and could be extended beyond using delays. This more generic name allows it to do more things if we want in the future.

## Renamed `useHover#mouseOnly` to `ignoreTouch`

I still need to investigate if these need changing:

- `ignoreMouse` in `useClick`
- `keyboardOnly` in `useFocus`
- Should `move: true` be default in `useHover`? It's useful in some cases, but I'm not sure if it should be default.
- Should `restMs` be `openRestMs` as it doesn't apply to `close`? And `restMs` in `safePolygon()` be `destroyRestMs`? Think certain names can be more descriptive here.

## Made `useInteractions` and `useMergeRefs` variadic instead of accepting an array

Looking online, most of these functions use `...rest` instead of an array, looks a bit cleaner as the array isn't necessary. Neither accept a second argument and I doubt they ever will.

## Remove `reference()` virtual element support

Replaced by `refs.setPositionReference(...)`

## Replace public refs with instance variables

Convenience:

- `tree.nodesRef.current` => `tree.nodes`
- `context.dataRef.current` => `context.data`

---

- I haven't removed `reference`, `floating`, `positionReference` top-level callbacks. I deprecated them in the types, should we remove them?