### PR TITLE
fix(FocusGuard): aria-hidden must not be focusable

### DIFF
--- a/packages/react/src/components/FocusGuard.tsx
+++ b/packages/react/src/components/FocusGuard.tsx
@@ -59,7 +59,6 @@ export const FocusGuard = React.forwardRef<
       tabIndex={0}
       // Role is only for VoiceOver
       role={role}
-      aria-hidden={role ? undefined : true}
       data-floating-ui-focus-guard=""
       style={HIDDEN_STYLES}
     />


### PR DESCRIPTION
This PR aims to solve an accessibility issue in `FocusGuard` as titled.

References:
* https://dequeuniversity.com/rules/axe/4.7/aria-hidden-focus
* https://accessibilityinsights.io/info-examples/web/aria-hidden-focus/
* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden

The intention is slightly different, but Chakra's [VisuallyHidden](https://chakra-ui.com/docs/components/visually-hidden) does not have `aria-hidden` set, and I think this can be also the case here.
