### PR TITLE
fix(vue): add deep watch option to address @vue/compat warnings

### DIFF
--- a/packages/vue/src/useFloating.ts
+++ b/packages/vue/src/useFloating.ts
@@ -102,9 +102,13 @@ export function useFloating<T extends ReferenceElement = ReferenceElement>(
   }
 
   watch([middlewareOption, placementOption, strategyOption], update, {
+    deep: true,
     flush: 'sync',
   });
-  watch([referenceElement, floatingElement], attach, {flush: 'sync'});
+  watch([referenceElement, floatingElement], attach, {
+    deep: true,
+    flush: 'sync',
+  });
   watch(openOption, reset, {flush: 'sync'});
 
   if (getCurrentScope()) {


### PR DESCRIPTION
My team is in the process of migrating our apps from Vue2 to Vue3 and we have been using `@vue/compat` to give us insights. In the process we discovered the following warning from `@vue/compat`

```
[Vue warn]: (deprecation WATCH_ARRAY) "watch" option or vm.$watch on an array value will no longer trigger on array mutation unless the "deep" option is specified.
If current usage is intended, you can disable the compat behavior and suppress this warning with:
```

We traced the source to be within the `@floating-ui/vue` package. This PR adds `deep: true` to the watch options object to address the warnings.

I tried to follow the conventions of the repo as best I could but if I messed anything up I'm happy to address it. I also didn't add tests as it seemed that the Vue ones are aimed at visual testing and this should have no affect but if those are needed I'm happy to add them.