### PR TITLE
feat(react): add toast component

### DIFF
--- a/packages/react/test/visual/components/Toast.tsx
+++ b/packages/react/test/visual/components/Toast.tsx
@@ -25,9 +25,7 @@ import {
 
 import {Button} from '../lib/Button';
 
-export type AppearanceTypes = 'error' | 'info' | 'success' | 'warning';
-export type Id = string;
-
+type Id = string;
 type ToastType = {
   id: Id;
   placement: Placement;
@@ -40,7 +38,7 @@ type ContextType = {
   toasts: ToastsType;
   dismiss: ElementProps;
   toast: (toast: Omit<ToastType, 'id'>) => void;
-  close: (toastId: string) => void;
+  close: (toastId: Id) => void;
   refs: ExtendedRefs<ReferenceType>;
 } & UseFloatingReturn;
 
@@ -104,7 +102,7 @@ export function useToasts({placement = 'top'}: {placement?: Placement}) {
     ]);
   }, []);
 
-  const close = useCallback((toastId: string) => {
+  const close = useCallback((toastId: Id) => {
     setToasts((prev) => prev.filter((toast) => toast.id !== toastId));
   }, []);
 
@@ -215,7 +213,7 @@ type ToastContentProps = {
   toastId: Id;
   isClosable?: boolean;
   children: ReactNode;
-} & HTMLAttributes<HTMLDivElement>;
+} & HTMLAttributes<HTMLLIElement>;
 
 export const ToastContent = forwardRef<HTMLLIElement, ToastContentProps>(
   ({toastId, children}, propRef) => {

--- a/packages/react/test/visual/components/Toast.tsx
+++ b/packages/react/test/visual/components/Toast.tsx
@@ -69,7 +69,7 @@ const Component = () => {
               })
             }
           >
-            Add Top
+            Add Toast
           </Button>
         </div>
       </>
@@ -283,10 +283,12 @@ type ToastContentProps = {
 
 export const ToastContent = forwardRef<HTMLLIElement, ToastContentProps>(
   ({toastId, placement, children}, propRef) => {
+    const duration = 300;
+    const [closeStyle, setCloseStyle] = useState<React.CSSProperties>({});
     const {context, close, dismiss} = useToastsContext();
     const {getItemProps} = useInteractions([dismiss]);
     const {styles} = useTransitionStyles(context, {
-      duration: 300,
+      duration,
       initial: () => ({
         opacity: 0,
       }),
@@ -302,8 +304,15 @@ export const ToastContent = forwardRef<HTMLLIElement, ToastContentProps>(
     });
 
     const closeToast = useCallback(() => {
-      close(toastId);
-    }, [close, toastId]);
+      setCloseStyle({
+        opacity: 0,
+        maxHeight: 0,
+        transition: `max-height ${duration}ms, opacity ${duration}ms`,
+      });
+      setTimeout(() => {
+        close(toastId);
+      }, duration);
+    }, [close, toastId, duration, setCloseStyle]);
 
     const {start, stop} = useTimeout(closeToast, 3000);
 
@@ -317,6 +326,7 @@ export const ToastContent = forwardRef<HTMLLIElement, ToastContentProps>(
         tabIndex={0}
         style={{
           display: 'flex',
+          maxHeight: '100vh',
           flexDirection: 'column',
           alignItems: placement.includes('left')
             ? 'flex-start'
@@ -324,6 +334,7 @@ export const ToastContent = forwardRef<HTMLLIElement, ToastContentProps>(
             ? 'flex-end'
             : 'center',
           ...styles,
+          ...closeStyle,
         }}
         {...getItemProps({
           onKeyDown: (e) => {

--- a/packages/react/test/visual/components/Toast.tsx
+++ b/packages/react/test/visual/components/Toast.tsx
@@ -34,6 +34,7 @@ type Id = string;
 type ToastType = {
   id: Id;
   delay?: number;
+  autoClose?: boolean;
   requestClose?: boolean;
   transition?: UseTransitionStylesProps;
   placement?: ToastPlacement;
@@ -98,7 +99,13 @@ export function useToasts() {
   const [placements, setPlacements] = useState(new Set<ToastPlacement>([]));
 
   const toast = useCallback(
-    ({placement, delay, transition, render}: Omit<ToastType, 'id'>) => {
+    ({
+      placement,
+      delay,
+      transition,
+      autoClose,
+      render,
+    }: Omit<ToastType, 'id'>) => {
       setPlacements((prev) => {
         if (!placement) {
           return new Set(prev);
@@ -115,6 +122,7 @@ export function useToasts() {
           placement,
           delay,
           transition,
+          autoClose,
           render,
         },
       ]);
@@ -207,6 +215,7 @@ const getToastPosition = (placement?: ToastPlacement) => {
 export function ToastProvider({
   placement: defaultPlacement = 'bottom',
   delay = 5000,
+  autoClose = true,
   requestClose = false,
   transition = {
     duration: 300,
@@ -278,6 +287,7 @@ export function ToastProvider({
                 key={toast.id}
                 id={toast.id}
                 placement={toast.placement ?? placement}
+                autoClose={toast.autoClose ?? autoClose}
                 delay={toast.delay ?? delay}
                 transition={
                   toast.transition
@@ -331,7 +341,7 @@ export const useTimeout = (fn: (...args: any) => void, duration: number) => {
 type ToastContentProps = Required<ToastType> & HTMLAttributes<HTMLLIElement>;
 
 export const ToastContent = forwardRef<HTMLLIElement, ToastContentProps>(
-  ({id, delay, transition, requestClose, render}, propRef) => {
+  ({id, delay, transition, autoClose, requestClose, render}, propRef) => {
     const [open, setOpen] = useState(true);
     const [focus, setFocus] = useState(false);
     const {context, refs} = useFloating({
@@ -366,7 +376,7 @@ export const ToastContent = forwardRef<HTMLLIElement, ToastContentProps>(
       }, closeToastTime);
     }, [close, closeToastTime, id]);
 
-    const {start, stop} = useTimeout(closeToast, delay);
+    const {start, stop} = useTimeout(autoClose ? closeToast : () => {}, delay);
 
     useEffect(() => {
       if (requestClose) {

--- a/packages/react/test/visual/components/Toast.tsx
+++ b/packages/react/test/visual/components/Toast.tsx
@@ -212,14 +212,10 @@ export function ToastProvider({
           <ul
             key={placement}
             ref={context.refs.setFloating}
+            className="pointer-events-none p-0 flex flex-col z-9999"
             aria-live="polite"
             style={{
               position: context.strategy,
-              padding: 0,
-              pointerEvents: 'none',
-              display: 'flex',
-              flexDirection: 'column',
-              zIndex: 9999,
               ...getToastPosition(placement),
             }}
             {...getFloatingProps({
@@ -318,21 +314,19 @@ export const ToastContent = forwardRef<HTMLLIElement, ToastContentProps>(
 
     return (
       <li
-        className={toastId}
         ref={propRef}
+        className={`flex flex-col max-h-screen ${
+          placement.includes('left')
+            ? 'items-start'
+            : placement.includes('right')
+            ? 'items-end'
+            : 'items-center'
+        }`}
         role="status"
         aria-atomic="true"
         aria-hidden="false"
         tabIndex={0}
         style={{
-          display: 'flex',
-          maxHeight: '100vh',
-          flexDirection: 'column',
-          alignItems: placement.includes('left')
-            ? 'flex-start'
-            : placement.includes('right')
-            ? 'flex-end'
-            : 'center',
           ...styles,
           ...closeStyle,
         }}
@@ -357,7 +351,7 @@ export const ToastContent = forwardRef<HTMLLIElement, ToastContentProps>(
           },
         })}
       >
-        {children}
+        <div className="pointer-events-auto w-fit-content">{children}</div>
       </li>
     );
   }

--- a/packages/react/test/visual/components/Toast.tsx
+++ b/packages/react/test/visual/components/Toast.tsx
@@ -1,0 +1,426 @@
+import {
+  ElementProps,
+  ExtendedRefs,
+  inner,
+  Placement,
+  ReferenceType,
+  useDismiss,
+  useFloating,
+  UseFloatingReturn,
+  useInteractions,
+  useListNavigation,
+  useTransitionStyles,
+} from '@floating-ui/react';
+import {
+  createContext,
+  forwardRef,
+  HTMLAttributes,
+  MutableRefObject,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import {Button} from '../lib/Button';
+
+export type AppearanceTypes = 'error' | 'info' | 'success' | 'warning';
+export type Id = string;
+type Options = {
+  appearance?: AppearanceTypes;
+  autoDismiss?: boolean;
+  id?: Id;
+  onDismiss?: (id: Id) => void;
+  [key: string]: any;
+};
+
+type AddToast = (
+  content: ReactNode,
+  options?: Options,
+  callback?: (id: string) => void
+) => void;
+
+type ToastType = Options & {
+  appearance: AppearanceTypes;
+  content: ReactNode;
+  id: Id;
+};
+type ToastsType = Array<ToastType>;
+
+type ContextType = {
+  listRef: MutableRefObject<Array<HTMLElement | null>>;
+  index: number | null;
+  toasts: ToastsType;
+  dismiss: ElementProps;
+  setIndex: (index: number) => void;
+  listNavigation: ElementProps;
+  addToast: AddToast;
+  removeToast: (toastId: string) => void;
+  refs: ExtendedRefs<ReferenceType>;
+  autoDismissTimeout: number;
+} & UseFloatingReturn;
+
+export const Main = () => (
+  <ToastProvider>
+    <Component />
+  </ToastProvider>
+);
+
+const Component = () => {
+  const {addToast} = useToastsContext();
+
+  const handleClick = (text: string, options: Options) => () => {
+    addToast(text, options);
+  };
+
+  return (
+    <ToastProvider>
+      <>
+        <h1 className="text-5xl font-bold mb-8">Toast</h1>
+        <div className="grid place-items-center border border-slate-400 rounded lg:w-[40rem] h-[20rem] mb-4">
+          <Button onClick={handleClick('info', {appearance: 'info'})}>
+            Add Toast
+          </Button>
+          <Button
+            onClick={handleClick('info', {
+              appearance: 'info',
+              autoDismiss: true,
+            })}
+          >
+            Add Toast autoDismiss
+          </Button>
+          <Button
+            onClick={handleClick('error', {
+              appearance: 'error',
+              autoDismiss: true,
+            })}
+          >
+            Add Error Toast autoDismiss
+          </Button>
+        </div>
+      </>
+    </ToastProvider>
+  );
+};
+
+export function generateUEID() {
+  const first = ('000' + ((Math.random() * 46656) | 0).toString(36)).slice(-3);
+  const second = ('000' + ((Math.random() * 46656) | 0).toString(36)).slice(-3);
+  return `${first}${second}`;
+}
+
+const getColor = (appearance?: AppearanceTypes) => {
+  switch (appearance) {
+    case 'info':
+      return '#CDF0FE';
+    case 'success':
+      return '#ECFCD3';
+    case 'error':
+      return '#FFE2E5';
+    case 'warning':
+      return '#FEFACF';
+    default:
+      return '#ffffff';
+  }
+};
+
+const getCountDownColor = (appearance?: AppearanceTypes) => {
+  switch (appearance) {
+    case 'info':
+      return '#00B4D8';
+    case 'success':
+      return '#5CB85C';
+    case 'error':
+      return '#D9534F';
+    case 'warning':
+      return '#F0AD4E';
+    default:
+      return '#ffffff';
+  }
+};
+
+export function useToasts({placement = 'bottom'}: {placement?: Placement}) {
+  const [index, setIndex] = useState<number | null>(0);
+  const [toasts, setToasts] = useState<ToastsType>([]);
+  const listRef = useRef<Array<HTMLElement | null>>([]);
+
+  const data = useFloating({
+    placement,
+    open: true,
+    middleware: [
+      inner({
+        listRef,
+        index: index ?? 0,
+      }),
+    ],
+  });
+
+  const addToast: AddToast = useCallback((content, options) => {
+    const id = options?.id ?? generateUEID();
+    const newToast = {id, content, ...options} as ToastType;
+    setToasts((prev) => [...prev, newToast]);
+  }, []);
+
+  const removeToast = useCallback((toastId: string) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== toastId));
+  }, []);
+
+  const dismiss = useDismiss(data.context);
+  const listNavigation = useListNavigation(data.context, {
+    listRef,
+    activeIndex: index,
+    onNavigate: setIndex,
+    enabled: false,
+  });
+
+  return useMemo(
+    () => ({
+      listRef,
+      index,
+      toasts,
+      dismiss,
+      listNavigation,
+      setIndex,
+      addToast,
+      removeToast,
+      ...data,
+    }),
+    [
+      listRef,
+      index,
+      toasts,
+      dismiss,
+      listNavigation,
+      setIndex,
+      addToast,
+      removeToast,
+      data,
+    ]
+  );
+}
+
+const ToastContext = createContext<ContextType>(null as any);
+
+export const useToastsContext = () => {
+  const context = useContext(ToastContext);
+
+  if (context == null) {
+    throw new Error('Toast components must be wrapped in <ToastProvider />');
+  }
+
+  return context;
+};
+
+export function ToastProvider({
+  placement,
+  autoDismissTimeout = 3000,
+  children,
+}: {
+  placement?: Placement;
+  autoDismissTimeout?: number;
+  children: ReactNode;
+}) {
+  const context = useToasts({placement});
+  const {getFloatingProps} = useInteractions([
+    context.dismiss,
+    context.listNavigation,
+  ]);
+
+  return (
+    <ToastContext.Provider value={{...context, autoDismissTimeout}}>
+      <ul
+        ref={context.refs.setFloating}
+        // role="region"
+        aria-live="polite"
+        style={{
+          position: context.strategy,
+          // TODO: dynamic style from placement prop
+          left: '50%',
+          transform: 'translateX(-50%)',
+          // remove default ul padding, margin
+          padding: 0,
+          margin: 0,
+        }}
+        {...getFloatingProps({
+          role: 'region',
+        })}
+      >
+        {context.toasts.map(({id, content, appearance, autoDismiss}, index) => (
+          <ToastElement
+            key={id}
+            toastId={id}
+            appearance={appearance}
+            autoDismiss={autoDismiss}
+            ref={(node) => {
+              context.listRef.current[index] = node;
+            }}
+          >
+            {content}
+          </ToastElement>
+        ))}
+      </ul>
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+type ToastContentProps = {
+  toastId: string;
+  appearance?: AppearanceTypes;
+  autoDismiss?: boolean;
+  children: ReactNode;
+} & HTMLAttributes<HTMLDivElement>;
+
+export const ToastElement = forwardRef<HTMLLIElement, ToastContentProps>(
+  ({toastId, appearance, autoDismiss, children}, propRef) => {
+    const [timerId, setTimerId] = useState();
+    const [isRunning, setIsRunning] = useState(false);
+    const {context, removeToast, autoDismissTimeout, dismiss, listNavigation} =
+      useToastsContext();
+    const [remainingTime, setRemainingTime] = useState(autoDismissTimeout);
+    const [startTime, setStartTime] = useState<number>(0);
+    const {getItemProps} = useInteractions([dismiss, listNavigation]);
+    const {styles} = useTransitionStyles(context, {
+      duration: 300,
+      initial: () => ({
+        opacity: 0,
+      }),
+      open: ({side}) => ({
+        opacity: 1,
+        transform: {
+          top: 'translateY(-0.5rem)',
+          right: 'translateX(0.5rem)',
+          bottom: 'translateY(0.5rem)',
+          left: 'translateX(-0.5rem)',
+        }[side],
+      }),
+    });
+
+    const startTimer = () => {
+      setIsRunning(true);
+      setStartTime(Date.now());
+    };
+
+    const stopTimer = () => {
+      setIsRunning(false);
+      setRemainingTime(
+        (remainingTime) => remainingTime - (Date.now() - startTime)
+      );
+      clearTimeout(timerId);
+    };
+
+    useEffect(() => {
+      if (autoDismiss) {
+        startTimer();
+      }
+      // fire only once
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+      if (isRunning) {
+        const id = setTimeout(() => {
+          removeToast(toastId);
+          clearTimeout(timerId);
+        }, remainingTime);
+        // @ts-ignore
+        setTimerId(id);
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isRunning]);
+
+    // style for auto dismiss progress bar animation
+    useEffect(() => {
+      if (autoDismiss && !document.getElementById('autoDismissStyle')) {
+        const style = document.createElement('style');
+        Object.assign(style, {
+          id: 'autoDismissStyle',
+          innerHTML: `@keyframes autoDismiss {
+            from {
+              width: 100%;
+            }
+            to {
+              width: 0%;
+            }
+          }`,
+        });
+        document.head.appendChild(style);
+      }
+    });
+
+    return (
+      <li
+        className={toastId}
+        ref={propRef}
+        role="status"
+        aria-atomic="true"
+        aria-hidden="false"
+        tabIndex={0}
+        style={{
+          width: '300px',
+          backgroundColor: getColor(appearance),
+          padding: '1rem',
+          marginBottom: '1rem',
+          borderRadius: 8,
+          boxShadow: 'rgba(0, 0, 0, 0.35) 0px 5px 15px',
+          display: 'flex',
+          ...styles,
+        }}
+        {...getItemProps({
+          onKeyDown: (e) => {
+            // Should useDismiss be used to handle closing with esc?
+            if (e.key === 'Enter' || e.key === 'Escape') {
+              removeToast(toastId);
+            }
+          },
+          onFocus: () => {
+            if (autoDismiss) {
+              stopTimer();
+            }
+          },
+          onBlur: () => {
+            if (autoDismiss) {
+              startTimer();
+            }
+          },
+          onMouseOver: () => {
+            if (autoDismiss) {
+              stopTimer();
+            }
+          },
+          onMouseLeave: () => {
+            if (autoDismiss) {
+              startTimer();
+            }
+          },
+        })}
+      >
+        {children}
+        <div
+          style={{position: 'absolute', right: '10px', cursor: 'pointer'}}
+          onClick={() => {
+            removeToast(toastId);
+          }}
+        >
+          {/* TODO: svg icon */}×
+        </div>
+        <div
+          style={{
+            animation: `autoDismiss ${autoDismissTimeout}ms linear`,
+            backgroundColor: getCountDownColor(appearance),
+            position: 'absolute',
+            height: '3px',
+            width: 0,
+            top: 0,
+            left: 0,
+            opacity: autoDismiss ? 1 : 0,
+            animationPlayState: isRunning ? 'running' : 'paused',
+          }}
+        />
+      </li>
+    );
+  }
+);

--- a/packages/react/test/visual/components/Toast.tsx
+++ b/packages/react/test/visual/components/Toast.tsx
@@ -37,7 +37,7 @@ type ToastType = {
   requestClose?: boolean;
   transition?: UseTransitionStylesProps;
   placement?: ToastPlacement;
-  render?: (onClose?: () => void) => ReactNode;
+  render?: (id: Id, onClose?: () => void) => ReactNode;
 };
 type ToastsType = Array<ToastType>;
 
@@ -72,7 +72,7 @@ const Component = () => {
             toast({
               placement: 'top',
               render: () => (
-                <div className="w-[300px] bg-white p-4 mb-4 rounded-lg shadow-lg flex">
+                <div className="w-[300px] bg-white p-4 mb-4 rounded-lg shadow-lg">
                   Hello
                 </div>
               ),
@@ -413,7 +413,7 @@ export const ToastContent = forwardRef<HTMLLIElement, ToastContentProps>(
           })}
         >
           <div style={{pointerEvents: 'auto', width: 'fit-content'}}>
-            {render && render(() => closeToast())}
+            {render && render(id, () => closeToast())}
           </div>
         </li>
       </FloatingFocusManager>

--- a/packages/react/test/visual/index.tsx
+++ b/packages/react/test/visual/index.tsx
@@ -21,6 +21,7 @@ import {Main as Navigation} from './components/Navigation';
 import {New} from './components/New';
 import {Main as Popover} from './components/Popover';
 import {Main as Select} from './components/Select';
+import {Main as Toast} from './components/Toast';
 import {Main as Tooltip} from './components/Tooltip';
 
 const ROUTES = [
@@ -34,6 +35,7 @@ const ROUTES = [
   {path: 'navigation', component: Navigation},
   {path: 'drawer', component: Drawer},
   {path: 'arrow', component: Arrow},
+  {path: 'toast', component: Toast},
 ];
 
 function App() {


### PR DESCRIPTION
#2192

@atomiks 

supports

- [x] Pauses closing on hover, focus and window blur
- [x] Supports hotkey to jump to toast viewport
- [x] Pressing esc when focused on toast closes it
- [x] Fully customizable toast components, positions, delay times, and animations
- [x] Global values can be specified from the Provider and reflected in individual toasts.
- [x] Globally defined values can be updated by individual toasts
  - If global and toast values do not exist, default values will be applied
- [ ] Fully follow the ARIA design pattern

not supported

- Supports closing via swipe gesture
- Toast with close button
- Default toast (nothing is rendered when render function is empty)

> Since this library is called "Floating UI", we can and should do more than just support elements that use anchor positioning — for example, a non-anchored floating Dialog or Drawer component are already possible to build using the existing interaction primitives, but a component like a Toast or anything draggable isn't despite them also being "floating" elements.

I agree with you. I was wanting a toast component that uses floating-ui.
I created the prototype as an experiment.

### usage

Brief description of how it is used (how it is intended to be used)

(edited)

```tsx
export const Main = () => (
  <ToastProvider placement="top-center">
    <Component />
  </ToastProvider>
);

const Component = () => {
  const {toast} = useToast();

  return (
    <div>
      <button
        onClick={() =>
          toast({
            placement: 'top',
            render: () => <div>Hello</div>,
          })
        }
      >
        Add Toast
      </button>
  </div>
  );
};
```

### worries

- I currently have this implementation in the visual test directory, is that correct?
- Should I create hooks and incorporate swipe gestures into floating-ui?
- I need assistance as my knowledge of accessibility is a little lacking.
- The API to manipulate the toast is not yet fully prepared here