### PR TITLE
fix(FloatingFocusManager): return focus to last connected node

### DIFF
--- a/.changeset/four-lions-rhyme.md
+++ b/.changeset/four-lions-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/react': patch
+---
+
+fix(FloatingFocusManager): return focus to last connected elementx

--- a/.changeset/four-lions-rhyme.md
+++ b/.changeset/four-lions-rhyme.md
@@ -2,4 +2,4 @@
 '@floating-ui/react': patch
 ---
 
-fix(FloatingFocusManager): return focus to last connected elementx
+fix(FloatingFocusManager): return focus to last connected element

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -31,6 +31,29 @@ import {usePortalContext} from './FloatingPortal';
 import {useFloatingTree} from './FloatingTree';
 import {FocusGuard, HIDDEN_STYLES} from './FocusGuard';
 
+const LIST_LIMIT = 20;
+let previouslyFocusedElements: Element[] = [];
+
+function addPreviouslyFocusedElement(element: Element | null) {
+  previouslyFocusedElements = previouslyFocusedElements.filter(
+    (el) => el.isConnected,
+  );
+
+  if (element && getNodeName(element) !== 'body') {
+    previouslyFocusedElements.push(element);
+    if (previouslyFocusedElements.length > LIST_LIMIT) {
+      previouslyFocusedElements = previouslyFocusedElements.slice(-LIST_LIMIT);
+    }
+  }
+}
+
+function getPreviouslyFocusedElement() {
+  return previouslyFocusedElements
+    .slice()
+    .reverse()
+    .find((el) => el.isConnected);
+}
+
 const VisuallyHiddenDismiss = React.forwardRef(function VisuallyHiddenDismiss(
   props: React.ButtonHTMLAttributes<HTMLButtonElement>,
   ref: React.Ref<HTMLButtonElement>,
@@ -59,29 +82,6 @@ export interface FloatingFocusManagerProps<
   modal?: boolean;
   visuallyHiddenDismiss?: boolean | string;
   closeOnFocusOut?: boolean;
-}
-
-let previouslyFocusedElements: Element[] = [];
-const LIST_LIMIT = 20;
-
-function addPreviouslyFocusedElement(element: Element | null) {
-  previouslyFocusedElements = previouslyFocusedElements.filter(
-    (el) => el.isConnected,
-  );
-
-  if (element && getNodeName(element) !== 'body') {
-    previouslyFocusedElements.push(element);
-    if (previouslyFocusedElements.length > LIST_LIMIT) {
-      previouslyFocusedElements = previouslyFocusedElements.slice(-LIST_LIMIT);
-    }
-  }
-}
-
-function getPreviouslyFocusedElement() {
-  return previouslyFocusedElements
-    .slice()
-    .reverse()
-    .find((el) => el.isConnected);
 }
 
 /**

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -267,7 +267,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
           movedToUnrelatedNode &&
           !isPointerDownRef.current &&
           // Fix React 18 Strict Mode returnFocus due to double rendering.
-          !previouslyFocusedElements.includes(relatedTarget)
+          relatedTarget !== getPreviouslyFocusedElement()
         ) {
           preventReturnFocusRef.current = true;
           onOpenChange(false, event);


### PR DESCRIPTION
Fixes https://github.com/floating-ui/floating-ui/issues/2607#issuecomment-1805222878

I'm not really sure about this solution, which keeps a rolling window of the last 10 elements that focus can return to.