### PR TITLE
fix(FloatingFocusManager): mutate internal preventReturnFocusRef instead of returnFocusRef

### DIFF
--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -366,10 +366,10 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
       const returnFocus = payload.data.returnFocus;
 
       if (typeof returnFocus === 'object') {
-        preventReturnFocusRef.current = false;
+        returnFocusRef.current = true;
         preventReturnFocusScroll = returnFocus.preventScroll;
       } else {
-        preventReturnFocusRef.current = !returnFocus;
+        returnFocusRef.current = returnFocus;
       }
     }
 

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -366,10 +366,10 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
       const returnFocus = payload.data.returnFocus;
 
       if (typeof returnFocus === 'object') {
-        returnFocusRef.current = true;
+        preventReturnFocusRef.current = false;
         preventReturnFocusScroll = returnFocus.preventScroll;
       } else {
-        returnFocusRef.current = returnFocus;
+        preventReturnFocusRef.current = !returnFocus;
       }
     }
 

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -338,6 +338,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     const previouslyFocusedElement = activeElement(doc);
     const contextData = dataRef.current;
     const initialFocusValue = initialFocusRef.current;
+    const returnFocusValue = returnFocusRef.current;
 
     previouslyFocusedElementRef.current = previouslyFocusedElement;
 
@@ -366,10 +367,10 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
       const returnFocus = payload.data.returnFocus;
 
       if (typeof returnFocus === 'object') {
-        returnFocusRef.current = true;
+        preventReturnFocusRef.current = false;
         preventReturnFocusScroll = returnFocus.preventScroll;
       } else {
-        returnFocusRef.current = returnFocus;
+        preventReturnFocusRef.current = !returnFocus;
       }
     }
 
