### PR TITLE
feat(react): `onOpenChange` event param

### DIFF
--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -240,7 +240,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
           relatedTarget !== previouslyFocusedElementRef.current
         ) {
           preventReturnFocusRef.current = true;
-          onOpenChange(false);
+          onOpenChange(false, event);
         }
       });
     }
@@ -484,7 +484,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
     return visuallyHiddenDismiss && modal ? (
       <VisuallyHiddenDismiss
         ref={location === 'start' ? startDismissButtonRef : endDismissButtonRef}
-        onClick={() => onOpenChange(false)}
+        onClick={(event) => onOpenChange(false, event.nativeEvent)}
       >
         {typeof visuallyHiddenDismiss === 'string'
           ? visuallyHiddenDismiss

--- a/packages/react/src/components/FloatingPortal.tsx
+++ b/packages/react/src/components/FloatingPortal.tsx
@@ -205,7 +205,7 @@ export function FloatingPortal({
                 focusManagerState?.refs.domReference.current;
               nextTabbable?.focus();
               focusManagerState?.closeOnFocusOut &&
-                focusManagerState?.onOpenChange(false);
+                focusManagerState?.onOpenChange(false, event.nativeEvent);
             }
           }}
         />

--- a/packages/react/src/hooks/useClick.ts
+++ b/packages/react/src/hooks/useClick.ts
@@ -78,15 +78,13 @@ export function useClick<RT extends ReferenceType = ReferenceType>(
                 ? dataRef.current.openEvent.type === 'mousedown'
                 : true)
             ) {
-              onOpenChange(false);
+              onOpenChange(false, event.nativeEvent);
             }
           } else {
             // Prevent stealing focus from the floating element
             event.preventDefault();
-            onOpenChange(true);
+            onOpenChange(true, event.nativeEvent);
           }
-
-          dataRef.current.openEvent = event.nativeEvent;
         },
         onClick(event) {
           if (eventOption === 'mousedown' && pointerTypeRef.current) {
@@ -108,13 +106,11 @@ export function useClick<RT extends ReferenceType = ReferenceType>(
                 ? dataRef.current.openEvent.type === 'click'
                 : true)
             ) {
-              onOpenChange(false);
+              onOpenChange(false, event.nativeEvent);
             }
           } else {
-            onOpenChange(true);
+            onOpenChange(true, event.nativeEvent);
           }
-
-          dataRef.current.openEvent = event.nativeEvent;
         },
         onKeyDown(event) {
           pointerTypeRef.current = undefined;
@@ -136,10 +132,10 @@ export function useClick<RT extends ReferenceType = ReferenceType>(
           if (event.key === 'Enter') {
             if (open) {
               if (toggle) {
-                onOpenChange(false);
+                onOpenChange(false, event.nativeEvent);
               }
             } else {
-              onOpenChange(true);
+              onOpenChange(true, event.nativeEvent);
             }
           }
         },
@@ -157,10 +153,10 @@ export function useClick<RT extends ReferenceType = ReferenceType>(
             didKeyDownRef.current = false;
             if (open) {
               if (toggle) {
-                onOpenChange(false);
+                onOpenChange(false, event.nativeEvent);
               }
             } else {
-              onOpenChange(true);
+              onOpenChange(true, event.nativeEvent);
             }
           }
         },

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -13,6 +13,7 @@ import {
   getWindow,
   isElement,
   isHTMLElement,
+  isReactEvent,
   isVirtualClick,
   isVirtualPointerEvent,
 } from '../utils/is';
@@ -139,7 +140,7 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
         },
       });
 
-      onOpenChange(false);
+      onOpenChange(false, isReactEvent(event) ? event.nativeEvent : event);
     }
   );
 
@@ -231,7 +232,7 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
       },
     });
 
