### PR TITLE
fix(useHover): cleanup when `domReference` changes

### DIFF
--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -396,7 +396,7 @@ export function useHover<RT extends ReferenceType = ReferenceType>(
       clearTimeout(restTimeoutRef.current);
       clearPointerEvents();
     };
-  }, [enabled, cleanupMouseMoveHandler, clearPointerEvents]);
+  }, [enabled, domReference, cleanupMouseMoveHandler, clearPointerEvents]);
 
   return React.useMemo(() => {
     if (!enabled) {

--- a/packages/react/test/unit/useHover.test.tsx
+++ b/packages/react/test/unit/useHover.test.tsx
@@ -177,3 +177,23 @@ test('mouseleave on the floating element closes it (mouse)', async () => {
 
   expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
 });
+
+test('does not show after delay if domReference changes', async () => {
+  const {rerender} = render(<App delay={1000} />);
+
+  fireEvent.mouseEnter(screen.getByRole('button'));
+
+  await act(async () => {
+    vi.advanceTimersByTime(1);
+  });
+
+  rerender(<App showReference={false} />);
+
+  await act(async () => {
+    vi.advanceTimersByTime(999);
+  });
+
+  expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+  cleanup();
+});


### PR DESCRIPTION
Fixes #2463