### PR TITLE
fix(getOverflowAncestors): avoid traversing iframes for clipping detection

### DIFF
--- a/.changeset/blue-seahorses-attend.md
+++ b/.changeset/blue-seahorses-attend.md
@@ -1,0 +1,6 @@
+---
+'@floating-ui/utils': patch
+'@floating-ui/dom': patch
+---
+
+fix(getOverflowAncestors): avoid traversing into iframes for clipping detection

--- a/packages/dom/src/platform/getClippingRect.ts
+++ b/packages/dom/src/platform/getClippingRect.ts
@@ -106,7 +106,7 @@ function getClippingElementAncestors(
     return cachedResult;
   }
 
-  let result = getOverflowAncestors(element).filter(
+  let result = getOverflowAncestors(element, [], false).filter(
     (el) => isElement(el) && getNodeName(el) !== 'body'
   ) as Array<Element>;
   let currentContainingBlockComputedStyle: CSSStyleDeclaration | null = null;

--- a/packages/dom/test/visual/spec/IFrame.tsx
+++ b/packages/dom/test/visual/spec/IFrame.tsx
@@ -102,7 +102,12 @@ function Inside({scroll}: {scroll: number[]}) {
   return (
     <>
       <h2>Inside</h2>
-      <div className="container" id="inside-container">
+      <div
+        className="container"
+        id="inside-container"
+        // https://github.com/floating-ui/floating-ui/issues/2552
+        style={{overflow: 'hidden'}}
+      >
         <iframe
           ref={setIFrame}
           width={350}

--- a/packages/utils/dom/src/index.ts
+++ b/packages/utils/dom/src/index.ts
@@ -158,7 +158,8 @@ export function getNearestOverflowAncestor(node: Node): HTMLElement {
 
 export function getOverflowAncestors(
   node: Node,
-  list: OverflowAncestors = []
+  list: OverflowAncestors = [],
+  traverseIframes = true
 ): OverflowAncestors {
   const scrollableAncestor = getNearestOverflowAncestor(node);
   const isBody = scrollableAncestor === node.ownerDocument?.body;
@@ -169,7 +170,9 @@ export function getOverflowAncestors(
       win,
       win.visualViewport || [],
       isOverflowElement(scrollableAncestor) ? scrollableAncestor : [],
-      win.frameElement ? getOverflowAncestors(win.frameElement) : [],
+      win.frameElement && traverseIframes
+        ? getOverflowAncestors(win.frameElement)
+        : []
     );
   }
 


### PR DESCRIPTION
Fixes https://github.com/floating-ui/floating-ui/issues/2552