### PR TITLE
getOverflowAncestors: traverse into iframe parent

### DIFF
--- a/.changeset/late-falcons-sell.md
+++ b/.changeset/late-falcons-sell.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/dom": patch
+---
+
+fix: traverse into iframe parents when finding overflow ancestors

--- a/packages/utils/dom/src/index.ts
+++ b/packages/utils/dom/src/index.ts
@@ -168,7 +168,8 @@ export function getOverflowAncestors(
     return list.concat(
       win,
       win.visualViewport || [],
-      isOverflowElement(scrollableAncestor) ? scrollableAncestor : []
+      isOverflowElement(scrollableAncestor) ? scrollableAncestor : [],
+      win.frameElement ? getOverflowAncestors(win.frameElement) : [],
     );
   }
 

--- a/packages/utils/test/getOverflowAncestors.test.ts
+++ b/packages/utils/test/getOverflowAncestors.test.ts
@@ -65,3 +65,20 @@ test('does treat display: inline-block elements as overflow ancestors', () => {
     window,
   ]);
 });
+
+test('returns overflow ancestors in iframe parents', () => {
+  const scroll = document.createElement('div');
+  scroll.style.overflow = 'scroll';
+  const iframe = document.createElement('iframe');
+  const test = document.createElement('div');
+
+  document.body.append(scroll);
+  scroll.append(iframe);
+  iframe.contentDocument!.body.append(test);
+
+  expect(getOverflowAncestors(test)).toEqual([
+    iframe.contentWindow,
+    scroll,
+    window,
+  ]);
+});

--- a/packages/utils/test/getOverflowAncestors.test.ts
+++ b/packages/utils/test/getOverflowAncestors.test.ts
@@ -74,7 +74,8 @@ test('returns overflow ancestors in iframe parents', () => {
 
   document.body.append(scroll);
   scroll.append(iframe);
-  iframe.contentDocument!.body.append(test);
+  expect(iframe.contentDocument).not.toBeNull();
+  iframe.contentDocument?.body.append(test);
 
   expect(getOverflowAncestors(test)).toEqual([
     iframe.contentWindow,


### PR DESCRIPTION
Fixes #2518.

When `getOverflowAncestors` reaches the `window` object, it checks whether there is `window.frameElement` and continues traversing up into the iframe's parent.

TODO before this is shippable:
- add tests
- verify usage in `getClippingElementAncestors`. Do we also want to traverse into iframe's parent there?