### PR TITLE
Fix FloatingUIReact UMD build

### DIFF
--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -25,7 +25,7 @@ const bundles = [
   {
     input,
     output: {
-      name: 'FloatingUIReactDOM',
+      name: 'FloatingUIReact',
       file: path.join(__dirname, 'dist/floating-ui.react.umd.js'),
       format: 'umd',
       globals: {
@@ -42,7 +42,7 @@ const bundles = [
   {
     input,
     output: {
-      name: 'FloatingUIReactDOM',
+      name: 'FloatingUIReact',
       file: path.join(__dirname, 'dist/floating-ui.react.umd.min.js'),
       format: 'umd',
       globals: {


### PR DESCRIPTION
[Re #2324] [Fix #2324]
The incorrect bundle name was causing an infinite recursion bug when trying to use the 'useFloating' React hook.