### PR TITLE
fix(useListNavigation): skip hidden items

### DIFF
--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -66,8 +66,8 @@ function findNonDisabledIndex(
       ? disabledIndices.includes(index)
       : list[index] == null ||
         list[index]?.hasAttribute('disabled') ||
-        list[index]?.getAttribute('aria-disabled') === 'true') ||
-        isHidden(list[index])
+        list[index]?.getAttribute('aria-disabled') === 'true' ||
+        isHidden(list[index]))
   );
 
   return index;

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -11,6 +11,7 @@ import {contains} from '../utils/contains';
 import {enqueueFocus} from '../utils/enqueueFocus';
 import {getDocument} from '../utils/getDocument';
 import {
+  isHidden,
   isHTMLElement,
   isMac,
   isSafari,
@@ -65,7 +66,8 @@ function findNonDisabledIndex(
       ? disabledIndices.includes(index)
       : list[index] == null ||
         list[index]?.hasAttribute('disabled') ||
-        list[index]?.getAttribute('aria-disabled') === 'true')
+        list[index]?.getAttribute('aria-disabled') === 'true') ||
+        isHidden(list[index])
   );
 
   return index;

--- a/packages/react/src/utils/is.ts
+++ b/packages/react/src/utils/is.ts
@@ -83,3 +83,9 @@ export function isMouseLikePointerType(
 export function isReactEvent(event: any): event is React.SyntheticEvent {
   return 'nativeEvent' in event;
 }
+
+export function isHidden(el: HTMLElement | null) {
+  if (!el) return false;
+
+  return el.offsetParent === null;
+}

--- a/packages/react/test/setupTests.ts
+++ b/packages/react/test/setupTests.ts
@@ -17,28 +17,37 @@ function isNullOrUndefined(a: any) {
 
 // From https://github.com/jsdom/jsdom/issues/1261#issuecomment-512217225
 Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
-    get() {
-        // eslint-disable-next-line
-        let element = this;
-        while (!isNullOrUndefined(element) &&
-                    (isNullOrUndefined(element.style) ||
-                    isNullOrUndefined(element.style.display) ||
-                    element.style.display.toLowerCase() !== 'none')) {
-            element = element.parentNode;
-        }
+  get() {
+    // eslint-disable-next-line
+    let element = this;
+    while (
+      !isNullOrUndefined(element) &&
+      (isNullOrUndefined(element.style) ||
+        isNullOrUndefined(element.style.display) ||
+        element.style.display.toLowerCase() !== 'none')
+    ) {
+      element = element.parentNode;
+    }
 
-        if (!isNullOrUndefined(element)) {
-            return null;
-        }
+    if (!isNullOrUndefined(element)) {
+      return null;
+    }
 
-        if (!isNullOrUndefined(this.style) && !isNullOrUndefined(this.style.position) && this.style.position.toLowerCase() === 'fixed') {
-            return null;
-        }
+    if (
+      !isNullOrUndefined(this.style) &&
+      !isNullOrUndefined(this.style.position) &&
+      this.style.position.toLowerCase() === 'fixed'
+    ) {
+      return null;
+    }
 
-        if (this.tagName.toLowerCase() === 'html' || this.tagName.toLowerCase() === 'body') {
-            return null;
-        }
+    if (
+      this.tagName.toLowerCase() === 'html' ||
+      this.tagName.toLowerCase() === 'body'
+    ) {
+      return null;
+    }
 
-        return this.parentNode;
-    },
+    return this.parentNode;
+  },
 });

--- a/packages/react/test/setupTests.ts
+++ b/packages/react/test/setupTests.ts
@@ -10,3 +10,35 @@ jest
   });
 
 global.ResizeObserver = ResizeObserverPolyfill;
+
+function isNullOrUndefined(a: any) {
+  return a == null;
+}
+
+// From https://github.com/jsdom/jsdom/issues/1261#issuecomment-512217225
+Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+    get() {
+        // eslint-disable-next-line
+        let element = this;
+        while (!isNullOrUndefined(element) &&
+                    (isNullOrUndefined(element.style) ||
+                    isNullOrUndefined(element.style.display) ||
+                    element.style.display.toLowerCase() !== 'none')) {
+            element = element.parentNode;
+        }
+
+        if (!isNullOrUndefined(element)) {
+            return null;
+        }
+
+        if (!isNullOrUndefined(this.style) && !isNullOrUndefined(this.style.position) && this.style.position.toLowerCase() === 'fixed') {
+            return null;
+        }
+
+        if (this.tagName.toLowerCase() === 'html' || this.tagName.toLowerCase() === 'body') {
+            return null;
+        }
+
+        return this.parentNode;
+    },
+});


### PR DESCRIPTION
Skips hidden elements from list navigation. Not sure if checking `offsetParent` is the best solution, feel free to suggest some alternative.

## Background

I am building this combobox with a tree popup. When a group is collapsed, the items inside are still rendered in react (because we need to get the label/id data back to the parent component), but hidden via CSS. When they are hidden, they should be skipped by list navigation.

![image](https://github.com/floating-ui/floating-ui/assets/1892091/f1925472-ec07-4ba3-9c0c-0a2f9303fe3d)
