### PR TITLE
fix(useMergeRefs): refs could be undefined

### DIFF
--- a/packages/react/src/hooks/useMergeRefs.ts
+++ b/packages/react/src/hooks/useMergeRefs.ts
@@ -5,7 +5,7 @@ import * as React from 'react';
  * @see https://floating-ui.com/docs/useMergeRefs
  */
 export function useMergeRefs<Instance>(
-  refs: Array<React.Ref<Instance>>
+  refs: Array<React.Ref<Instance> | undefined>
 ): React.RefCallback<Instance> | null {
   return React.useMemo(() => {
     if (refs.every((ref) => ref == null)) {


### PR DESCRIPTION
The ref can also be undefined, and in this case. And it is equivalent to null. Therefore, the double equals (==) can also filter it.