### PR TITLE
fix(useInteractions): merging function props that return values

### DIFF
--- a/packages/react/src/useInteractions.ts
+++ b/packages/react/src/useInteractions.ts
@@ -30,7 +30,10 @@ function mergeProps(
               map.get(key)?.push(value);
 
               acc[key] = (...args: unknown[]) => {
-                map.get(key)?.forEach((fn) => fn(...args));
+                return map
+                  .get(key)
+                  ?.map((fn) => fn(...args))
+                  .find((val) => val !== undefined);
               };
             }
           } else {

--- a/packages/react/test/unit/useInteractions.test.tsx
+++ b/packages/react/test/unit/useInteractions.test.tsx
@@ -82,6 +82,24 @@ test('does not break props that start with `on`', () => {
   render(<App />);
 });
 
+test('does not break props that return values', () => {
+  function App() {
+    const {getReferenceProps} = useInteractions([]);
+
+    const props = getReferenceProps({
+      // @ts-expect-error
+      onyx: () => 'returned value',
+    });
+
+    // @ts-expect-error
+    expect(props.onyx()).toBe('returned value');
+
+    return null;
+  }
+
+  render(<App />);
+});
+
 test('prop getters are memoized', () => {
   function App() {
     const [open, setOpen] = useState(false);


### PR DESCRIPTION
Our usecase for this is that our buttons accept Promise-returning onClick handlers, which put the button to a loading state while the promise resolves. This behavior broke when a button was wrapped with a Tooltip, as the prop merging here did not forward the returned promise.