### PR TITLE
feat(useRole): Extended useRole Hook to Support Additional Role Types

### DIFF
--- a/packages/react/src/hooks/useRole.ts
+++ b/packages/react/src/hooks/useRole.ts
@@ -3,6 +3,8 @@ import * as React from 'react';
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import {useId} from './useId';
 
+type TypeKeys = 'tooltip' | 'label' | 'autocomplete' | 'select' | 'multiselect';
+
 export interface UseRoleProps {
   enabled?: boolean;
   role?:
@@ -14,7 +16,12 @@ export interface UseRoleProps {
     | 'listbox'
     | 'grid'
     | 'tree';
+  type?: TypeKeys;
 }
+
+type FloatingProps = {
+  [key: string]: string | boolean | undefined;
+};
 
 /**
  * Adds base screen reader props to the reference and floating elements for a
@@ -26,17 +33,63 @@ export function useRole<RT extends ReferenceType = ReferenceType>(
   props: UseRoleProps = {}
 ): ElementProps {
   const {open, floatingId} = context;
-  const {enabled = true, role = 'dialog'} = props;
+  const {enabled = true, role = 'dialog', type} = props;
 
   const referenceId = useId();
+
+  if (
+    role &&
+    ![
+      'tooltip',
+      'label',
+      'dialog',
+      'alertdialog',
+      'menu',
+      'listbox',
+      'grid',
+      'tree',
+    ].includes(role)
+  ) {
+    throw new Error(`Invalid role: ${role}`);
+  }
+
+  if (
+    type &&
+    !['tooltip', 'label', 'autocomplete', 'select', 'multiselect'].includes(
+      type
+    )
+  ) {
+    throw new Error(`Invalid type: ${type}`);
+  }
 
   return React.useMemo(() => {
     if (!enabled) return {};
 
-    const floatingProps = {
+    const floatingProps: FloatingProps = {
       id: floatingId,
       ...(role !== 'label' && {role}),
     };
+
+    const typeToAriaProp: Record<TypeKeys, string> = {
+      tooltip: 'aria-describedby',
+      label: 'aria-labelledby',
+      autocomplete: 'aria-autocomplete',
+      select: 'aria-haspopup',
+      multiselect: 'aria-multiselectable',
+    };
+
+    const typeToAriaValue: Partial<Record<TypeKeys, string>> = {
+      autocomplete: 'both',
+      select: 'listbox',
+      multiselect: 'true',
+    };
+
+    if (type) {
+      const ariaProp = typeToAriaProp[type];
+      if (ariaProp) {
+        floatingProps[ariaProp] = typeToAriaValue[type] || floatingId;
+      }
+    }
 
     if (role === 'tooltip' || role === 'label') {
       return {
@@ -68,5 +121,5 @@ export function useRole<RT extends ReferenceType = ReferenceType>(
         }),
       },
     };
-  }, [enabled, role, open, floatingId, referenceId]);
+  }, [enabled, floatingId, role, type, open, referenceId]);
 }

--- a/packages/react/test/unit/useRole.test.tsx
+++ b/packages/react/test/unit/useRole.test.tsx
@@ -214,3 +214,39 @@ describe('listbox', () => {
     cleanup();
   });
 });
+
+describe('type prop', () => {
+  test('tooltip type sets correct aria attribute', () => {
+    render(<App type="tooltip" initiallyOpen />);
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-describedby');
+    cleanup();
+  });
+
+  test('label type sets correct aria attribute', () => {
+    render(<App type="label" initiallyOpen />);
+    const floatingElement = screen.getByRole('dialog');
+    expect(floatingElement).toHaveAttribute('aria-labelledby');
+    cleanup();
+  });
+
+  test('autocomplete type sets correct aria attribute', () => {
+    render(<App type="autocomplete" initiallyOpen />);
+    const floatingElement = screen.getByRole('dialog');
+    expect(floatingElement).toHaveAttribute('aria-autocomplete', 'both');
+    cleanup();
+  });
+
+  test('select type sets correct aria attribute', () => {
+    render(<App type="select" initiallyOpen />);
+    const floatingElement = screen.getByRole('dialog');
+    expect(floatingElement).toHaveAttribute('aria-haspopup', 'listbox');
+    cleanup();
+  });
+
+  test('multiselect type sets correct aria attribute', () => {
+    render(<App type="multiselect" initiallyOpen />);
+    const floatingElement = screen.getByRole('dialog');
+    expect(floatingElement).toHaveAttribute('aria-multiselectable', 'true');
+    cleanup();
+  });
+});


### PR DESCRIPTION
Hey folks,

I've been tinkering with the `useRole` hook and added some cool stuff based on requirements [here](https://github.com/floating-ui/floating-ui/issues/2099). Now, we can specify more role types like `tooltip`, `label`, `autocomplete`, `select`, and `multiselect`. This should help components play nicer with screen readers.

I've also added some checks to make sure we're using valid roles and types. If something's off, it'll throw an error.

I'm no expert in screen readers or accessibility, but I think these changes will make a difference. They should make the `useRole` hook more flexible and easier to use, especially for those tricky cases where we need custom configurations.

Looking forward to hearing your thoughts!