### PR TITLE
Fix initial keyboard focus on Grid navigation

### DIFF
--- a/packages/react/src/utils/composite.ts
+++ b/packages/react/src/utils/composite.ts
@@ -275,7 +275,7 @@ export function buildCellMap(sizes: Dimensions[], cols: number, dense: boolean) 
   return [...cellMap];
 }
 
-/** Gets cell index of an item's corner */
+/** Gets cell index of an item's corner or -1 when index is -1. */
 export function getCellIndexOfCorner(
   index: number,
   sizes: Dimensions[],
@@ -283,6 +283,8 @@ export function getCellIndexOfCorner(
   cols: number,
   corner: 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight'
 ) {
+  if (index === -1) return -1;
+
   const firstCellIndex = cellMap.indexOf(index);
 
   switch (corner) {

--- a/packages/react/test/unit/useListNavigation.test.tsx
+++ b/packages/react/test/unit/useListNavigation.test.tsx
@@ -471,6 +471,15 @@ describe('focusOnHover', () => {
 });
 
 describe('grid navigation', () => {
+  test('ArrowDown focuses first item', () => {
+    render(<Grid />);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByRole('menu')).toBeInTheDocument();
+    fireEvent.keyDown(document, {key: 'ArrowDown'});
+    expect(screen.getAllByRole('option')[8]).toHaveFocus();
+    cleanup();
+  });
   test('focuses first non-disabled item in grid', () => {
     render(<Grid />);
     fireEvent.keyDown(screen.getByRole('button'), {key: 'Enter'});

--- a/packages/react/test/visual/components/Grid.tsx
+++ b/packages/react/test/visual/components/Grid.tsx
@@ -52,6 +52,7 @@ export const Main = ({orientation = 'horizontal', loop = false}: Props) => {
         {open && (
           <FloatingFocusManager context={context}>
             <div
+              role="menu"
               ref={refs.setFloating}
               data-testid="floating"
               className="grid gap-2"


### PR DESCRIPTION
As @atomiks pointed out [here](https://github.com/floating-ui/floating-ui/pull/2676#issuecomment-1877993338), initial focus with arrow keys was broken on grid navigations after the variable sizes PR.

Turns out `getCellIndexOfCorner` was called with `index` `-1` and it wasn't prepared for that case. Easy fix.

---

However, when I tried to add a test so this doesn't happen again, I found some inconsistent behavior (possibly a bug). 
I added `<style>*:focus { border: 1px solid red !important }</style>` to the page before recording this video of the `Grid` component on commit `359e5e15` (before the variable sizes were introduced).

https://github.com/floating-ui/floating-ui/assets/32175149/2cd066c7-df33-45c0-80f2-7de965a4d1b1

You can see that when spam-clicking button, initial focus usually lands on the list, but sometimes it ends up in the first element. No idea why.

---

Because of this issue, I could only add a test for arrow down and not this one for arrow up:

```
test('ArrowUp focuses last item', async () => {
  render(<Grid />);

  fireEvent.click(screen.getByRole('button'));
  expect(screen.queryByRole('menu')).toBeInTheDocument();
  fireEvent.keyDown(document, {key: 'ArrowUp'});
  expect(screen.getAllByRole('option')[47]).toHaveFocus();
  cleanup();
});
```

It's worth noting that in the test environment, I ran a repeated test of `500` occurrences and focus always landed on the first element (which makes the test always fail).