### PR TITLE
fix(autoUpdate): `layoutShift` check

### DIFF
--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -44,9 +44,12 @@ export type Options = Partial<{
 // https://samthor.au/2021/observing-dom/
 function observeMove(element: Element, onMove: () => void) {
   let io: IntersectionObserver | null = null;
+  let timeoutId: NodeJS.Timeout;
+
   const root = getDocumentElement(element);
 
   function cleanup() {
+    clearTimeout(timeoutId);
     io && io.disconnect();
     io = null;
   }
@@ -71,11 +74,9 @@ function observeMove(element: Element, onMove: () => void) {
     const rootMargin = `${-insetTop}px ${-insetRight}px ${-insetBottom}px ${-insetLeft}px`;
 
     let isFirstUpdate = true;
-    let timeoutId: NodeJS.Timeout;
 
     io = new IntersectionObserver(
       (entries) => {
-        clearTimeout(timeoutId);
         const ratio = entries[0].intersectionRatio;
 
         if (ratio !== threshold) {

--- a/packages/dom/test/functional/autoUpdate.test.ts
+++ b/packages/dom/test/functional/autoUpdate.test.ts
@@ -26,6 +26,7 @@ import {click} from './utils/click';
 ['none', 'move', 'insert', 'delete'].forEach((option) => {
   test(`layoutShift: ${option}`, async ({page}) => {
     await page.goto('http://localhost:1234/autoUpdate');
+    await click(page, `[data-testid="layoutShift-init"]`);
     await click(page, `[data-testid="layoutShift-${option}"]`);
 
     expect(await page.locator('.container').screenshot()).toMatchSnapshot(

--- a/packages/dom/test/visual/spec/AutoUpdate.tsx
+++ b/packages/dom/test/visual/spec/AutoUpdate.tsx
@@ -14,34 +14,32 @@ const layoutShiftStrings: LayoutShiftString[] = [
 ];
 
 export function AutoUpdate() {
-  const {x, y, strategy, refs, update} = useFloating({
-    strategy: 'fixed',
-  });
-
   const [layoutShift, setLayoutShift] = useState<LayoutShiftString>('none');
   const [options, setOptions] = useState({
     ancestorScroll: false,
     ancestorResize: false,
     elementResize: false,
     animationFrame: false,
-    layoutShift: false,
   });
+  const layoutShiftOption = !options.ancestorScroll;
 
   const [referenceSize, setReferenceSize] = useState(200);
   const [floatingSize, setFloatingSize] = useState(100);
 
-  useEffect(() => {
+  const {x, y, strategy, refs, update} = useFloating({
+    strategy: 'fixed',
+  });
+
+  useLayoutEffect(() => {
     if (!refs.reference.current || !refs.floating.current) {
       return;
     }
 
-    return autoUpdate(
-      refs.reference.current,
-      refs.floating.current,
-      update,
-      options
-    );
-  }, [refs.floating, refs.reference, options, update]);
+    return autoUpdate(refs.reference.current, refs.floating.current, update, {
+      ...options,
+      layoutShift: layoutShiftOption,
+    });
+  }, [refs.floating, refs.reference, options, layoutShiftOption, update]);
 
   useLayoutEffect(() => {
     if (options.elementResize) {
@@ -154,7 +152,6 @@ export function AutoUpdate() {
             key={str}
             onClick={() => {
               setLayoutShift(str);
-              setOptions((o) => ({...o, layoutShift: str !== 'none'}));
             }}
             data-testid={`layoutShift-${str}`}
             style={{

--- a/packages/dom/test/visual/spec/AutoUpdate.tsx
+++ b/packages/dom/test/visual/spec/AutoUpdate.tsx
@@ -27,7 +27,9 @@ export function AutoUpdate() {
   const [referenceSize, setReferenceSize] = useState(200);
   const [floatingSize, setFloatingSize] = useState(100);
 
-  const {x, y, strategy, refs, update} = useFloating();
+  const {x, y, strategy, refs, update} = useFloating({
+    strategy: 'fixed',
+  });
 
   useLayoutEffect(() => {
     if (!refs.reference.current || !refs.floating.current) {

--- a/packages/dom/test/visual/spec/AutoUpdate.tsx
+++ b/packages/dom/test/visual/spec/AutoUpdate.tsx
@@ -1,16 +1,17 @@
 import {autoUpdate} from '@floating-ui/react-dom';
 import {useFloating} from '@floating-ui/react-dom';
-import {useEffect, useLayoutEffect, useState} from 'react';
+import {useLayoutEffect, useState} from 'react';
 
 import {Controls} from '../utils/Controls';
 
-type LayoutShiftString = 'move' | 'insert' | 'delete' | 'none';
+type LayoutShiftString = 'move' | 'insert' | 'delete' | 'none' | 'init';
 
 const layoutShiftStrings: LayoutShiftString[] = [
   'move',
   'insert',
   'delete',
   'none',
+  'init',
 ];
 
 export function AutoUpdate() {
@@ -21,14 +22,12 @@ export function AutoUpdate() {
     elementResize: false,
     animationFrame: false,
   });
-  const layoutShiftOption = !options.ancestorScroll;
+  const layoutShiftOption = layoutShift !== 'none';
 
   const [referenceSize, setReferenceSize] = useState(200);
   const [floatingSize, setFloatingSize] = useState(100);
 
-  const {x, y, strategy, refs, update} = useFloating({
-    strategy: 'fixed',
-  });
+  const {x, y, strategy, refs, update} = useFloating();
 
   useLayoutEffect(() => {
     if (!refs.reference.current || !refs.floating.current) {


### PR DESCRIPTION
Tests passed for https://github.com/floating-ui/floating-ui/pull/2373 since the useEffect was causing an update when the options changed, but the last refactor prevented the option from actually having an effect.

I couldn't work out a way to prevent the loop without the check breaking afterwards in various ways, so I throttled it to 100ms while the reference is clipped/hidden from view to prevent the CPU from spiking