### PR TITLE
fix(FloatingArrow): remove placement gap

### DIFF
--- a/packages/react/src/components/FloatingArrow.tsx
+++ b/packages/react/src/components/FloatingArrow.tsx
@@ -111,6 +111,8 @@ export const FloatingArrow = React.forwardRef(function FloatingArrow(
   const arrowX = arrow?.x != null ? staticOffset || arrow.x : '';
   const arrowY = arrow?.y != null ? staticOffset || arrow.y : '';
 
+  const placementGap = 0.5;
+
   const dValue =
     d ||
     'M0,0' +
@@ -141,8 +143,8 @@ export const FloatingArrow = React.forwardRef(function FloatingArrow(
         [yOffsetProp]: arrowY,
         [side]:
           isVerticalSide || isCustomShape
-            ? '100%'
-            : `calc(100% - ${strokeWidth / 2}px)`,
+            ? `calc(100% - ${placementGap}px)`
+            : `calc(100% - ${placementGap}px - ${strokeWidth / 2}px)`,
         transform: `${rotation}${transform ?? ''}`,
         ...restStyle,
       }}


### PR DESCRIPTION
First, i appreciate your good library :)

when i use FloatingArrow for using custom tooltip in my enterprise service, i found a gap between the arrow and the tooltip body.

Actually, It looked the same when I checked in the codesandbox in the official document. 
(https://codesandbox.io/s/floating-ui-react-scale-transform-origin-qv0t1c?file=/src/App.tsx)

You need to zoom in to find it and I'll attach the image file. :)

when i test Approximately 0.5 px was required to reduce the spacing.

If it's your intent, you can ignore the issue.

thank you 👍 

<img width="757" alt="placement" src="https://github.com/floating-ui/floating-ui/assets/26050574/7eba8241-555a-4b3e-b463-822b83275915">
