### PR TITLE
bugfix(devtools): stop using crypto.randomUUID

### DIFF
--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -12,6 +12,4 @@ export type Serialized<T> = T extends (infer R)[]
         ? {[P in keyof T]: Serialized<T[P]>}
         : T;
 
-export type ReferenceId = `${typeof HTML_ELEMENT_REFERENCE}:${ReturnType<
-  typeof crypto.randomUUID
->}`;
+export type ReferenceId = `${typeof HTML_ELEMENT_REFERENCE}:${string}`;

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@floating-ui/devtools",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "scripts": {
     "test": "vitest --globals",
     "dev": "rollup -c -w",

--- a/packages/devtools/src/extension/types.ts
+++ b/packages/devtools/src/extension/types.ts
@@ -12,6 +12,4 @@ export type Serialized<T> = T extends (infer R)[]
         ? {[P in keyof T]: Serialized<T[P]>}
         : T;
 
-export type ReferenceId = `${typeof HTML_ELEMENT_REFERENCE}:${ReturnType<
-  typeof crypto.randomUUID
->}`;
+export type ReferenceId = `${typeof HTML_ELEMENT_REFERENCE}:${string}`;

--- a/packages/devtools/src/utils/references.ts
+++ b/packages/devtools/src/utils/references.ts
@@ -1,8 +1,9 @@
 import {HTML_ELEMENT_REFERENCE} from '../extension/constants';
 import type {ReferenceId} from '../extension/types';
 
+let counter = 0;
 const generateReferenceId = (): ReferenceId => {
-  return `${HTML_ELEMENT_REFERENCE}:${crypto.randomUUID()}`;
+  return `${HTML_ELEMENT_REFERENCE}:${counter++}`;
 };
 
 export type References = {


### PR DESCRIPTION
Fixes https://github.com/floating-ui/floating-ui/issues/2672

1. Stops using `crypto.randomUUID` as it requires a secure `https://` domain to work, instead simply create id's using a counter