### PR TITLE
feat(useRole): allow item props

### DIFF
--- a/.changeset/shy-cars-mate.md
+++ b/.changeset/shy-cars-mate.md
@@ -2,5 +2,5 @@
 '@floating-ui/react': patch
 ---
 
-feat(useRole): add `select` and `combobox` roles and allow dynamic/derivable
-item props
+feat(useRole): add `select` and `combobox` component roles and allow
+dynamic/derivable item props based on `active` and `selected` states

--- a/.changeset/shy-cars-mate.md
+++ b/.changeset/shy-cars-mate.md
@@ -3,4 +3,6 @@
 ---
 
 feat(useRole): add `select` and `combobox` component roles and allow
-dynamic/derivable item props based on `active` and `selected` states
+dynamic/derivable item props based on `active` and `selected` states. Also adds
+`menuitem` role for nested `menu` reference elements, and automatically adds an
+`id` to the item props for the new component roles for virtual focus.

--- a/.changeset/shy-cars-mate.md
+++ b/.changeset/shy-cars-mate.md
@@ -1,0 +1,6 @@
+---
+'@floating-ui/react': patch
+---
+
+feat(useRole): add `select` and `combobox` roles and allow dynamic/derivable
+item props

--- a/.changeset/small-chairs-invite.md
+++ b/.changeset/small-chairs-invite.md
@@ -2,5 +2,6 @@
 '@floating-ui/react': patch
 ---
 
-fix(useListNavigation): apply descendant prop on floating element only for
-non-typeable combobox references
+fix(useListNavigation): apply `aria-activedescendant` prop on floating element
+only for non typeable-combobox reference elements. Fixes issues with Firefox
+VoiceOver on Mac forcing DOM focus into the listbox.

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -99,7 +99,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
     guards: _guards = true,
     initialFocus = 0,
     returnFocus = true,
-    modal: originalModal = true,
+    modal = true,
     visuallyHiddenDismiss = false,
     closeOnFocusOut = true,
   } = props;
@@ -122,7 +122,6 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
   // start.
   const isUntrappedTypeableCombobox =
     isTypeableCombobox(domReference) && ignoreInitialFocus;
-  const modal = isUntrappedTypeableCombobox ? false : originalModal;
 
   // Force the guards to be rendered if the `inert` attribute is not supported.
   const guards = supportsInert() ? _guards : true;
@@ -318,7 +317,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
       ].filter((x): x is Element => x != null);
 
       const cleanup =
-        originalModal || isUntrappedTypeableCombobox
+        modal || isUntrappedTypeableCombobox
           ? markOthers(insideElements, guards, !guards)
           : markOthers(insideElements);
 
@@ -330,7 +329,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
     disabled,
     domReference,
     floating,
-    originalModal,
+    modal,
     orderRef,
     portalContext,
     isUntrappedTypeableCombobox,

--- a/packages/react/src/hooks/useInteractions.ts
+++ b/packages/react/src/hooks/useInteractions.ts
@@ -2,18 +2,40 @@ import * as React from 'react';
 
 import type {ElementProps} from '../types';
 
