### PR TITLE
feat: `FloatingList`

### DIFF
--- a/packages/react/src/components/FloatingList.tsx
+++ b/packages/react/src/components/FloatingList.tsx
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import useLayoutEffect from 'use-isomorphic-layout-effect';
+
+function sortByDocumentPosition(a: Node, b: Node) {
+  const position = a.compareDocumentPosition(b);
+
+  if (
+    position & Node.DOCUMENT_POSITION_FOLLOWING ||
+    position & Node.DOCUMENT_POSITION_CONTAINED_BY
+  ) {
+    return -1;
+  }
+
+  if (
+    position & Node.DOCUMENT_POSITION_PRECEDING ||
+    position & Node.DOCUMENT_POSITION_CONTAINS
+  ) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function areMapsEqual(
+  map1: Map<Node, number | null>,
+  map2: Map<Node, number | null>
+) {
+  if (map1.size !== map2.size) {
+    return false;
+  }
+  for (const [key, value] of map1.entries()) {
+    if (value !== map2.get(key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export const FloatingListContext = React.createContext<null | {
+  register: (node: Node) => void;
+  unregister: (node: Node) => void;
+  map: Map<Node, number | null>;
+  elementsRef: React.MutableRefObject<Array<HTMLElement | null>>;
+  stringsRef?: React.MutableRefObject<Array<string | null>>;
+}>(null);
+
+export function FloatingList({
+  children,
+  elementsRef,
+  stringsRef,
+}: {
+  children: React.ReactNode;
+  elementsRef: React.MutableRefObject<Array<HTMLElement | null>>;
+  stringsRef?: React.MutableRefObject<Array<string | null>>;
+}): JSX.Element {
+  const [map, setMap] = React.useState(() => new Map<Node, number | null>());
+
+  const register = React.useCallback((node: Node) => {
+    setMap((prevMap) => new Map(prevMap).set(node, null));
+  }, []);
+
+  const unregister = React.useCallback((node: Node) => {
+    setMap((prevMap) => {
+      const map = new Map(prevMap);
+      map.delete(node);
+      return map;
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (map.size < 2) return;
+
+    const newMap = new Map(map);
+    const nodes = Array.from(newMap.keys()).sort(sortByDocumentPosition);
+
+    nodes.forEach((node, index) => {
+      newMap.set(node, index);
+    });
+
+    if (!areMapsEqual(map, newMap)) {
+      setMap(newMap);
+    }
+  }, [map]);
+
+  return (
+    <FloatingListContext.Provider
+      value={{register, unregister, map, elementsRef, stringsRef}}
+    >
+      {children}
+    </FloatingListContext.Provider>
+  );
+}
+
+export interface UseListItemProps {
+  label?: string;
+}
+
+export function useListItem({label}: UseListItemProps = {}): {
+  ref: (node: HTMLElement | null) => void;
+  index: number;
+} {
+  const [index, setIndex] = React.useState<number | null>(null);
+  const componentRef = React.useRef<Node | null>(null);
+  const ctx = React.useContext(FloatingListContext);
+
+  if (!ctx) {
+    throw new Error('useListItem must be used within a FloatingList');
+  }
+
+  const {register, unregister, map, elementsRef, stringsRef} = ctx;
+
+  const ref = React.useCallback(
+    (node: HTMLElement | null) => {
+      componentRef.current = node;
+
+      if (index !== null) {
+        elementsRef.current[index] = node;
+        if (stringsRef) {
+          stringsRef.current[index] = label || node?.textContent || null;
+        }
+      }
+    },
+    [index, elementsRef, stringsRef, label]
+  );
+
+  useLayoutEffect(() => {
+    const node = componentRef.current;
+    if (!node) return;
+
+    register(node);
+    return () => {
+      unregister(node);
+    };
+  }, [register, unregister]);
+
+  useLayoutEffect(() => {
+    const index = componentRef.current ? map.get(componentRef.current) : null;
+    if (index != null) {
+      setIndex(index);
+    }
+  }, [map]);
+
+  return React.useMemo(
+    () => ({
+      ref,
+      index: index == null ? -1 : index,
+    }),
+    [index, ref]
+  );
+}

--- a/packages/react/src/components/FloatingList.tsx
+++ b/packages/react/src/components/FloatingList.tsx
@@ -41,17 +41,17 @@ export const FloatingListContext = React.createContext<null | {
   unregister: (node: Node) => void;
   map: Map<Node, number | null>;
   elementsRef: React.MutableRefObject<Array<HTMLElement | null>>;
-  stringsRef?: React.MutableRefObject<Array<string | null>>;
+  labelsRef?: React.MutableRefObject<Array<string | null>>;
 }>(null);
 
 export function FloatingList({
   children,
   elementsRef,
-  stringsRef,
+  labelsRef,
 }: {
   children: React.ReactNode;
   elementsRef: React.MutableRefObject<Array<HTMLElement | null>>;
-  stringsRef?: React.MutableRefObject<Array<string | null>>;
+  labelsRef?: React.MutableRefObject<Array<string | null>>;
 }): JSX.Element {
   const [map, setMap] = React.useState(() => new Map<Node, number | null>());
 
@@ -84,7 +84,7 @@ export function FloatingList({
 
   return (
     <FloatingListContext.Provider
-      value={{register, unregister, map, elementsRef, stringsRef}}
+      value={{register, unregister, map, elementsRef, labelsRef}}
     >
       {children}
     </FloatingListContext.Provider>
@@ -107,7 +107,7 @@ export function useListItem({label}: UseListItemProps = {}): {
     throw new Error('useListItem must be used within a FloatingList');
   }
 
-  const {register, unregister, map, elementsRef, stringsRef} = ctx;
+  const {register, unregister, map, elementsRef, labelsRef} = ctx;
 
   const ref = React.useCallback(
     (node: HTMLElement | null) => {
@@ -115,12 +115,12 @@ export function useListItem({label}: UseListItemProps = {}): {
 
       if (index !== null) {
         elementsRef.current[index] = node;
-        if (stringsRef) {
-          stringsRef.current[index] = label || node?.textContent || null;
+        if (labelsRef) {
+          labelsRef.current[index] = label || node?.textContent || null;
         }
       }
     },
-    [index, elementsRef, stringsRef, label]
+    [index, elementsRef, labelsRef, label]
   );
 
   useLayoutEffect(() => {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,7 @@ export {
   useDelayGroupContext,
 } from './components/FloatingDelayGroup';
 export {FloatingFocusManager} from './components/FloatingFocusManager';
+export {FloatingList, useListItem} from './components/FloatingList';
 export {FloatingOverlay} from './components/FloatingOverlay';
 export {
   FloatingPortal,

--- a/packages/react/test/unit/FloatingList.test.tsx
+++ b/packages/react/test/unit/FloatingList.test.tsx
@@ -23,7 +23,7 @@ function Select({children}: {children: React.ReactNode}) {
   });
 
   const elementsRef = React.useRef<Array<HTMLElement | null>>([]);
-  const stringsRef = React.useRef<Array<string | null>>([]);
+  const labelsRef = React.useRef<Array<string | null>>([]);
 
   const click = useClick(context);
   const listNavigation = useListNavigation(context, {
@@ -32,7 +32,7 @@ function Select({children}: {children: React.ReactNode}) {
     onNavigate: setActiveIndex,
   });
   const typeahead = useTypeahead(context, {
-    listRef: stringsRef,
+    listRef: labelsRef,
     activeIndex,
     onMatch: setActiveIndex,
   });
@@ -48,7 +48,7 @@ function Select({children}: {children: React.ReactNode}) {
       <button ref={refs.setReference} {...getReferenceProps()}>
         Open select menu
       </button>
-      <FloatingList elementsRef={elementsRef} stringsRef={stringsRef}>
+      <FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
         {isOpen && (
           <div ref={refs.setFloating} role="listbox" {...getFloatingProps()}>
             {children}

--- a/packages/react/test/unit/FloatingList.test.tsx
+++ b/packages/react/test/unit/FloatingList.test.tsx
@@ -1,0 +1,178 @@
+import {act, fireEvent, render, screen} from '@testing-library/react';
+import * as React from 'react';
+
+import {
+  FloatingList,
+  useClick,
+  useFloating,
+  useInteractions,
+  useListItem,
+  useListNavigation,
+  useTypeahead,
+} from '../../src';
+
+const SelectContext = React.createContext<any>(null);
+
+function Select({children}: {children: React.ReactNode}) {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
+
+  const {refs, context} = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+  });
+
+  const elementsRef = React.useRef<Array<HTMLElement | null>>([]);
+  const stringsRef = React.useRef<Array<string | null>>([]);
+
+  const click = useClick(context);
+  const listNavigation = useListNavigation(context, {
+    listRef: elementsRef,
+    activeIndex,
+    onNavigate: setActiveIndex,
+  });
+  const typeahead = useTypeahead(context, {
+    listRef: stringsRef,
+    activeIndex,
+    onMatch: setActiveIndex,
+  });
+
+  const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
+    click,
+    listNavigation,
+    typeahead,
+  ]);
+
+  return (
+    <SelectContext.Provider value={{getItemProps, activeIndex}}>
+      <button ref={refs.setReference} {...getReferenceProps()}>
+        Open select menu
+      </button>
+      <FloatingList elementsRef={elementsRef} stringsRef={stringsRef}>
+        {isOpen && (
+          <div ref={refs.setFloating} role="listbox" {...getFloatingProps()}>
+            {children}
+          </div>
+        )}
+      </FloatingList>
+    </SelectContext.Provider>
+  );
+}
+
+function Option({
+  children,
+  label,
+}: {
+  children: React.ReactNode;
+  label?: string;
+}) {
+  const {getItemProps, activeIndex} = React.useContext(SelectContext);
+  const {ref, index} = useListItem({label});
+  const isActive = index === activeIndex && index !== null;
+  return (
+    <div
+      ref={ref}
+      role="option"
+      tabIndex={isActive ? 0 : -1}
+      {...getItemProps()}
+    >
+      {children}
+    </div>
+  );
+}
+
+test('registers element ref and indexes correctly', async () => {
+  render(
+    <Select>
+      <Option>One</Option>
+      <div>
+        <Option>Two</Option>
+        <Option>Three</Option>
+        <Option>Four</Option>
+      </div>
+      <>
+        <Option>Five</Option>
+        <Option>Six</Option>
+      </>
+    </Select>
+  );
+
+  fireEvent.click(screen.getByRole('button'));
+  await act(async () => {});
+
+  expect(screen.getAllByRole('option')[0]).toHaveFocus();
+
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'ArrowDown'});
+
+  expect(screen.getAllByRole('option')[1]).toHaveFocus();
+
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'ArrowDown'});
+
+  expect(screen.getAllByRole('option')[2]).toHaveFocus();
+
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'ArrowDown'});
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'ArrowDown'});
+
+  expect(screen.getAllByRole('option')[4]).toHaveFocus();
+  expect(screen.getAllByRole('option')[4].getAttribute('tabindex')).toBe('0');
+});
+
+test('registers strings correctly (no value)', async () => {
+  render(
+    <Select>
+      <Option>One</Option>
+      <div>
+        <Option>Two</Option>
+        <Option>Three</Option>
+        <Option>Four</Option>
+      </div>
+      <>
+        <Option>Five</Option>
+        <Option>Six</Option>
+      </>
+    </Select>
+  );
+
+  fireEvent.click(screen.getByRole('button'));
+  await act(async () => {});
+
+  expect(screen.getAllByRole('option')[0]).toHaveFocus();
+
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'F'});
+
+  expect(screen.getAllByRole('option')[3]).toHaveFocus();
+
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'I'});
+
+  expect(screen.getAllByRole('option')[4]).toHaveFocus();
+});
+
+test('registers strings correctly (label)', async () => {
+  render(
+    <Select>
+      <Option label="One">One</Option>
+      <div>
+        <Option label="Two">Two</Option>
+        <Option label="Three">Three</Option>
+        <Option label="Four">Four</Option>
+      </div>
+      <>
+        <Option label="Five">Five</Option>
+        <Option label="Six">Six</Option>
+      </>
+    </Select>
+  );
+
+  fireEvent.click(screen.getByRole('button'));
+  await act(async () => {});
+
+  expect(screen.getAllByRole('option')[0]).toHaveFocus();
+
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'F'});
+
+  expect(screen.getAllByRole('option')[3]).toHaveFocus();
+
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'I'});
+
+  expect(screen.getAllByRole('option')[4]).toHaveFocus();
+});

