### PR TITLE
fix(FloatingFocusManager): avoid returnFocus if focus moved elsewhere

### DIFF
--- a/.changeset/twelve-jeans-hope.md
+++ b/.changeset/twelve-jeans-hope.md
@@ -1,0 +1,6 @@
+---
+'@floating-ui/react': patch
+---
+
+fix(FloatingFocusManager): avoid returning focus to reference if focus moved
+elsewhere

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -422,17 +422,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
         });
       }
     };
-  }, [
-    disabled,
-    floating,
-    returnFocusRef,
-    dataRef,
-    refs,
-    events,
-    tree,
-    nodeId,
-    domReference,
-  ]);
+  }, [disabled, floating, returnFocusRef, dataRef, refs, events, tree, nodeId]);
 
   // Synchronize the `context` & `modal` value to the FloatingPortal context.
   // It will decide whether or not it needs to render its own guards.

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -385,12 +385,14 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
       events.off('dismiss', onDismiss);
 
       const activeEl = activeElement(doc);
-      const shouldFocusReference =
+      const isFocusInsideFloatingTree =
         contains(floating, activeEl) ||
         (tree &&
           getChildren(tree.nodesRef.current, nodeId).some((node) =>
             contains(node.context?.elements.floating, activeEl)
-          )) ||
+          ));
+      const shouldFocusReference =
+        isFocusInsideFloatingTree ||
         (contextData.openEvent &&
           ['click', 'mousedown'].includes(contextData.openEvent.type));
 
@@ -402,7 +404,13 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
         // eslint-disable-next-line react-hooks/exhaustive-deps
         returnFocusRef.current &&
         isHTMLElement(previouslyFocusedElementRef.current) &&
-        !preventReturnFocusRef.current
+        !preventReturnFocusRef.current &&
+        // If the focus moved somewhere else after mount, avoid returning focus
+        // since it likely entered a different element which should be
+        // respected: https://github.com/floating-ui/floating-ui/issues/2607
+        (previouslyFocusedElement !== activeEl
+          ? isFocusInsideFloatingTree
+          : true)
       ) {
         enqueueFocus(previouslyFocusedElementRef.current, {
           // When dismissing nested floating elements, by the time the rAF has
@@ -414,7 +422,17 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
         });
       }
     };
-  }, [disabled, floating, returnFocusRef, dataRef, refs, events, tree, nodeId]);
+  }, [
+    disabled,
+    floating,
+    returnFocusRef,
+    dataRef,
+    refs,
+    events,
+    tree,
+    nodeId,
+    domReference,
+  ]);
 
   // Synchronize the `context` & `modal` value to the FloatingPortal context.
   // It will decide whether or not it needs to render its own guards.


### PR DESCRIPTION
Fixes #2607