### PR TITLE
fix(FloatingFocusManager): allow trapped comboboxes

### DIFF
--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -115,10 +115,11 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
   // aria-hidden should be applied to all nodes still. Further, the visually
   // hidden dismiss button should only appear at the end of the list, not the
   // start.
-  const isTypeableCombobox =
+  const isUntrappedTypeableCombobox =
     domReference &&
     domReference.getAttribute('role') === 'combobox' &&
-    isTypeableElement(domReference);
+    isTypeableElement(domReference) &&
+    ignoreInitialFocus;
 
   const getTabbableContent = React.useCallback(
     (container: HTMLElement | null = floating) => {
@@ -158,7 +159,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
         if (
           contains(floating, activeElement(getDocument(floating))) &&
           getTabbableContent().length === 0 &&
-          !isTypeableCombobox
+          !isUntrappedTypeableCombobox
         ) {
           stopEvent(event);
         }
@@ -198,7 +199,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
     modal,
     orderRef,
     refs,
-    isTypeableCombobox,
+    isUntrappedTypeableCombobox,
     getTabbableContent,
     getTabbableElements,
   ]);
@@ -291,7 +292,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
         ...portalNodes,
         startDismissButtonRef.current,
         endDismissButtonRef.current,
-        orderRef.current.includes('reference') || isTypeableCombobox
+        orderRef.current.includes('reference') || isUntrappedTypeableCombobox
           ? domReference
           : null,
       ].filter((x): x is Element => x != null);
@@ -311,7 +312,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
     modal,
     orderRef,
     portalContext,
-    isTypeableCombobox,
+    isUntrappedTypeableCombobox,
     guards,
   ]);
 
@@ -494,7 +495,10 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
   }
 
   const shouldRenderGuards =
-    !disabled && guards && !isTypeableCombobox && (isInsidePortal || modal);
+    !disabled &&
+    guards &&
+    !isUntrappedTypeableCombobox &&
+    (isInsidePortal || modal);
 
   return (
     <>
@@ -527,7 +531,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
         Ensure the first swipe is the list item. The end of the listbox popup
         will have a dismiss button.
       */}
-      {!isTypeableCombobox && renderDismissButton('start')}
+      {!isUntrappedTypeableCombobox && renderDismissButton('start')}
       {children}
       {renderDismissButton('end')}
       {shouldRenderGuards && (

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -1116,7 +1116,7 @@ describe('Drawer', () => {
   });
 });
 
-test('untrapped combobox', async () => {
+test('trapped combobox prevents focus moving outside floating element', async () => {
   function App() {
     const [isOpen, setIsOpen] = useState(false);
 

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -1,4 +1,4 @@
-import {act, fireEvent, render, screen} from '@testing-library/react';
+import {act, cleanup, fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {cloneElement, useRef, useState} from 'react';
 import {Context as ResponsiveContext} from 'react-responsive';
@@ -14,6 +14,7 @@ import {
   useFloatingNodeId,
   useFloatingParentNodeId,
   useInteractions,
+  useRole,
 } from '../../src';
 import {FloatingFocusManagerProps} from '../../src/components/FloatingFocusManager';
 import {Main as Drawer} from '../visual/components/Drawer';
@@ -1113,4 +1114,59 @@ describe('Drawer', () => {
     await userEvent.click(screen.getByText('Close'));
     expect(document.activeElement).toBe(screen.getByText('My button'));
   });
+});
+
+test('untrapped combobox', async () => {
+  function App() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const {refs, floatingStyles, context} = useFloating({
+      open: isOpen,
+      onOpenChange: setIsOpen,
+    });
+
+    const role = useRole(context);
+    const dismiss = useDismiss(context);
+    const click = useClick(context);
+
+    const {getReferenceProps, getFloatingProps} = useInteractions([
+      role,
+      dismiss,
+      click,
+    ]);
+
+    return (
+      <div className="App">
+        <input
+          ref={refs.setReference}
+          {...getReferenceProps()}
+          data-testid="input"
+          role="combobox"
+        />
+        {isOpen && (
+          <FloatingFocusManager context={context}>
+            <div
+              ref={refs.setFloating}
+              style={floatingStyles}
+              {...getFloatingProps()}
+            >
+              <button>one</button>
+              <button>two</button>
+            </div>
+          </FloatingFocusManager>
+        )}
+      </div>
+    );
+  }
+
+  render(<App />);
+  await userEvent.click(screen.getByTestId('input'));
+  await act(async () => {});
+  expect(screen.getByTestId('input')).not.toHaveFocus();
+  expect(screen.getByRole('button', {name: 'one'})).toHaveFocus();
+  await userEvent.tab();
+  expect(screen.getByRole('button', {name: 'two'})).toHaveFocus();
+  await userEvent.tab();
+  expect(screen.getByRole('button', {name: 'one'})).toHaveFocus();
+  cleanup();
 });


### PR DESCRIPTION
If `initialFocus={-1}` is not specified on `FloatingFocusManager` while the reference is a `combobox`, then the focus management is considered trappable.

Fixes #2505 