### PR TITLE
Modifier type: Make properties optional

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -134,11 +134,11 @@ export type ModifierArguments<Options: Obj> = {
 };
 export type Modifier<Name, Options: Obj> = {|
   name: Name,
-  enabled: boolean,
-  phase: ModifierPhases,
+  enabled?: boolean,
+  phase?: ModifierPhases,
   requires?: Array<string>,
   requiresIfExists?: Array<string>,
-  fn: (ModifierArguments<Options>) => State | void,
+  fn?: (ModifierArguments<Options>) => State | void,
   effect?: (ModifierArguments<Options>) => (() => void) | void,
   options?: $Shape<Options>,
   data?: Obj,


### PR DESCRIPTION
Hello 👋 I'm not sure if PRs are still accepted into v2, but I'm wondering if these properties on `Modifier` can be made optional?

- `enabled`
- `phase`
- `fn`

Based on examples in the docs, it seems like they shouldn't be required. Here's [another example](https://codesandbox.io/s/popper-example-modifier-type-v9hrjq?file=/Demo.tsx) where it doesn't seem like those properties are required to be set to use the Modifier type. Is there a reason they are set to required?