### PR TITLE
[wip] feat: obstacles

### DIFF
--- a/packages/core/src/detectIntersections.ts
+++ b/packages/core/src/detectIntersections.ts
@@ -49,66 +49,79 @@ export async function detectIntersections(
       : rect
   );
 
+  const elementTop = elementClientRect.top - paddingObject.top;
+  const elementLeft = elementClientRect.left - paddingObject.left;
+  const elementBottom = elementClientRect.bottom + paddingObject.bottom;
+  const elementRight = elementClientRect.right + paddingObject.right;
+  const elementWidth = elementClientRect.width;
+  const elementHeight = elementClientRect.height;
+
   function getIsIntersecting(clientRect: ClientRectObject) {
     const {top, left, bottom, right} = clientRect;
     return (
-      elementClientRect.top - paddingObject.top < bottom &&
-      elementClientRect.bottom + paddingObject.bottom > top &&
-      elementClientRect.left - paddingObject.left < right &&
-      elementClientRect.right + paddingObject.right > left
+      elementTop < bottom &&
+      elementBottom > top &&
+      elementLeft < right &&
+      elementRight > left
     );
   }
 
   return obstacles
     .filter(
       (rect) =>
-        rect.x !== elementClientRect.x &&
-        rect.y !== elementClientRect.y &&
-        rect.width !== elementClientRect.width &&
-        rect.height !== elementClientRect.height &&
-        getIsIntersecting(rect)
+        !(
+          rect.x === elementClientRect.x &&
+          rect.y === elementClientRect.y &&
+          rect.width === elementClientRect.width &&
+          rect.height === elementClientRect.height
+        ) && getIsIntersecting(rect)
     )
     .map((obstacleClientRect) => {
+      const obstacleTop = obstacleClientRect.top;
+      const obstacleLeft = obstacleClientRect.left;
+      const obstacleBottom = obstacleClientRect.bottom;
+      const obstacleRight = obstacleClientRect.right;
+      const obstacleWidth = obstacleClientRect.width;
+      const obstacleHeight = obstacleClientRect.height;
+
       const xSide: Side =
-        elementClientRect.left + elementClientRect.width / 2 <
-        obstacleClientRect.left + obstacleClientRect.width / 2
+        elementLeft + elementWidth / 2 < obstacleLeft + obstacleWidth / 2
           ? 'left'
           : 'right';
       const ySide: Side =
-        elementClientRect.top + elementClientRect.height / 2 <
-        obstacleClientRect.top + obstacleClientRect.height / 2
+        elementTop + elementHeight / 2 < obstacleTop + obstacleHeight / 2
           ? 'top'
           : 'bottom';
 
       const leftOp =
         xSide === 'right'
-          ? elementClientRect.left < obstacleClientRect.left
-          : elementClientRect.left > obstacleClientRect.left;
+          ? elementLeft < obstacleLeft
+          : elementLeft > obstacleLeft;
       const rightOp =
         xSide === 'right'
-          ? elementClientRect.right > obstacleClientRect.right
-          : elementClientRect.right < obstacleClientRect.right;
+          ? elementRight > obstacleRight
+          : elementRight < obstacleRight;
       const topOp =
         ySide === 'bottom'
-          ? elementClientRect.top < obstacleClientRect.top
-          : elementClientRect.top > obstacleClientRect.top;
+          ? elementTop < obstacleTop
+          : elementTop > obstacleTop;
       const bottomOp =
         ySide === 'bottom'
-          ? elementClientRect.bottom > obstacleClientRect.bottom
-          : elementClientRect.bottom < obstacleClientRect.bottom;
+          ? elementBottom > obstacleBottom
+          : elementBottom < obstacleBottom;
 
       const left = leftOp
-        ? min(elementClientRect.left, obstacleClientRect.left)
-        : max(elementClientRect.left, obstacleClientRect.left);
+        ? min(elementLeft, obstacleLeft)
+        : max(elementLeft, obstacleLeft);
       const right = rightOp
-        ? min(elementClientRect.right, obstacleClientRect.right)
-        : max(elementClientRect.right, obstacleClientRect.right);
+        ? min(elementRight, obstacleRight)
+        : max(elementRight, obstacleRight);
       const top = topOp
-        ? min(elementClientRect.top, obstacleClientRect.top)
-        : max(elementClientRect.top, obstacleClientRect.top);
+        ? min(elementTop, obstacleTop)
+        : max(elementTop, obstacleTop);
       const bottom = bottomOp
-        ? min(elementClientRect.bottom, obstacleClientRect.bottom)
-        : max(elementClientRect.bottom, obstacleClientRect.bottom);
+        ? min(elementBottom, obstacleBottom)
+        : max(elementBottom, obstacleBottom);
 
       return {
         x: right - left,

--- a/packages/core/src/detectIntersections.ts
+++ b/packages/core/src/detectIntersections.ts
@@ -1,0 +1,117 @@
+import type {
+  ClientRectObject,
+  Coords,
+  MiddlewareState,
+  Padding,
+  Side,
+} from './types';
+import {getSideObjectFromPadding} from './utils/getPaddingObject';
+import {max, min} from './utils/math';
+import {rectToClientRect} from './utils/rectToClientRect';
+
+export interface Options {
+  /**
+   * The collidable rects or area in which intersection will be checked.
+   * @default []
+   */
+  collidables: Array<ClientRectObject>;
+
+  /**
+   * Virtual padding for the resolved intersection detection offsets.
+   * @default 0
+   */
+  padding: Padding;
+}
+
+/**
+ * Resolves with an array of intersection values for each intersecting
+ * collidable.
+ * @see https://floating-ui.com/docs/detectIntersections
+ */
+export async function detectIntersections(
+  state: MiddlewareState,
+  options: Partial<Options> = {}
+): Promise<Array<Coords & {xDirection: Side; yDirection: Side}>> {
+  const {x, y, platform, rects, elements, strategy} = state;
+  const {collidables = [], padding = 0} = options;
+
+  const paddingObject = getSideObjectFromPadding(padding);
+  const element = elements.floating;
+
+  const rect = {...rects.floating, x, y};
+  const offsetParent = await platform.getOffsetParent?.(elements.floating);
+
+  const elementClientRect = rectToClientRect(
+    platform.convertOffsetParentRelativeRectToViewportRelativeRect
+      ? await platform.convertOffsetParentRelativeRectToViewportRelativeRect({
+          rect,
+          offsetParent,
+          strategy,
+        })
+      : rect
+  );
+
+  function getIsIntersecting(clientRect: ClientRectObject) {
+    const {top, left, bottom, right} = clientRect;
+    return (
+      elementClientRect.top - paddingObject.top < bottom &&
+      elementClientRect.bottom + paddingObject.bottom > top &&
+      elementClientRect.left - paddingObject.left < right &&
+      elementClientRect.right + paddingObject.right > left
+    );
+  }
+
+  const collidablesExclusive = collidables.filter((el) => el !== element);
+  const intersectingCollidables =
+    collidablesExclusive.filter(getIsIntersecting);
+
+  return intersectingCollidables.map((collidableClientRect) => {
+    const xDirection: Side =
+      elementClientRect.left + elementClientRect.width / 2 <
+      collidableClientRect.left + collidableClientRect.width / 2
+        ? 'left'
+        : 'right';
+    const yDirection: Side =
+      elementClientRect.top + elementClientRect.height / 2 <
+      collidableClientRect.top + collidableClientRect.height / 2
+        ? 'top'
+        : 'bottom';
+
+    const leftOp =
+      xDirection === 'right'
+        ? elementClientRect.left < collidableClientRect.left
+        : elementClientRect.left > collidableClientRect.left;
+    const rightOp =
+      xDirection === 'right'
+        ? elementClientRect.right > collidableClientRect.right
+        : elementClientRect.right < collidableClientRect.right;
+    const topOp =
+      yDirection === 'bottom'
+        ? elementClientRect.top < collidableClientRect.top
+        : elementClientRect.top > collidableClientRect.top;
+    const bottomOp =
+      yDirection === 'bottom'
+        ? elementClientRect.bottom > collidableClientRect.bottom
+        : elementClientRect.bottom < collidableClientRect.bottom;
+
+    const left = leftOp
+      ? min(elementClientRect.left, collidableClientRect.left)
+      : max(elementClientRect.left, collidableClientRect.left);
+    const right = rightOp
+      ? min(elementClientRect.right, collidableClientRect.right)
+      : max(elementClientRect.right, collidableClientRect.right);
+    const top = topOp
+      ? min(elementClientRect.top, collidableClientRect.top)
+      : max(elementClientRect.top, collidableClientRect.top);
+    const bottom = bottomOp
+      ? min(elementClientRect.bottom, collidableClientRect.bottom)
+      : max(elementClientRect.bottom, collidableClientRect.bottom);
+
+    return {
+      x: right - left,
+      y: bottom - top,
+      xDirection,
+      yDirection,
+    };
+  });
+}

--- a/packages/core/src/middleware/flip.ts
+++ b/packages/core/src/middleware/flip.ts
@@ -108,8 +108,8 @@ export const flip = (
 
     const overflow = await detectOverflow(state, detectOverflowOptions);
     const intersections = await detectIntersections(state, {
-      collidables: Array.from(
-        document.querySelectorAll('[data-floating-ui-collidable]')
+      obstacles: Array.from(
+        document.querySelectorAll('[data-floating-ui-obstacle]')
       ).map((el) => el.getBoundingClientRect()),
     });
 

--- a/packages/core/src/middleware/flip.ts
+++ b/packages/core/src/middleware/flip.ts
@@ -1,3 +1,4 @@
+import {detectIntersections} from '../detectIntersections';
 import {
   detectOverflow,
   Options as DetectOverflowOptions,
@@ -106,6 +107,11 @@ export const flip = (
     const placements = [initialPlacement, ...fallbackPlacements];
 
     const overflow = await detectOverflow(state, detectOverflowOptions);
+    const intersections = await detectIntersections(state, {
+      collidables: Array.from(
+        document.querySelectorAll('[data-floating-ui-collidable]')
+      ).map((el) => el.getBoundingClientRect()),
+    });
 
     const overflows = [];
     let overflowsData = middlewareData.flip?.overflows || [];
@@ -122,7 +128,7 @@ export const flip = (
     overflowsData = [...overflowsData, {placement, overflows}];
 
     // One or more sides is overflowing.
-    if (!overflows.every((side) => side <= 0)) {
+    if (!overflows.every((side) => side <= 0) || intersections.length) {
       const nextIndex = (middlewareData.flip?.index || 0) + 1;
       const nextPlacement = placements[nextIndex];
 

--- a/packages/core/src/middleware/shift.ts
+++ b/packages/core/src/middleware/shift.ts
@@ -1,3 +1,4 @@
+import {detectIntersections} from '../detectIntersections';
 import {
   detectOverflow,
   Options as DetectOverflowOptions,
@@ -54,6 +55,11 @@ export const shift = (
 
     const coords = {x, y};
     const overflow = await detectOverflow(state, detectOverflowOptions);
+    const intersections = await detectIntersections(state, {
+      collidables: Array.from(
+        document.querySelectorAll('[data-floating-ui-collidable]')
+      ).map((el) => el.getBoundingClientRect()),
+    });
     const mainAxis = getMainAxisFromPlacement(getSide(placement));
     const crossAxis = getCrossAxis(mainAxis);
 
@@ -65,6 +71,18 @@ export const shift = (
       const maxSide = mainAxis === 'y' ? 'bottom' : 'right';
       const min = mainAxisCoord + overflow[minSide];
       const max = mainAxisCoord - overflow[maxSide];
+
+      if (intersections.length) {
+        if (mainAxis === 'x') {
+          mainAxisCoord +=
+            intersections[0].x *
+            (intersections[0].xDirection === 'right' ? 1 : -1);
+        } else {
+          mainAxisCoord +=
+            intersections[0].y *
+            (intersections[0].yDirection === 'bottom' ? 1 : -1);
+        }
+      }
 
       mainAxisCoord = within(min, mainAxisCoord, max);
     }

--- a/packages/core/src/middleware/shift.ts
+++ b/packages/core/src/middleware/shift.ts
@@ -56,8 +56,8 @@ export const shift = (
     const coords = {x, y};
     const overflow = await detectOverflow(state, detectOverflowOptions);
     const intersections = await detectIntersections(state, {
-      collidables: Array.from(
-        document.querySelectorAll('[data-floating-ui-collidable]')
+      obstacles: Array.from(
+        document.querySelectorAll('[data-floating-ui-obstacle]')
       ).map((el) => el.getBoundingClientRect()),
     });
     const mainAxis = getMainAxisFromPlacement(getSide(placement));
@@ -75,12 +75,10 @@ export const shift = (
       if (intersections.length) {
         if (mainAxis === 'x') {
           mainAxisCoord +=
-            intersections[0].x *
-            (intersections[0].xDirection === 'right' ? 1 : -1);
+            intersections[0].x * (intersections[0].xSide === 'right' ? 1 : -1);
         } else {
           mainAxisCoord +=
-            intersections[0].y *
-            (intersections[0].yDirection === 'bottom' ? 1 : -1);
+            intersections[0].y * (intersections[0].ySide === 'bottom' ? 1 : -1);
         }
       }
 

--- a/packages/dom/test/visual/index.tsx
+++ b/packages/dom/test/visual/index.tsx
@@ -21,6 +21,7 @@ import {Flip} from './spec/Flip';
 import {Hide} from './spec/Hide';
 import {IFrame} from './spec/IFrame';
 import {Inline} from './spec/Inline';
+import {Intersection} from './spec/Intersection';
 import {Offset} from './spec/Offset';
 import {Perf} from './spec/Perf';
 import {Placement} from './spec/Placement';
@@ -58,6 +59,7 @@ const ROUTES = [
   {path: 'virtual-element', component: VirtualElement},
   {path: 'perf', component: Perf},
   {path: 'iframe', component: IFrame},
+  {path: 'intersection', component: Intersection},
 ];
 
 function App() {

--- a/packages/dom/test/visual/spec/Intersection.tsx
+++ b/packages/dom/test/visual/spec/Intersection.tsx
@@ -1,0 +1,102 @@
+import {Placement as PlacementType} from '@floating-ui/core';
+import {autoUpdate, flip, shift, useFloating} from '@floating-ui/react-dom';
+import {useState} from 'react';
+
+import {allPlacements} from '../utils/allPlacements';
+import {Controls} from '../utils/Controls';
+import {useSize} from '../utils/useSize';
+
+function Collidable({x, y}: {x: number; y: number}) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: y,
+        left: x,
+        background: 'orange',
+        padding: 15,
+      }}
+      data-floating-ui-collidable
+    >
+      Collidable
+    </div>
+  );
+}
+
+export function Intersection() {
+  const [placement, setPlacement] = useState<PlacementType>('bottom');
+  const [size, handleSizeChange] = useSize();
+
+  const {refs, floatingStyles} = useFloating({
+    placement,
+    whileElementsMounted: autoUpdate,
+    middleware: [flip(), shift()],
+  });
+
+  return (
+    <>
+      <div
+        style={{
+          position: 'fixed',
+          width: '100%',
+          background: 'orange',
+          top: 0,
+          left: 0,
+          textAlign: 'center',
+          padding: 20,
+        }}
+        data-floating-ui-collidable
+      >
+        Collidable
+      </div>
+      <h1>Intersection</h1>
+      <p>The floating element should avoid the collidable elements.</p>
+      <div className="container">
+        <div style={{display: 'flex', gap: 10}}>
+          <div
+            ref={refs.setReference}
+            className="reference"
+            style={{width: 60, height: 60}}
+          />
+        </div>
+        <div
+          ref={refs.setFloating}
+          className="floating"
+          style={{...floatingStyles, width: size, height: size}}
+        >
+          Floating
+        </div>
+        <Collidable x={500} y={500} />
+        <Collidable x={550} y={300} />
+        <Collidable x={600} y={600} />
+      </div>
+
+      <Controls>
+        <label htmlFor="size">Size</label>
+        <input
+          id="size"
+          type="range"
+          min="1"
+          max="400"
+          value={size}
+          onChange={handleSizeChange}
+        />
+      </Controls>
+
+      <Controls>
+        {allPlacements.map((localPlacement) => (
+          <button
+            key={localPlacement}
+            data-testid={`placement-${localPlacement}`}
+            onClick={() => setPlacement(localPlacement)}
+            style={{
+              backgroundColor: localPlacement === placement ? 'black' : '',
+            }}
+          >
+            {localPlacement}
+          </button>
+        ))}
+      </Controls>
+    </>
+  );
+}

--- a/packages/dom/test/visual/spec/Intersection.tsx
+++ b/packages/dom/test/visual/spec/Intersection.tsx
@@ -6,7 +6,7 @@ import {allPlacements} from '../utils/allPlacements';
 import {Controls} from '../utils/Controls';
 import {useSize} from '../utils/useSize';
 
-function Collidable({x, y}: {x: number; y: number}) {
+function Obstacle({x, y}: {x: number; y: number}) {
   return (
     <div
       style={{
@@ -16,9 +16,9 @@ function Collidable({x, y}: {x: number; y: number}) {
         background: 'orange',
         padding: 15,
       }}
-      data-floating-ui-collidable
+      data-floating-ui-obstacle
     >
-      Collidable
+      Obstacle
     </div>
   );
 }
@@ -45,12 +45,12 @@ export function Intersection() {
           textAlign: 'center',
           padding: 20,
         }}
-        data-floating-ui-collidable
+        data-floating-ui-obstacle
       >
-        Collidable
+        Obstacle
       </div>
       <h1>Intersection</h1>
-      <p>The floating element should avoid the collidable elements.</p>
+      <p>The floating element should avoid the obstacle elements.</p>
       <div className="container">
         <div style={{display: 'flex', gap: 10}}>
           <div
@@ -66,9 +66,9 @@ export function Intersection() {
         >
           Floating
         </div>
-        <Collidable x={500} y={500} />
-        <Collidable x={550} y={300} />
-        <Collidable x={600} y={600} />
+        <Obstacle x={500} y={500} />
+        <Obstacle x={550} y={300} />
+        <Obstacle x={600} y={600} />
       </div>
 
       <Controls>


### PR DESCRIPTION
Closes #1440

As far as I can tell, this feature is most useful when another fixed / absolutely-positioned element is _also_ on the top-layer, or the floating element is "sharing" the layer it's on with something else. For example, you want to avoid a fixed navbar and not let it go under or over it, but instead avoid a collision like a boundary.

This is rudimentarily already possible using an option like `padding: {top: obstacleRect.height}` in `flip`/`shift`, etc, but this is cleaner and works better.

---


**The hardcoded `document.querySelectorAll` is temporary**. Each middleware will get an option like this, for tree-shaking purposes:

```js
flip({
  experimental_obstacles: experimental_avoidObstacles(
    Array.from(
      document.querySelectorAll('[data-obstacle]')
    ).map(el => el.getBoundingClientRect())
  ),
});
```

---

Needs to be added to:

- `size`
- `autoPlacement`

---

The algorithm is not perfect and struggles when there are multiple intersecting obstacles.

As mentioned, it's not ideal when you want multiple floating elements to avoid each other in a nice layout, as this technique technique is completely uncoordinated - the floating elements positioned first take full precedence instead of being nicely grouped. This behavior can still useful in some cases though it seems.