--- a/packages/react/test/unit/FloatingList.test.tsx
+++ b/packages/react/test/unit/FloatingList.test.tsx
@@ -176,3 +176,51 @@ test('registers strings correctly (label)', async () => {
 
   expect(screen.getAllByRole('option')[4]).toHaveFocus();
 });
+
+test('handles re-ordering', async () => {
+  const {rerender} = render(
+    <Select>
+      <Option>One</Option>
+      <div>
+        <Option>Two</Option>
+        <Option>Three</Option>
+        <Option>Four</Option>
+      </div>
+      <>
+        <Option>Five</Option>
+        <Option>Six</Option>
+      </>
+    </Select>
+  );
+
+  fireEvent.click(screen.getByRole('button'));
+  await act(async () => {});
+
+  expect(screen.getAllByRole('option')[0]).toHaveFocus();
+
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'ArrowDown'});
+
+  expect(screen.getAllByRole('option')[1]).toHaveFocus();
+
+  rerender(
+    <Select>
+      <Option>One</Option>
+      <div>
+        <Option>Two</Option>
+        <Option>Three</Option>
+        <Option>Four</Option>
+      </div>
+      <>
+        <Option>Six</Option>
+        <Option>Five</Option>
+      </>
+    </Select>
+  );
+
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'ArrowDown'});
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'ArrowDown'});
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'ArrowDown'});
+  fireEvent.keyDown(screen.getByRole('listbox'), {key: 'ArrowDown'});
+
+  expect(screen.getAllByRole('option')[5]).toHaveFocus();
+});

