### PR TITLE
fix(FloatingFocusManager): wait for tree nodes context to be updated

### DIFF
--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -206,7 +206,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     function handleFocusOutside(event: FocusEvent) {
       const relatedTarget = event.relatedTarget as Element | null;
 
-      setTimeout(() => {
+      queueMicrotask(() => {
         const movedToUnrelatedNode = !(
           contains(domReference, relatedTarget) ||
           contains(floating, relatedTarget) ||

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -206,37 +206,39 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>({
     function handleFocusOutside(event: FocusEvent) {
       const relatedTarget = event.relatedTarget as Element | null;
 
-      const movedToUnrelatedNode = !(
-        contains(domReference, relatedTarget) ||
-        contains(floating, relatedTarget) ||
-        contains(relatedTarget, floating) ||
-        contains(portalContext?.portalNode, relatedTarget) ||
-        relatedTarget?.hasAttribute('data-floating-ui-focus-guard') ||
-        (tree &&
-          (getChildren(tree.nodesRef.current, nodeId).find(
-            (node) =>
-              contains(node.context?.elements.floating, relatedTarget) ||
-              contains(node.context?.elements.domReference, relatedTarget)
-          ) ||
-            getAncestors(tree.nodesRef.current, nodeId).find(
+      setTimeout(() => {
+        const movedToUnrelatedNode = !(
+          contains(domReference, relatedTarget) ||
+          contains(floating, relatedTarget) ||
+          contains(relatedTarget, floating) ||
+          contains(portalContext?.portalNode, relatedTarget) ||
+          relatedTarget?.hasAttribute('data-floating-ui-focus-guard') ||
+          (tree &&
+            (getChildren(tree.nodesRef.current, nodeId).find(
               (node) =>
-                node.context?.elements.floating === relatedTarget ||
-                node.context?.elements.domReference === relatedTarget
-            )))
-      );
+                contains(node.context?.elements.floating, relatedTarget) ||
+                contains(node.context?.elements.domReference, relatedTarget)
+            ) ||
+              getAncestors(tree.nodesRef.current, nodeId).find(
+                (node) =>
+                  node.context?.elements.floating === relatedTarget ||
+                  node.context?.elements.domReference === relatedTarget
+              )))
+        );
 
-      // Focus did not move inside the floating tree, and there are no tabbable
-      // portal guards to handle closing.
-      if (
-        relatedTarget &&
-        movedToUnrelatedNode &&
-        !isPointerDownRef.current &&
-        // Fix React 18 Strict Mode returnFocus due to double rendering.
-        relatedTarget !== previouslyFocusedElementRef.current
-      ) {
-        preventReturnFocusRef.current = true;
-        onOpenChange(false);
-      }
+        // Focus did not move inside the floating tree, and there are no tabbable
+        // portal guards to handle closing.
+        if (
+          relatedTarget &&
+          movedToUnrelatedNode &&
+          !isPointerDownRef.current &&
+          // Fix React 18 Strict Mode returnFocus due to double rendering.
+          relatedTarget !== previouslyFocusedElementRef.current
+        ) {
+          preventReturnFocusRef.current = true;
+          onOpenChange(false);
+        }
+      });
     }
 
     if (floating && isHTMLElement(domReference)) {


### PR DESCRIPTION
This might be a weird one. I'm not exactly sure if this sort of usage is supported or not, but it seemed like a bug. The test resembles this a little bit, but not too much. I'll add a bigger backstory in a details panel.

Anyway, I found that the `getChildren` function call in `movedToUnrelatedNode` does not return any children, because it does not think the child is open yet, even though opening the child is what triggered the focusout in the first place. Seems like it is necessary to wait for [this layout effect](https://github.com/floating-ui/floating-ui/blob/master/packages/react/src/useFloating.ts#L111-L116) to have run before actually running the check. I'm not sure if the timeout is the best way to do this, however, I'm always reluctant to add such timeouts. Maybe the getChildren should skip the open check in that case instead? Either way, it worked for this test and did not seem to break any others, so...

WDYT?

<details>
<summary>My usecase</summary>

I have this usecase where:
- a dropdown menu item opens a confirmation dialog
- when the action is cancelled, focus should be returned to the item
- when the action is confirmed, the dropdown is closed and focus returns to the dropdown button

Now, in order to keep the dropdown menu open, so it would not close via focusout events et al, I need to render the modal inside of the dropdown's FloatingNode. I can't render it it in the dropdown menu (that is portalled), as both the dropdown menu and modal have a transition applied to them, and when nesting in the menu, the transitions don't work as expected.

It looks something like this in practice:

```tsx
export const DropdownTemplate = (args) => {
  const [status, setStatus] = React.useState('Waiting for action press');
  const { pending, proceed, cancel, confirm } = useConfirmation();
  const actionRef = React.useRef(null);
  const handleAction = React.useCallback(async () => {
    setStatus('Waiting for confirmation');
    const confirmed = await confirm();
    if (confirmed) {
      setStatus('Confirmed, doing something');
      const somethingResult = await doSomething();
      if (somethingResult) {
        setStatus('Something is done, waiting for action press');
      } else {
        setStatus('Something is not done, waiting for action press');
      }
      return somethingResult;
    } else {
      setStatus('Cancelled, waiting for action press');
    }
    return confirmed;
  }, [confirm]);
  return (
    <Stack alignItems="center" gap="medium">
      <Dropdown>
        <DropdownButton iconStart="small-more" iconEnd="small-chevron-down" size="small">
          Actions
        </DropdownButton>
        <DropdownMenu>
          <DropdownMenuItem ref={actionRef} onClick={handleAction}>
            Do something
          </DropdownMenuItem>
        </DropdownMenu>
        <AlertModal {...args} trigger={actionRef.current} open={pending} onClose={cancel}>
          <Button onClick={cancel} kind="subtle">
            Cancel
          </Button>
          <Button onClick={proceed} kind="primary">
            Confirm
          </Button>
        </AlertModal>
      </Dropdown>
      <Text>{status}</Text>
    </Stack>
  );
};
```

</details>