### PR TITLE
fix(FloatingList): allow ReactNode as label type

### DIFF
--- a/packages/react/src/components/FloatingList.tsx
+++ b/packages/react/src/components/FloatingList.tsx
@@ -41,7 +41,7 @@ export const FloatingListContext = React.createContext<{
   unregister: (node: Node) => void;
   map: Map<Node, number | null>;
   elementsRef: React.MutableRefObject<Array<HTMLElement | null>>;
-  labelsRef?: React.MutableRefObject<Array<string | null>>;
+  labelsRef?: React.MutableRefObject<Array<React.ReactNode>>;
 }>({
   register: () => {},
   unregister: () => {},
@@ -52,7 +52,7 @@ export const FloatingListContext = React.createContext<{
 interface FloatingListProps {
   children: React.ReactNode;
   elementsRef: React.MutableRefObject<Array<HTMLElement | null>>;
-  labelsRef?: React.MutableRefObject<Array<string | null>>;
+  labelsRef?: React.MutableRefObject<Array<React.ReactNode>>;
 }
 
 /**
@@ -104,7 +104,7 @@ export function FloatingList({
 }
 
 export interface UseListItemProps {
-  label?: string | null;
+  label?: React.ReactNode;
 }
 
 export function useListItem({label}: UseListItemProps = {}): {


### PR DESCRIPTION
One quite common thing in the React world is to have a `<Translate key="some.key" />` component which eventually renders a string. But if the hook/refs array does not allow `ReactNode`, it needs to be worked around. This will allow passing such component to the composition-based option directly & avoids type casting and other shenanigans.