### PR TITLE
[core] optimize getRectRelativeToOffsetParent function

### DIFF
--- a/packages/dom/src/utils/getRectRelativeToOffsetParent.ts
+++ b/packages/dom/src/utils/getRectRelativeToOffsetParent.ts
@@ -29,7 +29,7 @@ export function getRectRelativeToOffsetParent(
       scroll = getNodeScroll(offsetParent);
     }
 
-    if (isHTMLElement(offsetParent)) {
+    if (isOffsetParentAnElement) {
       const offsetRect = getBoundingClientRect(
         offsetParent,
         true,


### PR DESCRIPTION
Remove duplicate code.

The return value of isHTMLElement(offsetParent) has already been retrieved, so there is no need to compute it again