### PR TITLE
fix(utils): restore react path for v0.1.x

### DIFF
--- a/.changeset/strong-geckos-shave.md
+++ b/.changeset/strong-geckos-shave.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/utils': patch
+---
+
+fix: restore /react path

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,13 +12,16 @@
   "files": [
     "dist/",
     "dom/dist/",
+    "react/dist/",
     "dom/package.json",
+    "react/package.json",
     "**/*.d.ts",
     "**/*.d.mts"
   ],
   "exports": {
     "./package.json": "./package.json",
     "./dom/package.json": "./dom/package.json",
+    "./react/package.json": "./react/package.json",
     ".": {
       "import": {
         "types": "./src/types.d.ts",
@@ -36,6 +39,15 @@
       "types": "./dom/src/index.d.ts",
       "module": "./dom/dist/floating-ui.utils.dom.esm.js",
       "default": "./dom/dist/floating-ui.utils.dom.umd.js"
+    },
+    "./react": {
+      "import": {
+        "types": "./react/src/index.d.ts",
+        "default": "./react/dist/floating-ui.utils.react.mjs"
+      },
+      "types": "./react/src/index.d.ts",
+      "module": "./react/dist/floating-ui.utils.react.esm.js",
+      "default": "./react/dist/floating-ui.utils.react.umd.js"
     }
   },
   "scripts": {

--- a/packages/utils/react/package.json
+++ b/packages/utils/react/package.json
@@ -1,0 +1,6 @@
+{
+  "sideEffects": false,
+  "main": "./dist/floating-ui.utils.react.umd.js",
+  "module": "./dist/floating-ui.utils.react.esm.js",
+  "types": "./src/types.d.ts"
+}

--- a/packages/utils/react/src/index.ts
+++ b/packages/utils/react/src/index.ts
@@ -1,0 +1,181 @@
+import {isHTMLElement, isShadowRoot} from '@floating-ui/utils/dom';
+
+export function activeElement(doc: Document) {
+  let activeElement = doc.activeElement;
+
+  while (activeElement?.shadowRoot?.activeElement != null) {
+    activeElement = activeElement.shadowRoot.activeElement;
+  }
+
+  return activeElement;
+}
+
+export function contains(parent?: Element | null, child?: Element | null) {
+  if (!parent || !child) {
+    return false;
+  }
+
+  const rootNode = child.getRootNode && child.getRootNode();
+
+  // First, attempt with faster native method
+  if (parent.contains(child)) {
+    return true;
+  }
+
+  // then fallback to custom implementation with Shadow DOM support
+  if (rootNode && isShadowRoot(rootNode)) {
+    let next = child;
+    while (next) {
+      if (parent === next) {
+        return true;
+      }
+      // @ts-ignore
+      next = next.parentNode || next.host;
+    }
+  }
+
+  // Give up, the result is false
+  return false;
+}
+
+interface NavigatorUAData {
+  brands: Array<{brand: string; version: string}>;
+  mobile: boolean;
+  platform: string;
+}
+
+// Avoid Chrome DevTools blue warning.
+export function getPlatform(): string {
+  const uaData = (navigator as any).userAgentData as
+    | NavigatorUAData
+    | undefined;
+
+  if (uaData?.platform) {
+    return uaData.platform;
+  }
+
+  return navigator.platform;
+}
+
+export function getUserAgent(): string {
+  const uaData = (navigator as any).userAgentData as
+    | NavigatorUAData
+    | undefined;
+
+  if (uaData && Array.isArray(uaData.brands)) {
+    return uaData.brands
+      .map(({brand, version}) => `${brand}/${version}`)
+      .join(' ');
+  }
+
+  return navigator.userAgent;
+}
+
+// License: https://github.com/adobe/react-spectrum/blob/b35d5c02fe900badccd0cf1a8f23bb593419f238/packages/@react-aria/utils/src/isVirtualEvent.ts
+export function isVirtualClick(event: MouseEvent | PointerEvent): boolean {
+  if ((event as any).mozInputSource === 0 && event.isTrusted) {
+    return true;
+  }
+
+  const androidRe = /Android/i;
+  if (
+    (androidRe.test(getPlatform()) || androidRe.test(getUserAgent())) &&
+    (event as PointerEvent).pointerType
+  ) {
+    return event.type === 'click' && event.buttons === 1;
+  }
+
+  return event.detail === 0 && !(event as PointerEvent).pointerType;
+}
+
+export function isVirtualPointerEvent(event: PointerEvent) {
+  return (
+    (event.width === 0 && event.height === 0) ||
+    (event.width === 1 &&
+      event.height === 1 &&
+      event.pressure === 0 &&
+      event.detail === 0 &&
+      event.pointerType !== 'mouse') ||
+    // iOS VoiceOver returns 0.333• for width/height.
+    (event.width < 1 &&
+      event.height < 1 &&
+      event.pressure === 0 &&
+      event.detail === 0)
+  );
+}
+
+export function isSafari() {
+  // Chrome DevTools does not complain about navigator.vendor
+  return /apple/i.test(navigator.vendor);
+}
+
+export function isMac() {
+  return (
+    getPlatform().toLowerCase().startsWith('mac') && !navigator.maxTouchPoints
+  );
+}
+
+export function isMouseLikePointerType(
+  pointerType: string | undefined,
+  strict?: boolean
+) {
+  // On some Linux machines with Chromium, mouse inputs return a `pointerType`
+  // of "pen": https://github.com/floating-ui/floating-ui/issues/2015
+  const values: Array<string | undefined> = ['mouse', 'pen'];
+  if (!strict) {
+    values.push('', undefined);
+  }
+  return values.includes(pointerType);
+}
+
+export function isReactEvent(event: any): event is React.SyntheticEvent {
+  return 'nativeEvent' in event;
+}
+
+export function isRootElement(element: Element): boolean {
+  return element.matches('html,body');
+}
+
+export function getDocument(node: Element | null) {
+  return node?.ownerDocument || document;
+}
+
+export function isEventTargetWithin(
+  event: Event,
+  node: Node | null | undefined
+) {
+  if (node == null) {
+    return false;
+  }
+
+  if ('composedPath' in event) {
+    return event.composedPath().includes(node);
+  }
+
+  // TS thinks `event` is of type never as it assumes all browsers support composedPath, but browsers without shadow dom don't
+  const e = event as Event;
+  return e.target != null && node.contains(e.target as Node);
+}
+
+export function getTarget(event: Event) {
+  if ('composedPath' in event) {
+    return event.composedPath()[0];
+  }
+
+  // TS thinks `event` is of type never as it assumes all browsers support
+  // `composedPath()`, but browsers without shadow DOM don't.
+  return (event as Event).target;
+}
+
+export const TYPEABLE_SELECTOR =
+  "input:not([type='hidden']):not([disabled])," +
+  "[contenteditable]:not([contenteditable='false']),textarea:not([disabled])";
+
+export function isTypeableElement(element: unknown): boolean {
+  return isHTMLElement(element) && element.matches(TYPEABLE_SELECTOR);
+}
+
+export function stopEvent(event: Event | React.SyntheticEvent) {
+  event.preventDefault();
+  event.stopPropagation();
+}

--- a/packages/utils/react/src/types.ts
+++ b/packages/utils/react/src/types.ts
@@ -1,0 +1,1 @@
+export * from './';

--- a/packages/utils/rollup.config.mjs
+++ b/packages/utils/rollup.config.mjs
@@ -53,6 +53,33 @@ const bundles = [
       format: 'umd',
     },
   },
+  // React
+  {
+    input: './react/src/index.ts',
+    output: {
+      file: './react/dist/floating-ui.utils.react.esm.js',
+      format: 'esm',
+    },
+  },
+  {
+    input: './react/src/index.ts',
+    output: {
+      file: './react/dist/floating-ui.utils.react.mjs',
+      name: 'FloatingUIUtilsReact',
+      format: 'esm',
+    },
+  },
+  {
+    input: './react/src/index.ts',
+    output: {
+      file: './react/dist/floating-ui.utils.react.umd.js',
+      name: 'FloatingUIUtilsReact',
+      format: 'umd',
+      globals: {
+        '@floating-ui/utils/dom': 'FloatingUIUtilsDOM',
+      },
+    },
+  },
 ];
 
 export default bundles.map(({input, output}) => ({
@@ -62,6 +89,7 @@ export default bundles.map(({input, output}) => ({
     '@floating-ui/core',
     '@floating-ui/utils',
     '@floating-ui/utils/dom',
+    '@floating-ui/utils/react',
   ],
   plugins: [
     nodeResolve({extensions: ['.ts']}),


### PR DESCRIPTION
New installs of old versions of `@floating-ui/react` install `^v0.1.x`, so the `/react` path has to be kept in the `utils` package for those versions for now. A separate release will be made to bump utils to `v0.2.x` to prevent this issue later on.

Fixes https://github.com/floating-ui/floating-ui/discussions/2588