### PR TITLE
feat(useFocus): `visibleOnly` option

### DIFF
--- a/.changeset/dirty-phones-pay.md
+++ b/.changeset/dirty-phones-pay.md
@@ -1,0 +1,6 @@
+---
+'@floating-ui/react': minor
+---
+
+feat(useFocus): replace `keyboardOnly` option with `visibleOnly` (matches
+:focus-visible CSS selector)

--- a/packages/react/test/unit/useDismiss.test.tsx
+++ b/packages/react/test/unit/useDismiss.test.tsx
@@ -482,7 +482,7 @@ describe('bubbles', () => {
           useDismiss(popover.context),
         ]);
         const tooltipInteractions = useInteractions([
-          useFocus(tooltip.context),
+          useFocus(tooltip.context, {visibleOnly: false}),
           useDismiss(tooltip.context),
         ]);
 

--- a/packages/react/test/unit/useFocus.test.tsx
+++ b/packages/react/test/unit/useFocus.test.tsx
@@ -39,7 +39,7 @@ function App(props: UseFocusProps & {dismiss?: boolean; hover?: boolean}) {
 }
 
 test('opens on focus', () => {
-  render(<App />);
+  render(<App visibleOnly={false} />);
   const button = screen.getByRole('button');
   fireEvent.focus(button);
   expect(screen.queryByRole('tooltip')).toBeInTheDocument();

--- a/packages/react/test/visual/components/Omnibox.tsx
+++ b/packages/react/test/visual/components/Omnibox.tsx
@@ -125,10 +125,7 @@ export function Main() {
 
   const hasOptions = options.length > 0;
 
-  const focus = useFocus(context, {
-    enabled: hasOptions && isFocusEnabled,
-    keyboardOnly: false,
-  });
+  const focus = useFocus(context, {enabled: hasOptions && isFocusEnabled});
   const dismiss = useDismiss(context);
   const role = useRole(context, {enabled: hasOptions, role: 'listbox'});
   const listNavigation = useListNavigation(context, {


### PR DESCRIPTION
This replaces `keyboardOnly` since it better does what should be intended (matching `:focus-visible` selector).

Closes #2574