### PR TITLE
fix(flip): skip work if arrow data exists

### DIFF
--- a/.changeset/proud-swans-type.md
+++ b/.changeset/proud-swans-type.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/core': patch
+---
+
+fix(flip): skip if arrow has performed internal shifting

--- a/packages/core/src/middleware/flip.ts
+++ b/packages/core/src/middleware/flip.ts
@@ -92,6 +92,7 @@ export const flip = (
 
     // If the arrow data is available, it's caused a reset, so we should skip
     // any logic now since `flip()` has already done its work.
+    // https://github.com/floating-ui/floating-ui/issues/2549#issuecomment-1719601643
     if (middlewareData.arrow) {
       return {};
     }

--- a/packages/core/src/middleware/flip.ts
+++ b/packages/core/src/middleware/flip.ts
@@ -90,6 +90,12 @@ export const flip = (
       ...detectOverflowOptions
     } = evaluate(options, state);
 
+    // If the arrow data is available, it's caused a reset, so we should skip
+    // any logic now since `flip()` has already done its work.
+    if (middlewareData.arrow) {
+      return {};
+    }
+
     const side = getSide(placement);
     const isBasePlacement = getSide(initialPlacement) === initialPlacement;
     const rtl = await platform.isRTL?.(elements.floating);


### PR DESCRIPTION
Fixes https://github.com/floating-ui/floating-ui/issues/2549