### PR TITLE
allows ArrowOptions.element to be MaybeElement<Element>

### DIFF
--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -159,7 +159,7 @@ export type ArrowOptions = {
    * The arrow element or template ref to be positioned.
    * @required
    */
-  element: MaybeReadonlyRef<MaybeElement<HTMLElement>>;
+  element: MaybeReadonlyRef<MaybeElement<Element>>;
   /**
    * The padding between the arrow element and the floating element edges. Useful when the floating element has rounded corners.
    * @default 0


### PR DESCRIPTION
arrow middleware in the core package allows `element` to be type `any` and all other methods that operate with it specify type `Element` as well

- [getDimensions](https://github.com/floating-ui/floating-ui/blob/master/packages/dom/src/platform/getDimensions.ts#L5)
- [getOffsetParent](https://github.com/floating-ui/floating-ui/blob/eb6c042e42faae7567e717fe10afdd1953375e14/packages/dom/src/platform/getOffsetParent.ts#L48)

changing this type simplifies assigning an arrow ref through [function template refs](https://vuejs.org/guide/essentials/template-refs.html#function-refs) from within a slot

addresses #2451 