### PR TITLE
chore: adds typecheck command to verify types of every package

### DIFF
--- a/.github/actions/typescript/action.yml
+++ b/.github/actions/typescript/action.yml
@@ -5,5 +5,5 @@ runs:
   steps:
     - run: pnpm run lint
       shell: sh
-    - run: pnpm run build:api
+    - run: pnpm run typecheck
       shell: sh

--- a/extension/package.json
+++ b/extension/package.json
@@ -9,7 +9,8 @@
     "clean": "rimraf dist out-tsc",
     "storybook": "storybook dev",
     "build:storybook": "storybook build",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "typecheck": "tsc -b tsconfig.lib.json"
   },
   "dependencies": {
     "@floating-ui/devtools": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "publint": "turbo publint",
     "test": "turbo test",
     "prepack": "turbo prepack",
+    "typecheck": "turbo typecheck",
     "release": "turbo publint && changeset publish"
   },
   "author": "",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,8 @@
     "build": "rollup -c",
     "build:api": "build-api --tsc tsconfig.lib.json",
     "publint": "publint",
-    "prepack": "compat-exports"
+    "prepack": "compat-exports",
+    "typecheck": "tsc -b"
   },
   "author": "atomiks",
   "license": "MIT",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -8,7 +8,8 @@
     "build": "rollup -c",
     "build:api": "build-api",
     "publint": "publint",
-    "prepack": "compat-exports"
+    "prepack": "compat-exports",
+    "typecheck": "tsc -b"
   },
   "main": "./dist/floating-ui.devtools.umd.js",
   "module": "./dist/floating-ui.devtools.esm.js",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -37,7 +37,8 @@
     "test:watch": "vitest watch",
     "publint": "publint",
     "playwright": "playwright test ./test/functional",
-    "prepack": "compat-exports"
+    "prepack": "compat-exports",
+    "typecheck": "tsc -b"
   },
   "author": "atomiks",
   "license": "MIT",
@@ -63,6 +64,7 @@
   "devDependencies": {
     "config": "workspace:*",
     "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react": "^4.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -33,6 +33,18 @@ export const computePosition = (
 };
 
 export {autoUpdate} from './autoUpdate';
