### PR TITLE
fix(autoUpdate): avoid potential `IntersectionObserver` crash

### DIFF
--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -2,7 +2,7 @@ import type {FloatingElement, ReferenceElement} from './types';
 import {getBoundingClientRect} from './utils/getBoundingClientRect';
 import {getDocumentElement} from './utils/getDocumentElement';
 import {getOverflowAncestors} from './utils/getOverflowAncestors';
-import {floor} from './utils/math';
+import {floor, max, min} from './utils/math';
 import {unwrapElement} from './utils/unwrapElement';
 
 export type Options = Partial<{
@@ -84,7 +84,7 @@ function observeMove(element: Element, onMove: () => void) {
             return refresh();
           }
 
-          if (ratio === 0) {
+          if (!ratio) {
             timeoutId = setTimeout(() => {
               refresh(false, 1e-7);
             }, 100);
@@ -95,7 +95,7 @@ function observeMove(element: Element, onMove: () => void) {
 
         isFirstUpdate = false;
       },
-      {rootMargin, threshold}
+      {rootMargin, threshold: max(0, min(1, threshold || 1))}
     );
 
     io.observe(element);


### PR DESCRIPTION
Fixes #2389

I don't know how this can happen [given the spec says `intersectionRatio` is always between `0.0` and `1.0`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry/intersectionRatio#value)  - maybe some kind of floating point error? - but to avoid any issues with bugged implementations, clamp the value between `0` and `1` and fallback to `1` if it's some other falsy value

@HuanEragon not sure if you can test this, but if you edit the file locally with this change the error shouldn't happen