### PR TITLE
feat: onhover callbacks

### DIFF
--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -55,6 +55,8 @@ export function getDelay(
 export interface UseHoverProps<RT extends ReferenceType = ReferenceType> {
   enabled?: boolean;
   handleClose?: HandleCloseFn<RT> | null;
+  onHoverStartInitiated?: (event: Event) => void
+  onHoverCloseInitiated?: (event: Event) => void;
   restMs?: number;
   delay?: number | Partial<{open: number; close: number}>;
   mouseOnly?: boolean;
@@ -82,6 +84,8 @@ export function useHover<RT extends ReferenceType = ReferenceType>(
     enabled = true,
     delay = 0,
     handleClose = null,
+    onHoverStartInitiated = () => {},
+    onHoverCloseInitiated = () => {},
     mouseOnly = false,
     restMs = 0,
     move = true,
@@ -133,6 +137,7 @@ export function useHover<RT extends ReferenceType = ReferenceType>(
 
     function onLeave(event: MouseEvent) {
       if (isHoverOpen()) {
+        onHoverCloseInitiated(event);
         onOpenChange(false, event, 'hover');
       }
     }
@@ -146,6 +151,7 @@ export function useHover<RT extends ReferenceType = ReferenceType>(
     floating,
     open,
     onOpenChange,
+    onHoverCloseInitiated,
     enabled,
     handleCloseRef,
     dataRef,
@@ -165,16 +171,18 @@ export function useHover<RT extends ReferenceType = ReferenceType>(
       );
       if (closeDelay && !handlerRef.current) {
         clearTimeout(timeoutRef.current);
+        onHoverCloseInitiated(event);
         timeoutRef.current = setTimeout(
           () => onOpenChange(false, event, reason),
           closeDelay,
         );
       } else if (runElseBranch) {
         clearTimeout(timeoutRef.current);
+        onHoverCloseInitiated(event);
         onOpenChange(false, event, reason);
       }
     },
-    [delayRef, onOpenChange],
+    [delayRef, onOpenChange, onHoverCloseInitiated],
   );
 
   const cleanupMouseMoveHandler = React.useCallback(() => {
@@ -223,10 +231,12 @@ export function useHover<RT extends ReferenceType = ReferenceType>(
       );
 
       if (openDelay) {
+        onHoverStartInitiated(event);
         timeoutRef.current = setTimeout(() => {
           onOpenChange(true, event, 'hover');
         }, openDelay);
       } else {
+        onHoverStartInitiated(event);
         onOpenChange(true, event, 'hover');
       }
     }
@@ -329,6 +339,7 @@ export function useHover<RT extends ReferenceType = ReferenceType>(
     cleanupMouseMoveHandler,
     clearPointerEvents,
     onOpenChange,
+    onHoverStartInitiated,
     open,
     tree,
     delayRef,

--- a/website/pages/docs/useHover.mdx
+++ b/website/pages/docs/useHover.mdx
@@ -87,8 +87,8 @@ interface UseHoverProps {
   restMs?: number;
   move?: boolean;
   handleClose?: null | HandleCloseFn;
-  onHoverStartInitiated?: (event?: Event) => void
-  onHoverCloseInitiated?: (event?: Event) => void;
+  onHoverStartInitiated?: (event: Event) => void
+  onHoverCloseInitiated?: (event: Event) => void;
 }
 ```
 

--- a/website/pages/docs/useHover.mdx
+++ b/website/pages/docs/useHover.mdx
@@ -87,6 +87,8 @@ interface UseHoverProps {
   restMs?: number;
   move?: boolean;
   handleClose?: null | HandleCloseFn;
+  onHoverStartInitiated?: (event?: Event) => void
+  onHoverCloseInitiated?: (event?: Event) => void;
 }
 ```
 
@@ -210,6 +212,43 @@ This handler runs on `mousemove{:.string}`.
 
 For a simpler alternative, depending on the type of floating
 element, you can use a short close delay instead.
+
+
+### `onHoverStartInitiated{:.key}`
+
+default: `() => {}{:js}`
+
+This is a callback function that is invoked when the opening process of the floating element is initiated. It is called right before the `onOpenChange{:.function}` callback. This function receives the event that initiated the opening as an argument.
+
+It is usefull when you have an open delay, and you want to do something immediately when the opening process got started and cannot wait for the `onOpenChange{:.function}` callback.
+
+```ts
+import {useHover} from '@floating-ui/react';
+
+useHover(context, {
+  onHoverStartInitiated: (event: Event) => {
+    // Custom logic here...
+  },
+});
+```
+
+### `onHoverCloseInitiated{:.key}`
+
+default: `() => {}{:js}`
+
+This is a callback function that is invoked when the closing process of the floating element is initiated. It is called right before the `onOpenChange{:.function}` callback. This function receives the event that initiated the closing as an argument.
+
+It is usefull when you have a close delay, and you want to do something immediately when the closing process got started and cannot wait for the `onOpenChange{:.function}` callback.
+
+```ts
+import {useHover} from '@floating-ui/react';
+
+useHover(context, {
+  onHoverCloseInitiated: (event: Event) => {
+    // Custom logic here...
+  },
+});
+```
 
 ## safePolygon
 


### PR DESCRIPTION
### Description:

This pull request introduces new callback functions onHoverStartInitiated and onHoverCloseInitiated in the floating-ui library's React hook useHover. These additions enhance the library's capabilities by providing more control and flexibility in handling hover interactions.

### Key Changes:

- onHoverStartInitiated: This callback is triggered at the start of the hover process. It's useful for implementing immediate reactions to hover initiation, especially when there's a delay before the element opens.

- onHoverCloseInitiated: Similar to the above, this callback activates at the start of the hover close process. It's particularly handy for actions that need to occur right at the beginning of the closing phase.


<img width="791" alt="Screenshot 2023-12-20 at 19 44 10" src="https://github.com/floating-ui/floating-ui/assets/25705704/50ba3e5e-39c7-4211-af77-5043d8bfb52d">

<img width="778" alt="Screenshot 2023-12-20 at 19 45 27" src="https://github.com/floating-ui/floating-ui/assets/25705704/d8872058-c053-45d2-8a92-f870e5a45f74">


