### PR TITLE
feat(dom): export getRectRelativeToOffsetParent function

### DIFF
--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -32,6 +32,7 @@ export const computePosition = (
 export {autoUpdate} from './autoUpdate';
 export {platform} from './platform';
 export {getOverflowAncestors} from './utils/getOverflowAncestors';
+export {getRectRelativeToOffsetParent} from './utils/getRectRelativeToOffsetParent';
 export {
   arrow,
   autoPlacement,


### PR DESCRIPTION
This PR exports `getRectRelativeToOffsetParent()` function from `@floating-ui/dom`.

TL;DR Without it you can't compose `getElementRects()` in `platform`:
https://github.com/floating-ui/floating-ui/blob/b8990250568043b876e1c8fe42358fe337847ede/packages/dom/src/platform.ts#L20-L31

### Why?

We need this for a hack in https://github.com/microsoft/fluentui/pull/28045 that prevents jumps, see #26579 and https://github.com/microsoft/fluentui/issues/26579#issuecomment-1503562558.

- We need to set `position: fixed` for initial positioning so elements in React portals will not appear off screen
- This should be done after `getOffsetParent()` as `getOffsetParent()` will always return `null` when an element has `position: fixed`
- This should be done before `getRectRelativeToOffsetParent()`
- `getRectRelativeToOffsetParent()` is not exported 💥 