### PR TITLE
chore: changeset for @floating-ui/utils@0.1.2

### DIFF
--- a/.changeset/strong-mayflies-raise.md
+++ b/.changeset/strong-mayflies-raise.md
@@ -2,4 +2,4 @@
 '@floating-ui/utils': patch
 ---
 
-fix: traverse into iframe parents when finding overflow ancestors
+fix(dom): traverse into iframe parents when finding overflow ancestors

--- a/.changeset/strong-mayflies-raise.md
+++ b/.changeset/strong-mayflies-raise.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/utils': patch
+---
+
+fix: traverse into iframe parents when finding overflow ancestors


### PR DESCRIPTION
The changeset for https://github.com/floating-ui/floating-ui/pull/2535 was meant to be pointed to the `utils` not `dom` package.