### PR TITLE
feat(arrow): `alignmentOffset` data

### DIFF
--- a/.changeset/clever-seals-carry.md
+++ b/.changeset/clever-seals-carry.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/core': minor
+---
+
+feat(arrow): add `alignmentOffset` data

--- a/packages/core/src/middleware/arrow.ts
+++ b/packages/core/src/middleware/arrow.ts
@@ -100,15 +100,16 @@ export const arrow = (
         0;
     const alignmentOffset = shouldAddOffset
       ? center < min
-        ? min - center
-        : max - center
+        ? center - min
+        : center - max
       : 0;
 
     return {
-      [axis]: coords[axis] - alignmentOffset,
+      [axis]: coords[axis] + alignmentOffset,
       data: {
         [axis]: offset,
-        centerOffset: center - offset + alignmentOffset,
+        centerOffset: center - offset - alignmentOffset,
+        ...(shouldAddOffset && {alignmentOffset}),
       },
       reset: shouldAddOffset,
     };

--- a/packages/core/src/middleware/flip.ts
+++ b/packages/core/src/middleware/flip.ts
@@ -90,10 +90,11 @@ export const flip = (
       ...detectOverflowOptions
     } = evaluate(options, state);
 
-    // If the arrow data is available, it's caused a reset, so we should skip
-    // any logic now since `flip()` has already done its work.
+    // If a reset by the arrow was caused due to an alignment offset being
+    // added, we should skip any logic now since `flip()` has already done its
+    // work.
     // https://github.com/floating-ui/floating-ui/issues/2549#issuecomment-1719601643
-    if (middlewareData.arrow) {
+    if (middlewareData.arrow?.alignmentOffset) {
       return {};
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -70,6 +70,7 @@ export interface MiddlewareData {
   [key: string]: any;
   arrow?: Partial<Coords> & {
     centerOffset: number;
+    alignmentOffset?: number;
   };
   autoPlacement?: {
     index?: number;


### PR DESCRIPTION
- Adds `alignmentOffset` data if the arrow caused shifting of the floating element. Reduces potential for a breaking change if `arrow()` is placed before `flip()` in middleware arrays (should not be done, but technically worked.)