### PR TITLE
fix: useClick + useHover combo

### DIFF
--- a/packages/react/src/hooks/useClick.ts
+++ b/packages/react/src/hooks/useClick.ts
@@ -128,10 +128,8 @@ export function useClick<RT extends ReferenceType = ReferenceType>(
           }
 
           if (event.key === 'Enter') {
-            if (open) {
-              if (toggle) {
-                onOpenChange(false, event.nativeEvent);
-              }
+            if (open && toggle) {
+              onOpenChange(false, event.nativeEvent);
             } else {
               onOpenChange(true, event.nativeEvent);
             }
@@ -149,10 +147,8 @@ export function useClick<RT extends ReferenceType = ReferenceType>(
 
           if (event.key === ' ' && didKeyDownRef.current) {
             didKeyDownRef.current = false;
-            if (open) {
-              if (toggle) {
-                onOpenChange(false, event.nativeEvent);
-              }
+            if (open && toggle) {
+              onOpenChange(false, event.nativeEvent);
             } else {
               onOpenChange(true, event.nativeEvent);
             }

--- a/packages/react/src/hooks/useClick.ts
+++ b/packages/react/src/hooks/useClick.ts
@@ -71,15 +71,14 @@ export function useClick<RT extends ReferenceType = ReferenceType>(
             return;
           }
 
-          if (open) {
-            if (
-              toggle &&
-              (dataRef.current.openEvent
-                ? dataRef.current.openEvent.type === 'mousedown'
-                : true)
-            ) {
-              onOpenChange(false, event.nativeEvent);
-            }
+          if (
+            open &&
+            toggle &&
+            (dataRef.current.openEvent
+              ? dataRef.current.openEvent.type === 'mousedown'
+              : true)
+          ) {
+            onOpenChange(false, event.nativeEvent);
           } else {
             // Prevent stealing focus from the floating element
             event.preventDefault();
@@ -99,15 +98,14 @@ export function useClick<RT extends ReferenceType = ReferenceType>(
             return;
           }
 
-          if (open) {
-            if (
-              toggle &&
-              (dataRef.current.openEvent
-                ? dataRef.current.openEvent.type === 'click'
-                : true)
-            ) {
-              onOpenChange(false, event.nativeEvent);
-            }
+          if (
+            open &&
+            toggle &&
+            (dataRef.current.openEvent
+              ? dataRef.current.openEvent.type === 'click'
+              : true)
+          ) {
+            onOpenChange(false, event.nativeEvent);
           } else {
             onOpenChange(true, event.nativeEvent);
           }


### PR DESCRIPTION
Fixes #2443 

This makes `onOpenChange` fire with `true` onClick even if the `open` state is already `true`, to allow the `dataRef.current.openEvent` to be assigned and allow the mouseleave logic to check for it.