### PR TITLE
fix(FloatingFocusManager): respect child with autoFocus

### DIFF
--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -350,12 +350,15 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
       previouslyFocusedElement
     );
 
-    // If the `useListNavigation` hook is active, always ignore `initialFocus`
-    // because it has its own handling of the initial focus.
-    !ignoreInitialFocus &&
+    if (
+      // If the `useListNavigation` hook is active, always ignore `initialFocus`
+      // because it has its own handling of the initial focus.
+      !ignoreInitialFocus &&
       !focusAlreadyInsideFloatingEl &&
-      open &&
+      open
+    ) {
       enqueueFocus(elToFocus, {preventScroll: elToFocus === floating});
+    }
 
     // Dismissing via outside press should always ignore `returnFocus` to
     // prevent unwanted scrolling.

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -345,9 +345,15 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
         ? focusableElements[initialFocusValue]
         : initialFocusValue.current) || floating;
 
+    const focusAlreadyInsideFloatingEl = contains(
+      floating,
+      previouslyFocusedElement
+    );
+
     // If the `useListNavigation` hook is active, always ignore `initialFocus`
     // because it has its own handling of the initial focus.
     !ignoreInitialFocus &&
+      !focusAlreadyInsideFloatingEl &&
       open &&
       enqueueFocus(elToFocus, {preventScroll: elToFocus === floating});
 

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -50,6 +50,7 @@ function App(
             <button data-testid="three" onClick={() => setOpen(false)}>
               x
             </button>
+            {props.children}
           </div>
         </FloatingFocusManager>
       )}
@@ -80,6 +81,18 @@ describe('initialFocus', () => {
     render(<App initialFocus="two" />);
     fireEvent.click(screen.getByTestId('reference'));
     expect(screen.getByTestId('two')).toHaveFocus();
+
+    cleanup();
+  });
+
+  test('respects autoFocus', () => {
+    render(
+      <App>
+        <input autoFocus data-testid="input" />
+      </App>
+    );
+    fireEvent.click(screen.getByTestId('reference'));
+    expect(screen.getByTestId('input')).toHaveFocus();
 
     cleanup();
   });


### PR DESCRIPTION
I suppose this could be configured with initialFocus, but this would seem like an unnecessary configuration to me. I think users would expect autoFocus inside a dialog to just work.