-function mergeProps(
-  userProps: React.HTMLProps<Element> | undefined,
+const ACTIVE_KEY = 'active';
+const SELECTED_KEY = 'selected';
+
+export type ExtendedUserProps = {
+  [ACTIVE_KEY]?: boolean;
+  [SELECTED_KEY]?: boolean;
+};
+
+function mergeProps<Key extends keyof ElementProps>(
+  userProps: (React.HTMLProps<Element> & ExtendedUserProps) | undefined,
   propsList: Array<ElementProps | void>,
-  elementKey: 'reference' | 'floating' | 'item',
+  elementKey: Key,
 ): Record<string, unknown> {
   const map = new Map<string, Array<(...args: unknown[]) => void>>();
+  const isItem = elementKey === 'item';
+
+  let domUserProps = userProps;
+  if (isItem && userProps) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const {[ACTIVE_KEY]: _, [SELECTED_KEY]: __, ...validProps} = userProps;
+    domUserProps = validProps;
+  }
 
   return {
     ...(elementKey === 'floating' && {tabIndex: -1}),
-    ...userProps,
+    ...domUserProps,
     ...propsList
-      .map((value) => (value ? value[elementKey] : null))
+      .map((value) => {
+        const propsOrGetProps = value ? value[elementKey] : null;
+        if (typeof propsOrGetProps === 'function') {
+          return userProps ? propsOrGetProps(userProps) : null;
+        }
+        return propsOrGetProps;
+      })
       .concat(userProps)
       .reduce((acc: Record<string, unknown>, props) => {
         if (!props) {
@@ -21,6 +43,10 @@ function mergeProps(
         }
 
         Object.entries(props).forEach(([key, value]) => {
+          if (isItem && [ACTIVE_KEY, SELECTED_KEY].includes(key)) {
+            return;
+          }
+
           if (key.indexOf('on') === 0) {
             if (!map.has(key)) {
               map.set(key, []);
@@ -72,8 +98,12 @@ export function useInteractions(propsList: Array<ElementProps | void> = []) {
   );
 
   const getItemProps = React.useCallback(
-    (userProps?: React.HTMLProps<HTMLElement>) =>
-      mergeProps(userProps, propsList, 'item'),
+    (
+      userProps?: Omit<React.HTMLProps<HTMLElement>, 'selected' | 'active'> & {
+        selected?: boolean;
+        active?: boolean;
+      },
+    ) => mergeProps(userProps, propsList, 'item'),
     // Granularly check for `item` changes, because the `getItemProps` getter
     // should be as referentially stable as possible since it may be passed as
     // a prop to many components. All `item` key values must therefore be

--- a/packages/react/src/hooks/useInteractions.ts
+++ b/packages/react/src/hooks/useInteractions.ts
@@ -99,10 +99,8 @@ export function useInteractions(propsList: Array<ElementProps | void> = []) {
 
   const getItemProps = React.useCallback(
     (
-      userProps?: Omit<React.HTMLProps<HTMLElement>, 'selected' | 'active'> & {
-        selected?: boolean;
-        active?: boolean;
-      },
+      userProps?: Omit<React.HTMLProps<HTMLElement>, 'selected' | 'active'> &
+        ExtendedUserProps,
     ) => mergeProps(userProps, propsList, 'item'),
     // Granularly check for `item` changes, because the `getItemProps` getter
     // should be as referentially stable as possible since it may be passed as

--- a/packages/react/src/hooks/useRole.ts
+++ b/packages/react/src/hooks/useRole.ts
@@ -84,18 +84,23 @@ export function useRole<RT extends ReferenceType = ReferenceType>(
         ...(ariaRole === 'menu' && {'aria-labelledby': referenceId}),
       },
       item({active, selected}) {
+        const commonProps = {
+          role: 'option',
+          ...(active && {id: `${floatingId}-option`}),
+        };
+
         // For `menu`, we are unable to tell if the item is a `menuitemradio`
         // or `menuitemcheckbox`. For backwards-compatibility reasons, also
         // avoid defaulting to `menuitem` as it may overwrite custom role props.
         switch (role) {
           case 'select':
             return {
-              role: 'option',
+              ...commonProps,
               'aria-selected': active && selected,
             };
           case 'combobox': {
             return {
-              role: 'option',
+              ...commonProps,
               ...(active && {'aria-selected': true}),
             };
           }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -5,6 +5,8 @@ import type {
 } from '@floating-ui/react-dom';
 import type * as React from 'react';
 
+import type {ExtendedUserProps} from './hooks/useInteractions';
+
 export * from '.';
 export {FloatingArrowProps} from './components/FloatingArrow';
 export {FloatingFocusManagerProps} from './components/FloatingFocusManager';
@@ -156,7 +158,9 @@ export interface FloatingTreeType<RT extends ReferenceType = ReferenceType> {
 export interface ElementProps {
   reference?: React.HTMLProps<Element>;
   floating?: React.HTMLProps<HTMLElement>;
-  item?: React.HTMLProps<HTMLElement>;
+  item?:
+    | React.HTMLProps<HTMLElement>
+    | ((props: ExtendedUserProps) => React.HTMLProps<HTMLElement>);
 }
 
 export type ReferenceType = Element | VirtualElement;

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -1200,7 +1200,11 @@ test('untrapped combobox creates non-modal focus management', async () => {
         />
         {isOpen && (
           <FloatingPortal>
-            <FloatingFocusManager context={context} initialFocus={-1}>
+            <FloatingFocusManager
+              context={context}
+              initialFocus={-1}
+              modal={false}
+            >
               <div
                 ref={refs.setFloating}
                 style={floatingStyles}

--- a/packages/react/test/unit/useRole.test.tsx
+++ b/packages/react/test/unit/useRole.test.tsx
@@ -1,7 +1,13 @@
 import {cleanup, fireEvent, render, screen} from '@testing-library/react';
 import {useState} from 'react';
 
-import {useFloating, useId, useInteractions, useRole} from '../../src';
+import {
+  useClick,
+  useFloating,
+  useId,
+  useInteractions,
+  useRole,
+} from '../../src';
 import type {UseRoleProps} from '../../src/hooks/useRole';
 
 function App({
@@ -203,6 +209,136 @@ describe('listbox', () => {
     );
     expect(button.hasAttribute('aria-describedby')).toBe(false);
     expect(button.getAttribute('aria-expanded')).toBe('true');
+
+    fireEvent.click(button);
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(button.hasAttribute('aria-controls')).toBe(false);
+    expect(button.hasAttribute('aria-describedby')).toBe(false);
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+
+    cleanup();
+  });
+});
+
+describe('select', () => {
+  test('sets correct aria attributes based on the open state', () => {
+    function Select() {
+      const [isOpen, setIsOpen] = useState(false);
+      const {refs, context} = useFloating({
+        open: isOpen,
+        onOpenChange: setIsOpen,
+      });
+      const {getReferenceProps, getFloatingProps, getItemProps} =
+        useInteractions([
+          useClick(context),
+          useRole(context, {role: 'select'}),
+        ]);
+      return (
+        <>
+          <button ref={refs.setReference} {...getReferenceProps()} />
+          {isOpen && (
+            <div ref={refs.setFloating} {...getFloatingProps()}>
+              {[1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  data-testid={`item-${i}`}
+                  {...getItemProps({active: i === 2, selected: i === 2})}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      );
+    }
+
+    render(<Select />);
+
+    const button = screen.getByRole('combobox');
+
+    expect(button.getAttribute('aria-haspopup')).toBe('listbox');
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(button);
+
+    expect(screen.queryByRole('listbox')).toBeInTheDocument();
+    expect(button.getAttribute('aria-controls')).toBe(
+      screen.getByRole('listbox').getAttribute('id'),
+    );
+    expect(button.hasAttribute('aria-describedby')).toBe(false);
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    expect(button.getAttribute('aria-autocomplete')).toBe('none');
+    expect(screen.getByTestId('item-1').getAttribute('aria-selected')).toBe(
+      'false',
+    );
+    expect(screen.getByTestId('item-2').getAttribute('aria-selected')).toBe(
+      'true',
+    );
+
+    fireEvent.click(button);
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(button.hasAttribute('aria-controls')).toBe(false);
+    expect(button.hasAttribute('aria-describedby')).toBe(false);
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+
+    cleanup();
+  });
+});
+
+describe('combobox', () => {
+  test('sets correct aria attributes based on the open state', () => {
+    function Select() {
+      const [isOpen, setIsOpen] = useState(false);
+      const {refs, context} = useFloating({
+        open: isOpen,
+        onOpenChange: setIsOpen,
+      });
+      const {getReferenceProps, getFloatingProps, getItemProps} =
+        useInteractions([
+          useClick(context),
+          useRole(context, {role: 'combobox'}),
+        ]);
+      return (
+        <>
+          <input ref={refs.setReference} {...getReferenceProps()} />
+          {isOpen && (
+            <div ref={refs.setFloating} {...getFloatingProps()}>
+              {[1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  data-testid={`item-${i}`}
+                  {...getItemProps({active: i === 2, selected: i === 2})}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      );
+    }
+
+    render(<Select />);
+
+    const button = screen.getByRole('combobox');
+
+    expect(button.getAttribute('aria-haspopup')).toBe('listbox');
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(button);
+
+    expect(screen.queryByRole('listbox')).toBeInTheDocument();
+    expect(button.getAttribute('aria-controls')).toBe(
+      screen.getByRole('listbox').getAttribute('id'),
+    );
+    expect(button.hasAttribute('aria-describedby')).toBe(false);
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    expect(button.getAttribute('aria-autocomplete')).toBe('list');
+    expect(screen.getByTestId('item-1').getAttribute('aria-selected')).toBe(
+      null,
+    );
+    expect(screen.getByTestId('item-2').getAttribute('aria-selected')).toBe(
+      'true',
+    );
 
     fireEvent.click(button);
 

--- a/packages/react/test/visual/components/Autocomplete.tsx
+++ b/packages/react/test/visual/components/Autocomplete.tsx
@@ -7,7 +7,6 @@ import {
   size,
   useDismiss,
   useFloating,
-  useId,
   useInteractions,
   useListNavigation,
   useRole,
@@ -160,16 +159,12 @@ const Item = forwardRef<
   HTMLDivElement,
   ItemProps & React.HTMLProps<HTMLDivElement>
 >(({children, active, ...rest}, ref) => {
-  const id = useId();
   return (
     <div
       ref={ref}
       className={c('p-2 cursor-default', {
         'bg-blue-500 text-white': active,
       })}
-      role="option"
-      id={id}
-      aria-selected={active}
       {...rest}
     >
       {children}
@@ -204,7 +199,7 @@ export function Main() {
   });
 
   const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
-    useRole(context, {role: 'listbox'}),
+    useRole(context, {role: 'combobox'}),
     useDismiss(context),
     useListNavigation(context, {
       listRef,
@@ -271,8 +266,9 @@ export function Main() {
               >
                 {items.map((item, index) => (
                   <Item
+                    key={item}
                     {...getItemProps({
-                      key: item,
+                      active: activeIndex === index,
                       ref(node) {
                         listRef.current[index] = node;
                       },

--- a/packages/react/test/visual/components/Autocomplete.tsx
+++ b/packages/react/test/visual/components/Autocomplete.tsx
@@ -162,6 +162,7 @@ const Item = forwardRef<
   return (
     <div
       ref={ref}
+      tabIndex={-1}
       className={c('p-2 cursor-default', {
         'bg-blue-500 text-white': active,
       })}

--- a/packages/react/test/visual/components/MacSelect.tsx
+++ b/packages/react/test/visual/components/MacSelect.tsx
@@ -260,7 +260,7 @@ export function Main() {
   const {getReferenceProps, getFloatingProps, getItemProps} = useInteractions([
     useClick(context, {event: 'mousedown'}),
     useDismiss(context),
-    useRole(context, {role: 'listbox'}),
+    useRole(context, {role: 'select'}),
     useInnerOffset(context, {
       enabled: !fallback,
       onChange: setInnerOffset,
@@ -373,9 +373,6 @@ export function Main() {
                           // Prevent immediate selection on touch devices when
                           // pressing the ScrollArrows
                           disabled={blockSelection}
-                          aria-selected={selectedIndex === i}
-                          role="option"
-                          tabIndex={activeIndex === i ? 0 : -1}
                           style={{
                             background:
                               activeIndex === i
@@ -390,6 +387,8 @@ export function Main() {
                             listContentRef.current[i] = text;
                           }}
                           {...getItemProps({
+                            active: activeIndex === i,
+                            selected: selectedIndex === i,
                             onTouchStart() {
                               allowSelectRef.current = true;
                               allowMouseUpRef.current = false;

--- a/packages/react/test/visual/components/MacSelect.tsx
+++ b/packages/react/test/visual/components/MacSelect.tsx
@@ -382,6 +382,7 @@ export function Main() {
                                   : 'transparent',
                             fontWeight: i === selectedIndex ? 'bold' : 'normal',
                           }}
+                          tabIndex={i === activeIndex ? 0 : -1}
                           ref={(node) => {
                             listRef.current[i] = node;
                             listContentRef.current[i] = text;

--- a/packages/react/test/visual/components/Menu.tsx
+++ b/packages/react/test/visual/components/Menu.tsx
@@ -283,6 +283,7 @@ export const MenuItem = React.forwardRef<
       {...props}
       ref={useMergeRefs([item.ref, forwardedRef])}
       type="button"
+      role="menuitem"
       disabled={disabled}
       tabIndex={isActive ? 0 : -1}
       className={c(

--- a/packages/react/test/visual/components/Menu.tsx
+++ b/packages/react/test/visual/components/Menu.tsx
@@ -28,9 +28,7 @@ import c from 'clsx';
 import * as React from 'react';
 
 type MenuContextType = {
-  getItemProps: (
-    userProps?: React.HTMLProps<HTMLElement>,
-  ) => Record<string, unknown>;
+  getItemProps: ReturnType<typeof useInteractions>['getItemProps'];
   activeIndex: number | null;
   setActiveIndex: React.Dispatch<React.SetStateAction<number | null>>;
   setHasFocusInside: React.Dispatch<React.SetStateAction<boolean>>;
@@ -193,7 +191,6 @@ export const MenuComponent = React.forwardRef<
               ? 0
               : -1
         }
-        role={isNested ? 'menuitem' : undefined}
         className={c(
           props.className ||
             'text-left flex gap-4 justify-between items-center rounded py-1 px-2',
@@ -286,14 +283,14 @@ export const MenuItem = React.forwardRef<
       {...props}
       ref={useMergeRefs([item.ref, forwardedRef])}
       type="button"
-      role="menuitem"
-      tabIndex={isActive ? 0 : -1}
       disabled={disabled}
+      tabIndex={isActive ? 0 : -1}
       className={c(
         'text-left flex py-1 px-2 focus:bg-blue-500 focus:text-white outline-none rounded',
         {'opacity-40': disabled},
       )}
       {...menu.getItemProps({
+        active: isActive,
         onClick(event: React.MouseEvent<HTMLButtonElement>) {
           props.onClick?.(event);
           tree?.events.emit('click');

--- a/packages/react/test/visual/components/Select.tsx
+++ b/packages/react/test/visual/components/Select.tsx
@@ -31,10 +31,8 @@ function ColorSwatch({color}: {color?: string}) {
   );
 }
 
-const SelectContext = React.createContext<{
-  getItemProps: (
-    userProps?: React.HTMLProps<HTMLElement>,
-  ) => Record<string, unknown>;
+interface SelectContextData {
+  getItemProps: ReturnType<typeof useInteractions>['getItemProps'];
   activeIndex: number | null;
   selectedIndex: number | null;
   setActiveIndex: React.Dispatch<React.SetStateAction<number | null>>;
@@ -42,7 +40,9 @@ const SelectContext = React.createContext<{
   isTypingRef: React.MutableRefObject<boolean>;
   setSelectedValue: (value: string, index: number) => void;
   selectedValue: string;
-}>({} as any);
+}
+
+const SelectContext = React.createContext<SelectContextData>({} as any);
 
 function Select({
   children,
@@ -95,7 +95,7 @@ function Select({
 
   const click = useClick(context, {event: 'mousedown'});
   const dismiss = useDismiss(context);
-  const role = useRole(context, {role: 'listbox'});
+  const role = useRole(context, {role: 'select'});
   const listNav = useListNavigation(context, {
     listRef: elementsRef,
     activeIndex,
@@ -137,7 +137,6 @@ function Select({
           <Button
             ref={refs.setReference}
             aria-labelledby="select-label"
-            aria-autocomplete="none"
             data-open={isOpen ? '' : undefined}
             className="flex items-center gap-2 bg-slate-200 rounded w-[10rem]"
             {...getReferenceProps()}
@@ -191,13 +190,10 @@ const MemoOption = React.memo(
       getItemProps,
       onSelect,
       isTypingRef,
-    }: {
+    }: Pick<SelectContextData, 'getItemProps'> & {
       children: React.ReactNode;
       active: boolean;
       selected: boolean;
-      getItemProps: (
-        userProps?: React.HTMLProps<HTMLElement>,
-      ) => Record<string, unknown>;
       onSelect: () => void;
       isTypingRef: React.MutableRefObject<boolean>;
     },
@@ -206,9 +202,6 @@ const MemoOption = React.memo(
     return (
       <div
         ref={ref}
-        role="option"
-        tabIndex={active ? 0 : -1}
-        aria-selected={active && selected}
         className={c(
           'flex gap-2 items-center p-2 rounded outline-none cursor-default scroll-my-1',
           {
@@ -216,6 +209,8 @@ const MemoOption = React.memo(
           },
         )}
         {...getItemProps({
+          active,
+          selected,
           // Handle pointer select.
           onClick: onSelect,
           // Handle keyboard select.

--- a/packages/react/test/visual/components/Select.tsx
+++ b/packages/react/test/visual/components/Select.tsx
@@ -208,6 +208,7 @@ const MemoOption = React.memo(
             'bg-cyan-200': active,
           },
         )}
+        tabIndex={active ? 0 : -1}
         {...getItemProps({
           active,
           selected,


### PR DESCRIPTION
`role` gets extended with "component" roles, which are a step above base `aria` roles that also add item roles. Additional props based on these "component roles" are also added to the reference/floating element, if required.

```js
useRole(context, {
  role: 'select', // ariaRole === 'listbox'
});
```

The above generates `item` props: `role="option"`,  `aria-selected={boolean}`. These props get generated automatically as long as the call site of `getItemProps()` receives the `active` and `selected` props: `getItemProps({active, selected})`, since these are dependencies of the prop derivation.

Alternative to #2633
Closes #2099 