### PR TITLE
refactor(useDismiss): allow preventing bubbling without `FloatingTree`

### DIFF
--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -81,7 +81,7 @@ export const useDismiss = <RT extends ReferenceType = ReferenceType>(
     referencePress = false,
     referencePressEvent = 'pointerdown',
     ancestorScroll = false,
-    bubbles = true,
+    bubbles,
   }: Props = {}
 ): ElementProps => {
   const tree = useFloatingTree();

--- a/packages/react/test/unit/useDismiss.test.tsx
+++ b/packages/react/test/unit/useDismiss.test.tsx
@@ -308,10 +308,12 @@ describe('bubbles', () => {
   describe('escapeKey', () => {
     test('without FloatingTree', async () => {
       function App() {
+        const [popoverOpen, setPopoverOpen] = useState(true);
         const [tooltipOpen, setTooltipOpen] = useState(false);
 
         const popover = useFloating({
-          open: true,
+          open: popoverOpen,
+          onOpenChange: setPopoverOpen,
         });
         const tooltip = useFloating({
           open: tooltipOpen,
@@ -332,17 +334,19 @@ describe('bubbles', () => {
               ref={popover.refs.setReference}
               {...popoverInteractions.getReferenceProps()}
             />
-            <div
-              role="dialog"
-              ref={popover.refs.setFloating}
-              {...popoverInteractions.getFloatingProps()}
-            >
-              <button
-                data-testid="focus-button"
-                ref={tooltip.refs.setReference}
-                {...tooltipInteractions.getReferenceProps()}
-              />
-            </div>
+            {popoverOpen && (
+              <div
+                role="dialog"
+                ref={popover.refs.setFloating}
+                {...popoverInteractions.getFloatingProps()}
+              >
+                <button
+                  data-testid="focus-button"
+                  ref={tooltip.refs.setReference}
+                  {...tooltipInteractions.getReferenceProps()}
+                />
+              </div>
+            )}
             {tooltipOpen && (
               <div
                 role="tooltip"
@@ -370,8 +374,8 @@ describe('bubbles', () => {
 
     test('true', async () => {
       render(
-        <NestedDialog testId="outer">
-          <NestedDialog testId="inner">
+        <NestedDialog testId="outer" bubbles>
+          <NestedDialog testId="inner" bubbles>
             <button>test button</button>
           </NestedDialog>
         </NestedDialog>


### PR DESCRIPTION
- https://github.com/floating-ui/floating-ui/discussions/2206
- https://github.com/floating-ui/floating-ui/discussions/2138

The escape key listener is attached to the `document` which prevents propagation from being able to be stopped and requires setting up a `FloatingTree`, which may be impractical for "agnostic" components that compose together like a Dialog and Select.

With this PR, if the reference and floating element have focus inside them, it now uses a keydown listener on the elements and can stop propagation for `esc` dismissal. If focus isn't inside either element, it falls back to the document listener, but in most cases this will fix the issue of agnostic components wanting to stop propagation.

This changes the default for `escapeKey` bubbling to `false`. 