### PR TITLE
fix(useFocus): avoid blur close only on browser page blur

### DIFF
--- a/.changeset/six-boxes-decide.md
+++ b/.changeset/six-boxes-decide.md
@@ -1,6 +1,5 @@
 ---
 '@floating-ui/react': patch
-'@floating-ui/utils': patch
 ---
 
-fix(activeElement): traverse iframes
+fix(useFocus): close on blur only if focus remains in document

--- a/.changeset/six-boxes-decide.md
+++ b/.changeset/six-boxes-decide.md
@@ -1,0 +1,6 @@
+---
+'@floating-ui/react': patch
+'@floating-ui/utils': patch
+---
+
+fix(activeElement): traverse iframes

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -1,13 +1,9 @@
-import {
-  getNodeName,
-  getWindow,
-  isElement,
-  isHTMLElement,
-} from '@floating-ui/utils/dom';
+import {getWindow, isElement, isHTMLElement} from '@floating-ui/utils/dom';
 import {
   activeElement,
   contains,
   getDocument,
+  isSafari,
   isTypeableElement,
 } from '@floating-ui/utils/react';
 import * as React from 'react';
@@ -116,6 +112,10 @@ export function useFocus<RT extends ReferenceType = ReferenceType>(
 
           if (visibleOnly) {
             try {
+              // Safari unreliably matches `:focus-visible` on the reference
+              // if focus was outside the page initially - use the fallback
+              // instead.
+              if (isSafari()) throw Error();
               if (!event.target.matches(':focus-visible')) return;
             } catch (e) {
               // Old browsers will throw an error when using `:focus-visible`.

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -148,7 +148,12 @@ export function useFocus<RT extends ReferenceType = ReferenceType>(
             );
 
             // Focus left the page, keep it open.
-            if (!activeEl || getNodeName(activeEl) === 'body') return;
+            if (
+              (!relatedTarget && activeEl === domReference) ||
+              !activeEl ||
+              getNodeName(activeEl) === 'body'
+            )
+              return;
 
             // When focusing the reference element (e.g. regular click), then
             // clicking into the floating element, prevent it from hiding.

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -1,4 +1,9 @@
-import {getWindow, isElement, isHTMLElement} from '@floating-ui/utils/dom';
+import {
+  getNodeName,
+  getWindow,
+  isElement,
+  isHTMLElement,
+} from '@floating-ui/utils/dom';
 import {
   activeElement,
   contains,
@@ -129,8 +134,6 @@ export function useFocus<RT extends ReferenceType = ReferenceType>(
           blockFocusRef.current = false;
           const relatedTarget = event.relatedTarget;
 
-          if (!relatedTarget) return;
-
           // Hit the non-modal focus management portal guard. Focus will be
           // moved into the floating element immediately after.
           const movedToFocusGuard =
@@ -140,6 +143,13 @@ export function useFocus<RT extends ReferenceType = ReferenceType>(
 
           // Wait for the window blur listener to fire.
           timeoutRef.current = window.setTimeout(() => {
+            const activeEl = activeElement(
+              domReference ? domReference.ownerDocument : document
+            );
+
+            // Focus left the page, keep it open.
+            if (!activeEl || getNodeName(activeEl) === 'body') return;
+
             // When focusing the reference element (e.g. regular click), then
             // clicking into the floating element, prevent it from hiding.
             // Note: it must be focusable, e.g. `tabindex="-1"`.

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -148,12 +148,7 @@ export function useFocus<RT extends ReferenceType = ReferenceType>(
             );
 
             // Focus left the page, keep it open.
-            if (
-              (!relatedTarget && activeEl === domReference) ||
-              !activeEl ||
-              getNodeName(activeEl) === 'body'
-            )
-              return;
+            if (!relatedTarget && activeEl === domReference) return;
 
             // When focusing the reference element (e.g. regular click), then
             // clicking into the floating element, prevent it from hiding.

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -3,6 +3,7 @@ import {
   activeElement,
   contains,
   getDocument,
+  getTarget,
   isSafari,
   isTypeableElement,
 } from '@floating-ui/utils/react';
@@ -110,19 +111,18 @@ export function useFocus<RT extends ReferenceType = ReferenceType>(
         onFocus(event) {
           if (blockFocusRef.current) return;
 
-          if (visibleOnly) {
+          const target = getTarget(event.nativeEvent);
+
+          if (visibleOnly && isElement(target)) {
             try {
               // Safari unreliably matches `:focus-visible` on the reference
               // if focus was outside the page initially - use the fallback
               // instead.
               if (isSafari()) throw Error();
-              if (!event.target.matches(':focus-visible')) return;
+              if (!target.matches(':focus-visible')) return;
             } catch (e) {
               // Old browsers will throw an error when using `:focus-visible`.
-              if (
-                !keyboardModalityRef.current &&
-                !isTypeableElement(event.target)
-              ) {
+              if (!keyboardModalityRef.current && !isTypeableElement(target)) {
                 return;
               }
             }

--- a/packages/utils/react/src/index.ts
+++ b/packages/utils/react/src/index.ts
@@ -1,26 +1,13 @@
-import {getNodeName, isHTMLElement, isShadowRoot} from '@floating-ui/utils/dom';
+import {isHTMLElement, isShadowRoot} from '@floating-ui/utils/dom';
 
-export function activeElement(doc: Document): Element | null {
-  // Traverse shadow roots.
-  let result = doc.activeElement;
-  while (result?.shadowRoot?.activeElement) {
-    result = result.shadowRoot.activeElement;
+export function activeElement(doc: Document) {
+  let activeElement = doc.activeElement;
+
+  while (activeElement?.shadowRoot?.activeElement != null) {
+    activeElement = activeElement.shadowRoot.activeElement;
   }
 
-  if (!result || getNodeName(result) === 'body') {
-    try {
-      // Check parent documents.
-      const parentDocument =
-        result?.ownerDocument.defaultView?.frameElement?.ownerDocument;
-      if (parentDocument) {
-        return activeElement(parentDocument);
-      }
-    } catch (e) {
-      return null;
-    }
-  }
-
-  return result;
+  return activeElement;
 }
 
 export function contains(parent?: Element | null, child?: Element | null) {

--- a/packages/utils/react/src/index.ts
+++ b/packages/utils/react/src/index.ts
@@ -1,13 +1,24 @@
-import {isHTMLElement, isShadowRoot} from '@floating-ui/utils/dom';
+import {getNodeName, isHTMLElement, isShadowRoot} from '@floating-ui/utils/dom';
 
-export function activeElement(doc: Document) {
-  let activeElement = doc.activeElement;
-
-  while (activeElement?.shadowRoot?.activeElement != null) {
-    activeElement = activeElement.shadowRoot.activeElement;
+export function activeElement(doc: Document): Element | null {
+  // Traverse shadow roots
+  let result = doc.activeElement;
+  while (result?.shadowRoot?.activeElement) {
+    result = result.shadowRoot.activeElement;
   }
 
-  return activeElement;
+  if (!result || getNodeName(result) === 'body') {
+    // Check allowed parent documents
+    const parentDocument =
+      result?.ownerDocument.defaultView?.frameElement?.ownerDocument;
+    if (parentDocument) {
+      return activeElement(parentDocument);
+    }
+  }
+
+  console.log({result});
+
+  return result;
 }
 
 export function contains(parent?: Element | null, child?: Element | null) {

--- a/packages/utils/react/src/index.ts
+++ b/packages/utils/react/src/index.ts
@@ -16,8 +16,6 @@ export function activeElement(doc: Document): Element | null {
     }
   }
 
-  console.log({result});
-
   return result;
 }
 

--- a/packages/utils/react/src/index.ts
+++ b/packages/utils/react/src/index.ts
@@ -1,18 +1,22 @@
 import {getNodeName, isHTMLElement, isShadowRoot} from '@floating-ui/utils/dom';
 
 export function activeElement(doc: Document): Element | null {
-  // Traverse shadow roots
+  // Traverse shadow roots.
   let result = doc.activeElement;
   while (result?.shadowRoot?.activeElement) {
     result = result.shadowRoot.activeElement;
   }
 
   if (!result || getNodeName(result) === 'body') {
-    // Check allowed parent documents
-    const parentDocument =
-      result?.ownerDocument.defaultView?.frameElement?.ownerDocument;
-    if (parentDocument) {
-      return activeElement(parentDocument);
+    try {
+      // Check parent documents.
+      const parentDocument =
+        result?.ownerDocument.defaultView?.frameElement?.ownerDocument;
+      if (parentDocument) {
+        return activeElement(parentDocument);
+      }
+    } catch (e) {
+      return null;
     }
   }
 


### PR DESCRIPTION
Fixes #2575 

This amends `activeElement` function to traverse (allowed) iframe parent documents to find the active element. If it's `null` or the `body`, then it's assumed focus left the page into the chrome/elsewhere, so the blur should be ignored. This should fix local iframe issues while ensuring the floating element doesn't close on blur in other situations unwantedly 