### PR TITLE
fix(autoUpdate): guard for ResizeObserver existence

### DIFF
--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -137,7 +137,7 @@ export function autoUpdate(
   const {
     ancestorScroll = true,
     ancestorResize = true,
-    elementResize = true,
+    elementResize = typeof ResizeObserver === 'function',
     layoutShift = typeof IntersectionObserver === 'function',
     animationFrame = false,
   } = options;


### PR DESCRIPTION
Might as well add this check now to support testing envs by default