### PR TITLE
fix(useListNavigation): allow scheduled list population

### DIFF
--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -464,7 +464,9 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     if (ignoreInitialFocus || !floating) return;
 
     function setState() {
-      setTabbableContentLength(getTabbableContent().length);
+      if (activeElement(getDocument(floating)) !== refs.domReference.current) {
+        setTabbableContentLength(getTabbableContent().length);
+      }
     }
 
     setState();


### PR DESCRIPTION
Partially solves https://github.com/floating-ui/floating-ui/issues/2235 /cc @Marsony

[`use-descendants@beta`](https://www.npmjs.com/package/use-descendants) (unfortunately unmaintained, but works) allows you to do this:

```js
<Select>
  <OptionGroup>
    <Option />
    <Option />
  </OptionGroup>
  <OptionGroup>
    <Option />
  </OptionGroup>
</Select>
```

Where `Option` can read its `index` in the `Select` tree despite the `OptionGroup` wrapper. 


```js
function Option() {
  const {listRef} = useSelectContext();
  const index = useDescendant();

  return (
    <div
      ref={node => (listRef.current[index] = node)}
    />
  );
}
```

However, it causes a state update in a layout effect, and `ArrowDown`/`ArrowUp` on the reference element expects the list to be populated in the same render cycle as the open state changing. This allows the list to be populated async (for only 1 task/frame) on keydown, and then the package works fine.

This descendant technique should be included as part of the new `useList` API, where keeping track of a list item index won't be necessary any longer