### PR TITLE
fix(isContainingBlock): Safari `will-change` filter

### DIFF
--- a/packages/dom/src/utils/getBoundingClientRect.ts
+++ b/packages/dom/src/utils/getBoundingClientRect.ts
@@ -2,8 +2,9 @@ import type {ClientRectObject, VirtualElement} from '@floating-ui/core';
 import {rectToClientRect} from '@floating-ui/core';
 
 import {FALLBACK_SCALE, getScale} from './getScale';
+import {getVisualOffsets} from './getVisualOffsets';
 import {getWindow} from './getWindow';
-import {isElement, isSafari} from './is';
+import {isElement} from './is';
 import {unwrapElement} from './unwrapElement';
 
 export function getBoundingClientRect(
@@ -26,17 +27,14 @@ export function getBoundingClientRect(
     }
   }
 
-  const win = domElement ? getWindow(domElement) : window;
-  const addVisualOffsets = isSafari() && isFixedStrategy;
+  const visualOffsets = getVisualOffsets(
+    domElement,
+    isFixedStrategy,
+    offsetParent
+  );
 
-  let x =
-    (clientRect.left +
-      (addVisualOffsets ? win.visualViewport?.offsetLeft || 0 : 0)) /
-    scale.x;
-  let y =
-    (clientRect.top +
-      (addVisualOffsets ? win.visualViewport?.offsetTop || 0 : 0)) /
-    scale.y;
+  let x = (clientRect.left + visualOffsets.x) / scale.x;
+  let y = (clientRect.top + visualOffsets.y) / scale.y;
   let width = clientRect.width / scale.x;
   let height = clientRect.height / scale.y;
 

--- a/packages/dom/src/utils/getClippingRect.ts
+++ b/packages/dom/src/utils/getClippingRect.ts
@@ -16,14 +16,13 @@ import {getOverflowAncestors} from './getOverflowAncestors';
 import {getParentNode} from './getParentNode';
 import {getScale} from './getScale';
 import {getViewportRect} from './getViewportRect';
-import {getWindow} from './getWindow';
+import {getVisualOffsets} from './getVisualOffsets';
 import {
   isContainingBlock,
   isElement,
   isHTMLElement,
   isLastTraversableNode,
   isOverflowElement,
-  isSafari,
 } from './is';
 import {max, min} from './math';
 import {getNodeName} from './node';
@@ -68,13 +67,12 @@ function getClientRectFromClippingAncestor(
   } else if (isElement(clippingAncestor)) {
     rect = getInnerBoundingClientRect(clippingAncestor, strategy);
   } else {
-    const mutableRect = {...clippingAncestor};
-    if (isSafari()) {
-      const win = getWindow(element);
-      mutableRect.x -= win.visualViewport?.offsetLeft || 0;
-      mutableRect.y -= win.visualViewport?.offsetTop || 0;
-    }
-    rect = mutableRect;
+    const visualOffsets = getVisualOffsets(element);
+    rect = {
+      ...clippingAncestor,
+      x: clippingAncestor.x - visualOffsets.x,
+      y: clippingAncestor.y - visualOffsets.y,
+    };
   }
 
   return rectToClientRect(rect);

--- a/packages/dom/src/utils/getRectRelativeToOffsetParent.ts
+++ b/packages/dom/src/utils/getRectRelativeToOffsetParent.ts
@@ -14,20 +14,13 @@ export function getRectRelativeToOffsetParent(
 ): Rect {
   const isOffsetParentAnElement = isHTMLElement(offsetParent);
   const documentElement = getDocumentElement(offsetParent);
-  const rect = getBoundingClientRect(
-    element,
-    true,
-    strategy === 'fixed',
-    offsetParent
-  );
+  const isFixed = strategy === 'fixed';
+  const rect = getBoundingClientRect(element, true, isFixed, offsetParent);
 
   let scroll = {scrollLeft: 0, scrollTop: 0};
   const offsets = {x: 0, y: 0};
 
-  if (
-    isOffsetParentAnElement ||
-    (!isOffsetParentAnElement && strategy !== 'fixed')
-  ) {
+  if (isOffsetParentAnElement || (!isOffsetParentAnElement && !isFixed)) {
     if (
       getNodeName(offsetParent) !== 'body' ||
       isOverflowElement(documentElement)
@@ -36,7 +29,12 @@ export function getRectRelativeToOffsetParent(
     }
 
     if (isHTMLElement(offsetParent)) {
-      const offsetRect = getBoundingClientRect(offsetParent, true);
+      const offsetRect = getBoundingClientRect(
+        offsetParent,
+        true,
+        isFixed,
+        offsetParent
+      );
       offsets.x = offsetRect.x + offsetParent.clientLeft;
       offsets.y = offsetRect.y + offsetParent.clientTop;
     } else if (documentElement) {

--- a/packages/dom/src/utils/getVisualOffsets.ts
+++ b/packages/dom/src/utils/getVisualOffsets.ts
@@ -1,0 +1,25 @@
+import {getWindow} from './getWindow';
+import {isSafari} from './is';
+
+const noOffsets = {x: 0, y: 0};
+
+export function getVisualOffsets(
+  element: Element | undefined,
+  isFixed = true,
+  floatingOffsetParent?: Element | Window | undefined
+) {
+  if (!isSafari()) {
+    return noOffsets;
+  }
+
+  const win = element ? getWindow(element) : window;
+
+  if (!floatingOffsetParent || (isFixed && floatingOffsetParent !== win)) {
+    return noOffsets;
+  }
+
+  return {
+    x: win.visualViewport?.offsetLeft || 0,
+    y: win.visualViewport?.offsetTop || 0,
+  };
+}

--- a/packages/dom/src/utils/is.ts
+++ b/packages/dom/src/utils/is.ts
@@ -44,23 +44,19 @@ export function isTableElement(element: Element): boolean {
 export function isContainingBlock(element: Element): boolean {
   const safari = isSafari();
   const css = getComputedStyle(element);
-  const backdropFilter =
-    css.backdropFilter || (css as any).WebkitBackdropFilter;
 
-  // This is non-exhaustive but covers the most common CSS properties that
-  // create a containing block.
   // https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
   return (
     css.transform !== 'none' ||
     css.perspective !== 'none' ||
-    (backdropFilter ? backdropFilter !== 'none' : false) ||
+    (!safari && (css.backdropFilter ? css.backdropFilter !== 'none' : false)) ||
     (!safari && (css.filter ? css.filter !== 'none' : false)) ||
-    ['transform', 'perspective']
-      .concat(!safari ? 'filter' : [])
-      .some((value) => (css.willChange || '').includes(value)) ||
-    ['paint', 'layout', 'strict', 'content'].some((value) => {
-      return (css.contain || '').includes(value);
-    })
+    ['transform', 'perspective', 'filter'].some((value) =>
+      (css.willChange || '').includes(value)
+    ) ||
+    ['paint', 'layout', 'strict', 'content'].some((value) =>
+      (css.contain || '').includes(value)
+    )
   );
 }
 


### PR DESCRIPTION
Continues #2334

For some reason Safari (since at least 16.1, don't have any older versions) creates a containing block if `will-change: filter` is specified, but not if using `filter: (...)` itself...