### PR TITLE
chore(devtools): bump version to 0.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17571,7 +17571,7 @@
     },
     "packages/devtools": {
       "name": "@floating-ui/devtools",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "peerDependencies": {
         "@floating-ui/dom": ">=1.0.0 <2.0.0"
       }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@floating-ui/devtools",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "scripts": {
     "test": "vitest --globals",
     "dev": "rollup -c -w",


### PR DESCRIPTION
Follow up on https://github.com/floating-ui/floating-ui/pull/2667

## changes

1. bumps version of `@floating-ui/devtools` from `0.0.1` to `0.0.2`