### PR TITLE
Clarify the purpose of react-dom and react in getting-started.mdx

### DIFF
--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -64,22 +64,28 @@ npm install @floating-ui/dom
 
 ### React
 
-Use with [React](/docs/react) or
-[React Native](/docs/react-native).
-
-#### React DOM (only positioning)
-
-```bash
-npm install @floating-ui/react-dom
-```
-
-#### React (all features)
+Use with [React](/docs/react).
 
 ```bash
 npm install @floating-ui/react
 ```
 
-#### React Native
+<Notice>
+
+A smaller alternative to the above package exists, which only
+wraps `@floating-ui/dom` positioning features without any
+interactions:
+
+```bash
+# Positioning only (smaller size)
+npm install @floating-ui/react-dom
+```
+
+</Notice>
+
+### React Native
+
+Use with [React Native](/docs/react-native).
 
 ```bash
 npm install @floating-ui/react-native

--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -64,10 +64,16 @@ npm install @floating-ui/dom
 
 ### React
 
-Use with [React DOM](/docs/react) or
+Use with [React](/docs/react) or
 [React Native](/docs/react-native).
 
-#### React DOM
+#### React DOM (only positioning)
+
+```bash
+npm install @floating-ui/react-dom
+```
+
+#### React (all features)
 
 ```bash
 npm install @floating-ui/react


### PR DESCRIPTION
Hello Federico and atomiks! 👋🏼😊

Thank you very much for having made popper.js/floating-ui and maintaining them all these years 🙌🏼

I wanted to integrate floating-ui for positioning only (as I use other libraries for interactions) and started reading the documentation on the "Getting Started" page. I thought it'd be better if the Getting Started page already had the positioning-only-package install command, as their difference isn't clear until the user goes to the /docs/react page.

I used the same language found on /docs/react page for consistency.