### PR TITLE
fix(useDismiss): add capture phase option for useDismiss

### DIFF
--- a/.changeset/seven-elephants-lay.md
+++ b/.changeset/seven-elephants-lay.md
@@ -2,4 +2,4 @@
 "@floating-ui/react": patch
 ---
 
-feat(useDismiss): add `capture` option and default `outsidePress` and `escapeKey` to `true`
+feat(useDismiss): add `capture` option and default `outsidePress` to `true`

--- a/.changeset/seven-elephants-lay.md
+++ b/.changeset/seven-elephants-lay.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+feat(useDismiss): add `capture` option and default `outsidePress` and `escapeKey` to `true`

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -285,11 +285,11 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
   });
 
   const closeOnPressOutsideCapture = useEffectEvent((event: MouseEvent) => {
-    event.target?.addEventListener(
-      outsidePressEvent,
-      () => closeOnPressOutside(event),
-      {once: true}
-    );
+    const callback = () => {
+      closeOnPressOutside(event);
+      event.target?.removeEventListener(outsidePressEvent, callback);
+    };
+    event.target?.addEventListener(outsidePressEvent, callback);
   });
 
   React.useEffect(() => {
@@ -310,9 +310,7 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
       doc.addEventListener(
         outsidePressEvent,
         capture ? closeOnPressOutsideCapture : closeOnPressOutside,
-        {
-          capture,
-        }
+        capture
       );
 
     let ancestors: (Element | Window | VisualViewport)[] = [];
@@ -348,9 +346,7 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
         doc.removeEventListener(
           outsidePressEvent,
           capture ? closeOnPressOutsideCapture : closeOnPressOutside,
-          {
-            capture,
-          }
+          capture
         );
       ancestors.forEach((ancestor) => {
         ancestor.removeEventListener('scroll', onScroll);

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -287,9 +287,9 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
   const closeOnPressOutsideCapture = useEffectEvent((event: MouseEvent) => {
     const callback = () => {
       closeOnPressOutside(event);
-      event.target?.removeEventListener(outsidePressEvent, callback);
+      getTarget(event)?.removeEventListener(outsidePressEvent, callback);
     };
-    event.target?.addEventListener(outsidePressEvent, callback);
+    getTarget(event)?.addEventListener(outsidePressEvent, callback);
   });
 
   React.useEffect(() => {

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -284,7 +284,7 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
     onOpenChange(false, event);
   });
 
-  const lazyCloseOnPressOutside = useEffectEvent((event: MouseEvent) => {
+  const closeOnPressOutsideCapture = useEffectEvent((event: MouseEvent) => {
     event.target?.addEventListener(
       outsidePressEvent,
       () => closeOnPressOutside(event),
@@ -307,9 +307,13 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
     const doc = getDocument(floating);
     escapeKey && doc.addEventListener('keydown', closeOnEscapeKeyDown);
     outsidePress &&
-      doc.addEventListener(outsidePressEvent, lazyCloseOnPressOutside, {
-        capture,
-      });
+      doc.addEventListener(
+        outsidePressEvent,
+        capture ? closeOnPressOutsideCapture : closeOnPressOutside,
+        {
+          capture,
+        }
+      );
 
     let ancestors: (Element | Window | VisualViewport)[] = [];
 
@@ -341,9 +345,13 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
     return () => {
       escapeKey && doc.removeEventListener('keydown', closeOnEscapeKeyDown);
       outsidePress &&
-        doc.removeEventListener(outsidePressEvent, lazyCloseOnPressOutside, {
-          capture,
-        });
+        doc.removeEventListener(
+          outsidePressEvent,
+          capture ? closeOnPressOutsideCapture : closeOnPressOutside,
+          {
+            capture,
+          }
+        );
       ancestors.forEach((ancestor) => {
         ancestor.removeEventListener('scroll', onScroll);
       });
@@ -365,7 +373,7 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
     closeOnEscapeKeyDown,
     closeOnPressOutside,
     capture,
-    lazyCloseOnPressOutside,
+    closeOnPressOutsideCapture,
   ]);
 
   React.useEffect(() => {

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -63,10 +63,10 @@ export interface UseDismissProps {
   referencePress?: boolean;
   referencePressEvent?: 'pointerdown' | 'mousedown' | 'click';
   outsidePress?: boolean | ((event: MouseEvent) => boolean);
+  outsidePressCapture?: boolean;
   outsidePressEvent?: 'pointerdown' | 'mousedown' | 'click';
   ancestorScroll?: boolean;
   bubbles?: boolean | {escapeKey?: boolean; outsidePress?: boolean};
-  capture?: boolean;
 }
 
 /**
@@ -90,12 +90,12 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
     enabled = true,
     escapeKey = true,
     outsidePress: unstable_outsidePress = true,
+    outsidePressCapture = true,
     outsidePressEvent = 'pointerdown',
     referencePress = false,
     referencePressEvent = 'pointerdown',
     ancestorScroll = false,
     bubbles,
-    capture = true,
   } = props;
 
   const tree = useFloatingTree();
@@ -309,8 +309,8 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
     outsidePress &&
       doc.addEventListener(
         outsidePressEvent,
-        capture ? closeOnPressOutsideCapture : closeOnPressOutside,
-        capture
+        outsidePressCapture ? closeOnPressOutsideCapture : closeOnPressOutside,
+        outsidePressCapture
       );
 
     let ancestors: (Element | Window | VisualViewport)[] = [];
@@ -345,8 +345,10 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
       outsidePress &&
         doc.removeEventListener(
           outsidePressEvent,
-          capture ? closeOnPressOutsideCapture : closeOnPressOutside,
-          capture
+          outsidePressCapture
+            ? closeOnPressOutsideCapture
+            : closeOnPressOutside,
+          outsidePressCapture
         );
       ancestors.forEach((ancestor) => {
         ancestor.removeEventListener('scroll', onScroll);
@@ -368,7 +370,7 @@ export function useDismiss<RT extends ReferenceType = ReferenceType>(
     outsidePressBubbles,
     closeOnEscapeKeyDown,
     closeOnPressOutside,
-    capture,
+    outsidePressCapture,
     closeOnPressOutsideCapture,
   ]);
 

--- a/packages/react/test/unit/useDismiss.test.tsx
+++ b/packages/react/test/unit/useDismiss.test.tsx
@@ -14,10 +14,7 @@ import {
   useFocus,
   useInteractions,
 } from '../../src';
-import {
-  normalizeBubblesProp,
-  UseDismissProps,
-} from '../../src/hooks/useDismiss';
+import {normalizeProp, UseDismissProps} from '../../src/hooks/useDismiss';
 
 function App(props: UseDismissProps) {
   const [open, setOpen] = useState(true);
@@ -354,40 +351,44 @@ describe('bubbles', () => {
 
   describe('prop resolution', () => {
     test('undefined', () => {
-      const {escapeKeyBubbles, outsidePressBubbles} = normalizeBubblesProp();
+      const {escapeKey: escapeKeyBubbles, outsidePress: outsidePressBubbles} =
+        normalizeProp();
 
       expect(escapeKeyBubbles).toBe(false);
       expect(outsidePressBubbles).toBe(true);
     });
 
     test('false', () => {
-      const {escapeKeyBubbles, outsidePressBubbles} =
-        normalizeBubblesProp(false);
+      const {escapeKey: escapeKeyBubbles, outsidePress: outsidePressBubbles} =
+        normalizeProp(false);
 
       expect(escapeKeyBubbles).toBe(false);
       expect(outsidePressBubbles).toBe(false);
     });
 
     test('{}', () => {
-      const {escapeKeyBubbles, outsidePressBubbles} = normalizeBubblesProp({});
+      const {escapeKey: escapeKeyBubbles, outsidePress: outsidePressBubbles} =
+        normalizeProp({});
 
       expect(escapeKeyBubbles).toBe(false);
       expect(outsidePressBubbles).toBe(true);
     });
 
     test('{ escapeKey: false }', () => {
-      const {escapeKeyBubbles, outsidePressBubbles} = normalizeBubblesProp({
-        escapeKey: false,
-      });
+      const {escapeKey: escapeKeyBubbles, outsidePress: outsidePressBubbles} =
+        normalizeProp({
+          escapeKey: false,
+        });
 
       expect(escapeKeyBubbles).toBe(false);
       expect(outsidePressBubbles).toBe(true);
     });
 
     test('{ outsidePress: false }', () => {
-      const {escapeKeyBubbles, outsidePressBubbles} = normalizeBubblesProp({
-        outsidePress: false,
-      });
+      const {escapeKey: escapeKeyBubbles, outsidePress: outsidePressBubbles} =
+        normalizeProp({
+          outsidePress: false,
+        });
 
       expect(escapeKeyBubbles).toBe(false);
       expect(outsidePressBubbles).toBe(false);


### PR DESCRIPTION
fixes
- #2345 
- #2594 

In the document capture phase, a main handler is added to `event.target`, and during the "AT_TARGET" phase, the handler is executed to operate the logic that determines `insideReactTree`.