### PR TITLE
Change `vue-demi` version range and remove `peerDependencies` and `peerDependenciesMeta`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21516,9 +21516,9 @@
       }
     },
     "node_modules/vue-demi": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.5.tgz",
+      "integrity": "sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==",
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -21984,7 +21984,7 @@
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^0.1.0",
-        "vue-demi": "^0.13.11"
+        "vue-demi": ">=0.13.0"
       },
       "devDependencies": {
         "@parcel/transformer-vue": "^2.6.0",
@@ -23501,7 +23501,7 @@
         "@rollup/plugin-commonjs": "^21.0.1",
         "@testing-library/vue": "^6.6.1",
         "vue": "^3.2.45",
-        "vue-demi": "^0.13.11"
+        "vue-demi": ">=0.13.0"
       }
     },
     "@hapi/hoek": {
@@ -38223,9 +38223,9 @@
       }
     },
     "vue-demi": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.5.tgz",
+      "integrity": "sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==",
       "requires": {}
     },
     "w3c-xmlserializer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21991,15 +21991,6 @@
         "@rollup/plugin-commonjs": "^21.0.1",
         "@testing-library/vue": "^6.6.1",
         "vue": "^3.2.45"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^2.0.0 || >=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     }
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -54,15 +54,6 @@
     "positioning",
     "vue"
   ],
-  "peerDependencies": {
-    "@vue/composition-api": "^1.0.0-rc.1",
-    "vue": "^2.0.0 || >=3.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@vue/composition-api": {
-      "optional": true
-    }
-  },
   "dependencies": {
     "@floating-ui/dom": "^0.1.0",
     "vue-demi": "^0.13.11"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -56,7 +56,7 @@
   ],
   "dependencies": {
     "@floating-ui/dom": "^0.1.0",
-    "vue-demi": "^0.13.11"
+    "vue-demi": ">=0.13.0"
   },
   "devDependencies": {
     "@parcel/transformer-vue": "^2.6.0",


### PR DESCRIPTION
Due to the `@vue/composition-api` peer dependency, Nuxt 3 users cannot install `@floating-ui/vue` without the `--force` flag. The installation fails with the error:

```sh
npm ERR! Conflicting peer dependency: vue@2.6.14
npm ERR! node_modules/vue
npm ERR!   peer vue@">= 2.5 < 2.7" from @vue/composition-api@1.7.1
npm ERR!   node_modules/@vue/composition-api
npm ERR!     peerOptional @vue/composition-api@"^1.0.0-rc.1" from @floating-ui/vue@1.0.0
npm ERR!     node_modules/@floating-ui/vue
npm ERR!       @floating-ui/vue@"*" from the root project
```

Context: https://github.com/floating-ui/floating-ui/discussions/2339

This configuration of `peerDependencies` is recommended by [`vue-demi`](https://github.com/vueuse/vue-demi#usage). But [`@vueuse/core`](https://github.com/vueuse/vueuse/blob/b7b985b198d9e72136f65fae39b2125cd3abef5b/packages/core/package.json#L41-L46) doesn't follow this recommendation. I have found couple issues about Yarn warnings like this https://github.com/vueuse/vueuse/issues/2781.

I'm not sure that removing of `peerDependencies` and `peerDependenciesMeta` is the right way, but it will allow Nuxt 3 users to install `@floating-ui/vue`.

Do you have any thoughts on this?