### PR TITLE
feat(FloatingArrow): `skewToCenter` prop

### DIFF
--- a/packages/react/src/components/FloatingArrow.tsx
+++ b/packages/react/src/components/FloatingArrow.tsx
@@ -31,6 +31,12 @@ export interface FloatingArrowProps extends React.SVGAttributes<SVGSVGElement> {
   staticOffset?: string | number | null;
 
   /**
+   * Whether to skew the arrow shape so that it points to the center as best as
+   * possible.
+   */
+  skewToCenter?: boolean;
+
+  /**
    * Custom path string.
    */
   d?: string;
@@ -61,6 +67,7 @@ export const FloatingArrow = React.forwardRef(function FloatingArrow(
     height = 7,
     tipRadius = 0,
     strokeWidth = 0,
+    skewToCenter = false,
     staticOffset,
     stroke,
     d,
@@ -106,12 +113,24 @@ export const FloatingArrow = React.forwardRef(function FloatingArrow(
   const arrowX = arrow?.x != null ? staticOffset || arrow.x : '';
   const arrowY = arrow?.y != null ? staticOffset || arrow.y : '';
 
+  const centerOffset =
+    staticOffset || !skewToCenter
+      ? 0
+      : (arrow?.centerOffset || 0) *
+        (side === 'top' || side === 'right' ? 1 : -1);
+  const skewOffset =
+    centerOffset < 0
+      ? -Math.min(width / 2 - tipRadius, -centerOffset)
+      : Math.min(width / 2 - tipRadius, centerOffset);
+
   const dValue =
     d ||
     'M0,0' +
       ` H${width}` +
-      ` L${width - svgX},${height - svgY}` +
-      ` Q${width / 2},${height} ${svgX},${height - svgY}` +
+      ` L${width - svgX + skewOffset},${height - svgY}` +
+      ` Q${width / 2 + skewOffset},${height} ${svgX + skewOffset},${
+        height - svgY
+      }` +
       ' Z';
 
   const rotation = {
@@ -148,13 +167,11 @@ export const FloatingArrow = React.forwardRef(function FloatingArrow(
           fill="none"
           stroke={stroke}
           // Account for the stroke on the fill path rendered below.
-          strokeWidth={strokeWidth + (d ? 0 : 1)}
+          strokeWidth={strokeWidth}
           d={dValue}
         />
       )}
-      {/* In Firefox, for left/right placements there's a ~0.5px gap where the
-      border can show through. Adding a stroke on the fill removes it. */}
-      <path stroke={strokeWidth && !d ? rest.fill : 'none'} d={dValue} />
+      <path stroke="none" d={dValue} />
       {/* Assumes the border-width of the floating element matches the 
       stroke. */}
       <clipPath id={clipPathId}>

--- a/packages/react/test/visual/components/Arrow.tsx
+++ b/packages/react/test/visual/components/Arrow.tsx
@@ -94,6 +94,7 @@ export const Main = () => {
             placement={placement}
             arrowProps={{
               fill: 'rgba(0,0,0,0.75)',
+              skewToCenter: true,
             }}
             floatingProps={{
               className: 'bg-black/75 text-white p-2',
@@ -176,8 +177,7 @@ export const Main = () => {
             key={placement}
             placement={placement}
             arrowProps={{
-              className:
-                'fill-white [&>path:first-of-type]:stroke-pink-500 [&>path:last-of-type]:stroke-white',
+              className: 'fill-white [&>path:first-of-type]:stroke-pink-500',
               strokeWidth: 1,
             }}
             floatingProps={{


### PR DESCRIPTION
Can't seem to replicate the gap issue in Firefox anymore and leaving it off is necessary for the 90deg triangle with a stroke to  have a correct thickness...

https://github.com/floating-ui/floating-ui/assets/22450188/3c813c9a-29a6-46b6-bf11-8ca3a7b8785e