+export {
+  arrow,
+  autoPlacement,
+  detectOverflow,
+  flip,
+  hide,
+  inline,
+  limitShift,
+  offset,
+  shift,
+  size,
+} from './middleware';
 export {platform} from './platform';
 export type {
   ArrowOptions,
@@ -78,17 +90,5 @@ export type {
   Side,
   SideObject,
   Strategy,
-} from '@floating-ui/core';
-export {
-  arrow,
-  autoPlacement,
-  detectOverflow,
-  flip,
-  hide,
-  inline,
-  limitShift,
-  offset,
-  shift,
-  size,
 } from '@floating-ui/core';
 export {getOverflowAncestors} from '@floating-ui/utils/dom';

--- a/packages/dom/src/middleware.ts
+++ b/packages/dom/src/middleware.ts
@@ -1,0 +1,105 @@
+import type {
+  Coords,
+  Derivable,
+  InlineOptions,
+  LimitShiftOptions,
+} from '@floating-ui/core';
+import {
+  arrow as arrowCore,
+  autoPlacement as autoPlacementCore,
+  flip as flipCore,
+  hide as hideCore,
+  inline as inlineCore,
+  limitShift as limitShiftCore,
+  shift as shiftCore,
+  size as sizeCore,
+} from '@floating-ui/core';
+
+import type {
+  ArrowOptions,
+  AutoPlacementOptions,
+  FlipOptions,
+  HideOptions,
+  Middleware,
+  MiddlewareState,
+  ShiftOptions,
+  SizeOptions,
+} from './types';
+
+export {detectOverflow, offset} from '@floating-ui/core';
+
+/**
+ * Optimizes the visibility of the floating element by choosing the placement
+ * that has the most space available automatically, without needing to specify a
+ * preferred placement. Alternative to `flip`.
+ * @see https://floating-ui.com/docs/autoPlacement
+ */
+export const autoPlacement: (
+  options?: AutoPlacementOptions | Derivable<AutoPlacementOptions>,
+) => Middleware = autoPlacementCore;
+
+/**
+ * Optimizes the visibility of the floating element by shifting it in order to
+ * keep it in view when it will overflow the clipping boundary.
+ * @see https://floating-ui.com/docs/shift
+ */
+export const shift: (
+  options?: ShiftOptions | Derivable<ShiftOptions>,
+) => Middleware = shiftCore;
+
+/**
+ * Optimizes the visibility of the floating element by flipping the `placement`
+ * in order to keep it in view when the preferred placement(s) will overflow the
+ * clipping boundary. Alternative to `autoPlacement`.
+ * @see https://floating-ui.com/docs/flip
+ */
+export const flip: (
+  options?: FlipOptions | Derivable<FlipOptions>,
+) => Middleware = flipCore;
+
+/**
+ * Provides data that allows you to change the size of the floating element —
+ * for instance, prevent it from overflowing the clipping boundary or match the
+ * width of the reference element.
+ * @see https://floating-ui.com/docs/size
+ */
+export const size: (
+  options?: SizeOptions | Derivable<SizeOptions>,
+) => Middleware = sizeCore;
+
+/**
+ * Provides data to hide the floating element in applicable situations, such as
+ * when it is not in the same clipping context as the reference element.
+ * @see https://floating-ui.com/docs/hide
+ */
+export const hide: (
+  options?: HideOptions | Derivable<HideOptions>,
+) => Middleware = hideCore;
+
+/**
+ * Provides data to position an inner element of the floating element so that it
+ * appears centered to the reference element.
+ * @see https://floating-ui.com/docs/arrow
+ */
+export const arrow: (
+  options: ArrowOptions | Derivable<ArrowOptions>,
+) => Middleware = arrowCore;
+
+/**
+ * Provides improved positioning for inline reference elements that can span
+ * over multiple lines, such as hyperlinks or range selections.
+ * @see https://floating-ui.com/docs/inline
+ */
+export const inline: (
+  options?: InlineOptions | Derivable<InlineOptions>,
+) => Middleware = inlineCore;
+
+/**
+ * Built-in `limiter` that will stop `shift()` at a certain point.
+ */
+export const limitShift: (
+  options?: LimitShiftOptions | Derivable<LimitShiftOptions>,
+) => {
+  options: any;
+  fn: (state: MiddlewareState) => Coords;
+} = limitShiftCore;

--- a/packages/dom/test/index.test-d.ts
+++ b/packages/dom/test/index.test-d.ts
@@ -1,4 +1,4 @@
-import type {Middleware} from '.';
+import type {Middleware} from '../src';
 import {
   arrow,
   autoPlacement,
@@ -12,7 +12,7 @@ import {
   platform,
   shift,
   size,
-} from '.';
+} from '../src';
 
 // @ts-expect-error
 computePosition();

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -33,7 +33,8 @@
     "build": "rollup -c",
     "build:api": "build-api --tsc tsconfig.lib.json",
     "publint": "publint",
-    "prepack": "compat-exports"
+    "prepack": "compat-exports",
+    "typecheck": "tsc -b"
   },
   "author": "atomiks",
   "license": "MIT",

--- a/packages/react-dom/test/index.test-d.tsx
+++ b/packages/react-dom/test/index.test-d.tsx
@@ -1,6 +1,6 @@
 import {useRef} from 'react';
 
-import {arrow, offset, platform, shift, useFloating} from '.';
+import {arrow, offset, platform, shift, useFloating} from '../src';
 
 App;
 function App() {

--- a/packages/react-native/index.test-d.tsx
+++ b/packages/react-native/index.test-d.tsx
@@ -1,7 +1,7 @@
 import {useRef} from 'react';
 import {View} from 'react-native';
 
-import {arrow, offset, shift, useFloating} from '.';
+import {arrow, offset, shift, useFloating} from './src';
 
 App;
 function App() {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -16,9 +16,10 @@
     "lint": "eslint .",
     "clean": "rimraf dist out-tsc",
     "build": "rollup -c",
-    "build:api": "build-api",
+    "build:api": "build-api --tsc tsconfig.lib.json",
     "publint": "publint",
-    "prepack": "compat-exports"
+    "prepack": "compat-exports",
+    "typecheck": "tsc -b"
   },
   "author": "atomiks",
   "license": "MIT",

--- a/packages/react-native/tsconfig.json
+++ b/packages/react-native/tsconfig.json
@@ -2,9 +2,11 @@
   "extends": "config/tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ES2020"],
-    "outDir": "out-tsc",
-    "types": []
+    "outDir": "out-tsc"
   },
-  "include": ["src"],
-  "references": [{"path": "../core/tsconfig.lib.json"}]
+  "include": [],
+  "references": [
+    {"path": "./tsconfig.lib.json"},
+    {"path": "./tsconfig.test.json"}
+  ]
 }