--- a/packages/react/test/visual/components/Select.tsx
+++ b/packages/react/test/visual/components/Select.tsx
@@ -70,15 +70,15 @@ function Select({children}: {children: React.ReactNode}) {
     ],
   });
 
-  const listElementsRef = React.useRef<Array<HTMLElement | null>>([]);
-  const listStringsRef = React.useRef<Array<string | null>>([]);
+  const elementsRef = React.useRef<Array<HTMLElement | null>>([]);
+  const labelsRef = React.useRef<Array<string | null>>([]);
   const isTypingRef = React.useRef(false);
 
   const click = useClick(context, {event: 'mousedown'});
   const dismiss = useDismiss(context);
   const role = useRole(context, {role: 'listbox'});
   const listNav = useListNavigation(context, {
-    listRef: listElementsRef,
+    listRef: elementsRef,
     activeIndex,
     selectedIndex,
     onNavigate: setActiveIndex,
@@ -86,7 +86,7 @@ function Select({children}: {children: React.ReactNode}) {
     loop: true,
   });
   const typeahead = useTypeahead(context, {
-    listRef: listStringsRef,
+    listRef: labelsRef,
     activeIndex,
     selectedIndex,
     onMatch: open ? setActiveIndex : setSelectedIndex,
@@ -123,7 +123,7 @@ function Select({children}: {children: React.ReactNode}) {
             {value || 'Select...'}
           </Button>
         </div>
-        <FloatingList elementsRef={listElementsRef} stringsRef={listStringsRef}>
+        <FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
           <SelectContext.Provider
             value={{
               getItemProps,


### PR DESCRIPTION
@pierreburel @Marsony

The `sortByDocumentPosition` technique is found in other libs to enable this feature, and this one doesn't write or read any refs during render, so hopefully good for concurrent features.

Usage:

`FloatingList` is a context provider for children

- `elementsRef` is `useListNavigation`'s `listRef`
- `labelsRef` is `useTypeahead`'s `listRef` which uses the `label` passed into `useListItem` or falls back to the node's `textContent`

```js
<FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
  ...
</FloatingList>
```

- `useListItem` reads that context and returns an `index` and a `ref`:

```js
const {activeIndex} = useSelectContext();
const {ref, index} = useListItem();
const isActive = activeIndex === index;

// No need to manually assign an index:
<div ref={ref} tabIndex={isActive ? 0 : -1} />
```

For controlled (pre-selected values) is there anything else we should do?  @pierreburel - your demo has `listValuesRef` but this is not included here