-    onOpenChange(false);
+    onOpenChange(false, event);
   });
 
   React.useEffect(() => {
@@ -242,8 +243,8 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
     dataRef.current.__escapeKeyBubbles = escapeKeyBubbles;
     dataRef.current.__outsidePressBubbles = outsidePressBubbles;
 
-    function onScroll() {
-      onOpenChange(false);
+    function onScroll(event: Event) {
+      onOpenChange(false, event);
     }
 
     const doc = getDocument(floating);
@@ -316,13 +317,15 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
     return {
       reference: {
         onKeyDown: closeOnEscapeKeyDown,
-        [bubbleHandlerKeys[referencePressEvent]]: () => {
+        [bubbleHandlerKeys[referencePressEvent]]: (
+          event: React.SyntheticEvent
+        ) => {
           if (referencePress) {
             events.emit('dismiss', {
               type: 'referencePress',
               data: {returnFocus: false},
             });
-            onOpenChange(false);
+            onOpenChange(false, event.nativeEvent);
           }
         },
       },

--- a/packages/react/src/hooks/useFloating.ts
+++ b/packages/react/src/hooks/useFloating.ts
@@ -33,7 +33,12 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
 
   const position = usePosition<RT>(options);
   const tree = useFloatingTree<RT>();
-  const onOpenChange = useEffectEvent(unstable_onOpenChange);
+  const onOpenChange = useEffectEvent((open: boolean, event?: Event) => {
+    if (open) {
+      dataRef.current.openEvent = event;
+    }
+    unstable_onOpenChange?.(open, event);
+  });
 
   const domReferenceRef = React.useRef<NarrowedElement<RT> | null>(null);
   const dataRef = React.useRef<ContextData>({});

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -110,14 +110,12 @@ export function useFocus<RT extends ReferenceType = ReferenceType>(
           if (
             event.type === 'focus' &&
             dataRef.current.openEvent?.type === 'mousedown' &&
-            dataRef.current.openEvent &&
             isEventTargetWithin(dataRef.current.openEvent, domReference)
           ) {
             return;
           }
 
-          dataRef.current.openEvent = event.nativeEvent;
-          onOpenChange(true);
+          onOpenChange(true, event.nativeEvent);
         },
         onBlur(event) {
           blockFocusRef.current = false;
@@ -143,7 +141,7 @@ export function useFocus<RT extends ReferenceType = ReferenceType>(
               return;
             }
 
-            onOpenChange(false);
+            onOpenChange(false, event.nativeEvent);
           });
         },
       },

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -503,7 +503,7 @@ export function useListNavigation<RT extends ReferenceType = ReferenceType>(
 
       if (nested && isCrossOrientationCloseKey(event.key, orientation, rtl)) {
         stopEvent(event);
-        onOpenChange(false);
+        onOpenChange(false, event.nativeEvent);
 
         if (isHTMLElement(domReference)) {
           domReference.focus();
@@ -809,7 +809,7 @@ export function useListNavigation<RT extends ReferenceType = ReferenceType>(
                 indexRef.current = getMinIndex(listRef, disabledIndices);
                 onNavigate(indexRef.current);
               } else {
-                onOpenChange(true);
+                onOpenChange(true, event.nativeEvent);
               }
             }
 
@@ -824,7 +824,7 @@ export function useListNavigation<RT extends ReferenceType = ReferenceType>(
             stopEvent(event);
 
             if (!open && openOnArrowKeyDown) {
-              onOpenChange(true);
+              onOpenChange(true, event.nativeEvent);
             } else {
               onKeyDown(event);
             }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -114,7 +114,7 @@ export interface FloatingEvents {
 }
 
 export interface ContextData {
-  openEvent?: MouseEvent | PointerEvent | FocusEvent;
+  openEvent?: Event;
   /** @deprecated use `onTypingChange` prop in `useTypeahead` */
   typing?: boolean;
   [key: string]: any;
@@ -124,7 +124,7 @@ export type FloatingContext<RT extends ReferenceType = ReferenceType> =
   Prettify<
     Omit<UsePositionFloatingReturn<RT>, 'refs' | 'elements'> & {
       open: boolean;
-      onOpenChange: (open: boolean) => void;
+      onOpenChange: (open: boolean, event?: Event) => void;
       events: FloatingEvents;
       dataRef: React.MutableRefObject<ContextData>;
       nodeId: string | undefined;
@@ -172,6 +172,6 @@ export type UseFloatingReturn<RT extends ReferenceType = ReferenceType> =
 export interface UseFloatingOptions<RT extends ReferenceType = ReferenceType>
   extends UsePositionOptions<RT> {
   open: boolean;
-  onOpenChange: (open: boolean) => void;
+  onOpenChange: (open: boolean, event?: Event) => void;
   nodeId: string;
 }

--- a/packages/react/src/utils/is.ts
+++ b/packages/react/src/utils/is.ts
@@ -79,3 +79,7 @@ export function isMouseLikePointerType(
   }
   return values.includes(pointerType);
 }
+
+export function isReactEvent(event: any): event is React.SyntheticEvent {
+  return 'nativeEvent' in event;
+}

--- a/packages/react/src/utils/isEventTargetWithin.ts
+++ b/packages/react/src/utils/isEventTargetWithin.ts
@@ -6,7 +6,7 @@
  * @returns Whether the event.target/composedPath is within the node.
  */
 export function isEventTargetWithin(
-  event: FocusEvent | MouseEvent,
+  event: Event,
   node: Node | null | undefined
 ) {
   if (node == null) {


### PR DESCRIPTION
There have been requests to access the event (https://github.com/floating-ui/floating-ui/issues/2047) inside `onOpenChange`. `dataRef.current.openEvent` does not currently get written before `onOpenChange` is called in all cases, and there's no `close` equivalent.

- `onOpenChange` is called without an event in `FloatingDelayGroup`, so it's optionally passed
-  `onOpenChange` isn't called if the user externally changes state, like `setIsOpen(false)`. In this case I think it makes sense to just react to whatever's needed inside the event where they did that anyway