### PR TITLE
fix(react/utils): cross-browser `isVirtualPointerEvent`

### DIFF
--- a/.changeset/olive-carpets-drive.md
+++ b/.changeset/olive-carpets-drive.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(react/utils): cross-browser `isVirtualPointerEvent`

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -90,7 +90,8 @@ export function isVirtualClick(event: MouseEvent | PointerEvent): boolean {
 export function isVirtualPointerEvent(event: PointerEvent) {
   return (
     (!isAndroid() && event.width === 0 && event.height === 0) ||
-    (event.width === 1 &&
+    (isAndroid() &&
+      event.width === 1 &&
       event.height === 1 &&
       event.pressure === 0 &&
       event.detail === 0 &&
@@ -99,7 +100,8 @@ export function isVirtualPointerEvent(event: PointerEvent) {
     (event.width < 1 &&
       event.height < 1 &&
       event.pressure === 0 &&
-      event.detail === 0)
+      event.detail === 0 &&
+      event.pointerType === 'touch')
   );
 }
 


### PR DESCRIPTION
Fix recent Chrome issue brought up in https://github.com/floating-ui/floating-ui/pull/2696

Don't have a solution for https://github.com/floating-ui/floating-ui/issues/2666 yet.