### PR TITLE
Update FloatingPortal.tsx to specify return type

### DIFF
--- a/packages/react/src/components/FloatingPortal.tsx
+++ b/packages/react/src/components/FloatingPortal.tsx
@@ -114,7 +114,7 @@ export function FloatingPortal({
   id,
   root = null,
   preserveTabOrder = true,
-}: FloatingPortalProps) {
+}: FloatingPortalProps): JSX.Element {
   const portalNode = useFloatingPortalNode({id, root});
   const [focusManagerState, setFocusManagerState] =
     React.useState<FocusManagerState>(null);


### PR DESCRIPTION
Fixes an issue where the generated .d.ts files have an inline import even though JSX is global.

Without this change, I had to either turn on `skipLibCheck` in my tsconfig or otherwise I get this error:
```
node_modules/@floating-ui/react/src/components/FloatingPortal.d.ts:22:133 - error TS2694: Namespace '"node_modules/@types/react/jsx-runtime"' has no exported member 'JSX'.

22 export declare function FloatingPortal({ children, id, root, preserveTabOrder, }: FloatingPortalProps): import("react/jsx-runtime").JSX.Element;
                                                                                                                                       ~~~


Found 1 error in node_modules/@floating-ui/react/src/components/FloatingPortal.d.ts:22
```