### PR TITLE
feat(safePolygon): replace `restMs` with `requireIntent` boolean

### DIFF
--- a/packages/react/test/visual/components/Menu.tsx
+++ b/packages/react/test/visual/components/Menu.tsx
@@ -106,7 +106,6 @@ export const MenuComponent = React.forwardRef<
     enabled: isNested && allowHover,
     delay: {open: 75},
     handleClose: safePolygon({
-      restMs: 25,
       blockPointerEvents: true,
     }),
   });


### PR DESCRIPTION
When multiple reference elements lie next to each other and they have hoverable floating elements, the cursor speed is much better at determining if the polygon logic should be active compared to `restMs`.