### PR TITLE
fix(FloatingArrow): allow generic reference type context

### DIFF
--- a/packages/react/index.test-d.tsx
+++ b/packages/react/index.test-d.tsx
@@ -85,9 +85,12 @@ function App() {
   const ref2 = useRef<HTMLDivElement>(null);
   const ref = useMergeRefs([ref1, ref2, arrowRef, null]);
 
+  const {context: contextGeneric} = useFloating<HTMLDivElement>();
+
   return (
     <div ref={ref} style={floatingStyles}>
       <FloatingArrow context={context} />
+      <FloatingArrow context={contextGeneric} />
       <FloatingArrow
         ref={arrowRef}
         context={context}

--- a/packages/react/src/components/FloatingArrow.tsx
+++ b/packages/react/src/components/FloatingArrow.tsx
@@ -5,7 +5,7 @@ import {useId} from '../hooks/useId';
 import type {Alignment, FloatingContext, Side} from '../types';
 
 export interface FloatingArrowProps extends React.SVGAttributes<SVGSVGElement> {
-  context: FloatingContext;
+  context: Omit<FloatingContext, 'refs'>;
 
   /**
    * Width of the arrow.

--- a/packages/react/src/components/FloatingArrow.tsx
+++ b/packages/react/src/components/FloatingArrow.tsx
@@ -5,7 +5,12 @@ import {useId} from '../hooks/useId';
 import type {Alignment, FloatingContext, Side} from '../types';
 
 export interface FloatingArrowProps extends React.SVGAttributes<SVGSVGElement> {
-  context: Omit<FloatingContext, 'refs'>;
+  // Omit the original `refs` property from the context to avoid issues with
+  // generics: https://github.com/floating-ui/floating-ui/issues/2483
+  /**
+   * The floating context.
+   */
+  context: Omit<FloatingContext, 'refs'> & {refs: any};
 
   /**
    * Width of the arrow.


### PR DESCRIPTION
Fixes #2483

@mattbrazza I tried a few things with generics but it seems hard with `forwardRef` :\  omitting the refs from the type fixes the problem and the component doesn't need that part of the context anyway