@@ -383,7 +384,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
       }
 
       if (
-        returnFocusRef.current &&
+        returnFocusValue &&
         isHTMLElement(previouslyFocusedElementRef.current) &&
         !preventReturnFocusRef.current
       ) {

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -338,7 +338,6 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     const previouslyFocusedElement = activeElement(doc);
     const contextData = dataRef.current;
     const initialFocusValue = initialFocusRef.current;
-    const returnFocusValue = returnFocusRef.current;
 
     previouslyFocusedElementRef.current = previouslyFocusedElement;
 
@@ -384,7 +383,8 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
       }
 
       if (
-        returnFocusValue &&
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        returnFocusRef.current &&
         isHTMLElement(previouslyFocusedElementRef.current) &&
         !preventReturnFocusRef.current
       ) {

--- a/packages/react/test/visual/components/Popover.tsx
+++ b/packages/react/test/visual/components/Popover.tsx
@@ -16,6 +16,7 @@ import {
   useId,
   useInteractions,
   useRole,
+  useTransitionStatus,
 } from '@floating-ui/react';
 import * as Checkbox from '@radix-ui/react-checkbox';
 import {CheckIcon} from '@radix-ui/react-icons';
@@ -29,10 +30,11 @@ export const Main = () => {
   return (
     <>
       <h1 className="text-5xl font-bold mb-8">Popover</h1>
-      <div className="grid place-items-center border border-slate-400 rounded lg:w-[40rem] h-[20rem] mb-4">
+      <div className="flex place-items-center border border-slate-400 rounded lg:w-[40rem] h-[20rem] mb-4">
         <Popover
           modal={modal}
           bubbles={true}
+          transitionDuration={1000}
           render={({labelId, descriptionId, close}) => (
             <>
               <h2 id={labelId} className="text-2xl font-bold mb-2">
@@ -44,6 +46,7 @@ export const Main = () => {
               <Popover
                 modal={modal}
                 bubbles={true}
+                transitionDuration={1000}
                 render={({labelId, descriptionId, close}) => (
                   <>
                     <h2 id={labelId} className="text-2xl font-bold mb-2">
@@ -55,6 +58,7 @@ export const Main = () => {
                     <Popover
                       modal={modal}
                       bubbles={false}
+                      transitionDuration={1000}
                       render={({labelId, descriptionId, close}) => (
                         <>
                           <h2 id={labelId} className="text-2xl font-bold mb-2">
@@ -69,7 +73,7 @@ export const Main = () => {
                         </>
                       )}
                     >
-                      <Button>My button</Button>
+                      <Button>First third button</Button>
                     </Popover>
                     <button onClick={close} className="font-bold">
                       Close
@@ -77,7 +81,7 @@ export const Main = () => {
                   </>
                 )}
               >
-                <Button>My button</Button>
+                <Button>First second button</Button>
               </Popover>
               <button onClick={close} className="font-bold">
                 Close
@@ -85,7 +89,67 @@ export const Main = () => {
             </>
           )}
         >
-          <Button>My button</Button>
+          <Button>First button</Button>
+        </Popover>
+        <Popover
+          modal={modal}
+          bubbles={true}
+          transitionDuration={1000}
+          render={({labelId, descriptionId, close}) => (
+            <>
+              <h2 id={labelId} className="text-2xl font-bold mb-2">
+                Title
+              </h2>
+              <p id={descriptionId} className="mb-2">
+                Description
+              </p>
+              <Popover
+                modal={modal}
+                bubbles={true}
+                transitionDuration={1000}
+                render={({labelId, descriptionId, close}) => (
+                  <>
+                    <h2 id={labelId} className="text-2xl font-bold mb-2">
+                      Title
+                    </h2>
+                    <p id={descriptionId} className="mb-2">
+                      Description
+                    </p>
+                    <Popover
+                      modal={modal}
+                      bubbles={false}
+                      transitionDuration={1000}
+                      render={({labelId, descriptionId, close}) => (
+                        <>
+                          <h2 id={labelId} className="text-2xl font-bold mb-2">
+                            Title
+                          </h2>
+                          <p id={descriptionId} className="mb-2">
+                            Description
+                          </p>
+                          <button onClick={close} className="font-bold">
+                            Close
+                          </button>
+                        </>
+                      )}
+                    >
+                      <Button>Second third button</Button>
+                    </Popover>
+                    <button onClick={close} className="font-bold">
+                      Close
+                    </button>
+                  </>
+                )}
+              >
+                <Button>Second second button</Button>
+              </Popover>
+              <button onClick={close} className="font-bold">
+                Close
+              </button>
+            </>
+          )}
+        >
+          <Button>Second button</Button>
         </Popover>
       </div>
 
@@ -116,6 +180,7 @@ interface Props {
   modal?: boolean;
   children?: React.ReactElement<HTMLElement>;
   bubbles?: boolean;
+  transitionDuration?: number;
 }
 
 function PopoverComponent({
@@ -124,6 +189,7 @@ function PopoverComponent({
   placement,
   modal = true,
   bubbles = true,
+  transitionDuration = 0,
 }: Props) {
   const [open, setOpen] = useState(false);
 
@@ -149,6 +215,10 @@ function PopoverComponent({
     }),
   ]);
 
+  const {isMounted} = useTransitionStatus(context, {
+    duration: transitionDuration,
+  });
+
   return (
     <FloatingNode id={nodeId}>
       {isValidElement(children) &&
@@ -160,7 +230,7 @@ function PopoverComponent({
           } as React.HTMLProps<Element>)
         )}
       <FloatingPortal>
-        {open && (
+        {isMounted && (
           <FloatingFocusManager context={context} modal={modal}>
             <div
               className="bg-white border border-slate-900/10 shadow-md rounded px-4 py-6 bg-clip-padding"

--- a/packages/react/test/visual/components/Popover.tsx
+++ b/packages/react/test/visual/components/Popover.tsx
@@ -16,7 +16,6 @@ import {
   useId,
   useInteractions,
   useRole,
-  useTransitionStatus,
 } from '@floating-ui/react';
 import * as Checkbox from '@radix-ui/react-checkbox';
 import {CheckIcon} from '@radix-ui/react-icons';
@@ -30,11 +29,10 @@ export const Main = () => {
   return (
     <>
       <h1 className="text-5xl font-bold mb-8">Popover</h1>
-      <div className="flex place-items-center border border-slate-400 rounded lg:w-[40rem] h-[20rem] mb-4">
+      <div className="grid place-items-center border border-slate-400 rounded lg:w-[40rem] h-[20rem] mb-4">
         <Popover
           modal={modal}
           bubbles={true}
-          transitionDuration={1000}
           render={({labelId, descriptionId, close}) => (
             <>
               <h2 id={labelId} className="text-2xl font-bold mb-2">
@@ -46,7 +44,6 @@ export const Main = () => {
               <Popover
                 modal={modal}
                 bubbles={true}
-                transitionDuration={1000}
                 render={({labelId, descriptionId, close}) => (
                   <>
                     <h2 id={labelId} className="text-2xl font-bold mb-2">
@@ -58,7 +55,6 @@ export const Main = () => {
                     <Popover
                       modal={modal}
                       bubbles={false}
-                      transitionDuration={1000}
                       render={({labelId, descriptionId, close}) => (
                         <>
                           <h2 id={labelId} className="text-2xl font-bold mb-2">
@@ -73,7 +69,7 @@ export const Main = () => {
                         </>
                       )}
                     >
-                      <Button>First third button</Button>
+                      <Button>My button</Button>
                     </Popover>
                     <button onClick={close} className="font-bold">
                       Close
@@ -81,7 +77,7 @@ export const Main = () => {
                   </>
                 )}
               >
-                <Button>First second button</Button>
+                <Button>My button</Button>
               </Popover>
               <button onClick={close} className="font-bold">
                 Close
@@ -89,67 +85,7 @@ export const Main = () => {
             </>
           )}
         >
-          <Button>First button</Button>
-        </Popover>
-        <Popover
-          modal={modal}
-          bubbles={true}
-          transitionDuration={1000}
-          render={({labelId, descriptionId, close}) => (
-            <>
-              <h2 id={labelId} className="text-2xl font-bold mb-2">
-                Title
-              </h2>
-              <p id={descriptionId} className="mb-2">
-                Description
-              </p>
-              <Popover
-                modal={modal}
-                bubbles={true}
-                transitionDuration={1000}
-                render={({labelId, descriptionId, close}) => (
-                  <>
-                    <h2 id={labelId} className="text-2xl font-bold mb-2">
-                      Title
-                    </h2>
-                    <p id={descriptionId} className="mb-2">
-                      Description
-                    </p>
-                    <Popover
-                      modal={modal}
-                      bubbles={false}
-                      transitionDuration={1000}
-                      render={({labelId, descriptionId, close}) => (
-                        <>
-                          <h2 id={labelId} className="text-2xl font-bold mb-2">
-                            Title
-                          </h2>
-                          <p id={descriptionId} className="mb-2">
-                            Description
-                          </p>
-                          <button onClick={close} className="font-bold">
-                            Close
-                          </button>
-                        </>
-                      )}
-                    >
-                      <Button>Second third button</Button>
-                    </Popover>
-                    <button onClick={close} className="font-bold">
-                      Close
-                    </button>
-                  </>
-                )}
-              >
-                <Button>Second second button</Button>
-              </Popover>
-              <button onClick={close} className="font-bold">
-                Close
-              </button>
-            </>
-          )}
-        >
-          <Button>Second button</Button>
+          <Button>My button</Button>
         </Popover>
       </div>
 
@@ -180,7 +116,6 @@ interface Props {
   modal?: boolean;
   children?: React.ReactElement<HTMLElement>;
   bubbles?: boolean;
-  transitionDuration?: number;
 }
 
 function PopoverComponent({
@@ -189,7 +124,6 @@ function PopoverComponent({
   placement,
   modal = true,
   bubbles = true,
-  transitionDuration = 0,
 }: Props) {
   const [open, setOpen] = useState(false);
 
@@ -215,10 +149,6 @@ function PopoverComponent({
     }),
   ]);
 
-  const {isMounted} = useTransitionStatus(context, {
-    duration: transitionDuration,
-  });
-
   return (
     <FloatingNode id={nodeId}>
       {isValidElement(children) &&
@@ -230,7 +160,7 @@ function PopoverComponent({
           } as React.HTMLProps<Element>)
         )}
       <FloatingPortal>
-        {isMounted && (
+        {open && (
           <FloatingFocusManager context={context} modal={modal}>
             <div
               className="bg-white border border-slate-900/10 shadow-md rounded px-4 py-6 bg-clip-padding"


### PR DESCRIPTION
We ran into a problem with a Popover that uses the transition hook, the main structure was like this:

```
<Popover id="a">
  <Popover id="b">
  </Popover>
</Popover>
<Popover id="c">
</Popover>
```

The bug occurred when:
1. open Popover a
2. open nested Popover b
3. open Popover c, which should close both a and b with an outside press
4. but Popover c also closed

Since a and b closed with transition timeouts, the layout effect cleanup function also run with a timeout. This surfaced an issue where in the cleanup function, `returnFocusRef.current` was not `false` anymore, even though it was set to false in the `onDismiss` function. I assume this is because `returnFocusRef` depends on the prop value, and with the transitions, it gets rerendered and reset at some point. I think this is a bug, internally we shouldn't mutate the ref that comes from the prop. Instead, we should mutate the internal `preventReturnFocusRef` when necessary.

I tried writing a test for it, but failed, since this issue only seemed to happen with transition timeouts, which would need to be mocked with fake timers in tests. Hoping the change makes sense without a test/repro as well.