--- a/packages/react-native/tsconfig.lib.json
+++ b/packages/react-native/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "config/tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2020"],
+    "outDir": "out-tsc",
+    "composite": true,
+    "types": []
+  },
+  "include": ["src"],
+  "references": [{"path": "../core/tsconfig.lib.json"}]
+}

--- a/packages/react-native/tsconfig.test.json
+++ b/packages/react-native/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "config/tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2020"],
+    "outDir": "out-tsc",
+    "composite": true,
+    "jsx": "react-jsx",
+    "types": []
+  },
+  "files": ["index.test-d.tsx"],
+  "references": [{"path": "./tsconfig.lib.json"}]
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -44,7 +44,8 @@
     "build:api": "build-api --tsc tsconfig.lib.json --aec api-extractor.json --aec api-extractor.utils.json",
     "dev": "vite",
     "publint": "publint",
-    "prepack": "compat-exports"
+    "prepack": "compat-exports",
+    "typecheck": "tsc -b"
   },
   "author": "atomiks",
   "license": "MIT",

--- a/packages/react/test/index.test-d.tsx
+++ b/packages/react/test/index.test-d.tsx
@@ -16,7 +16,7 @@ import {
   useMergeRefs,
   useRole,
   useTypeahead,
-} from '.';
+} from '../src';
 
 App;
 function App() {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -53,7 +53,8 @@
     "build": "rollup -c",
     "build:api": "build-api --tsc tsconfig.lib.json --aec api-extractor.json --aec api-extractor.dom.json --aec api-extractor.react.json",
     "publint": "publint",
-    "prepack": "compat-exports"
+    "prepack": "compat-exports",
+    "typecheck": "tsc -b"
   },
   "author": "atomiks",
   "license": "MIT",

--- a/packages/utils/tsconfig.test.json
+++ b/packages/utils/tsconfig.test.json
@@ -4,5 +4,5 @@
     "outDir": "out-tsc"
   },
   "include": ["test", "vite.config.mts"],
-  "references": [{"path": "./tsconfig.lib.json"}]
+  "references": [{"path": "./tsconfig.lib.json"}, {"path": "../../config"}]
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -34,7 +34,8 @@
     "build:api": "build-api --tsc tsconfig.lib.json",
     "dev": "vite",
     "publint": "publint",
-    "prepack": "compat-exports"
+    "prepack": "compat-exports",
+    "typecheck": "tsc -b"
   },
   "author": "lozinsky",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       '@types/react':
         specifier: ^18.2.45
         version: 18.2.46
+      '@types/react-dom':
+        specifier: ^18.2.18
+        version: 18.2.18
       '@vitejs/plugin-react':
         specifier: ^4.2.0
         version: 4.2.1(vite@5.0.10)

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,7 @@
       ]
     },
     "build:api": {
+      "dependsOn": ["^build:api"],
       "outputs": ["dist/**/*.d{.ts,.mts}"],
       "inputs": [
         "src/**",
@@ -22,6 +23,11 @@
         "api-extractor.json",
         "api-extractor.*.json"
       ]
+    },
+    "typecheck": {
+      "dependsOn": ["^typecheck"],
+      "outputs": ["out-tsc/**"],
+      "inputs": ["src/**", "test/**", "tsconfig.json", "tsconfig.*.json"]
     },
     "publint": {
       "dependsOn": ["prepack"],


### PR DESCRIPTION
Follow up on https://github.com/floating-ui/floating-ui/pull/2677#issuecomment-1874861287

1. adds `typecheck` command to run `tsc -b` for every single package
2. move `*-d.ts{,x}` files to `test` folders to be included in types verification
3. modifies CI gh action to use `pnpm run typecheck` instead of `pnpm run build:api`
4. redeclares middlewares from `core` at `dom` [with more specific types](https://github.com/floating-ui/floating-ui/pull/2687/files#diff-df833d72712902a450cc9e36309797cbe2109bd425ada294461da6229cce1882) (this was mistakenly removed by https://github.com/floating-ui/floating-ui/pull/2677/files#diff-b5f898db2c0f33da655f0da10d2aa08eb272bd34c63b177adb3a2b38157de73f)

## Remaining problems

Seems like types for the `extension` package stories are having some conflict problems between multiple vite versions (v4 and v5), for now I've omitted stories from the typechecking, I'll investigate more later on