### PR TITLE
chore: modifies `defineRollupConfig` to support custom output file format

### DIFF
--- a/config/src/utils/outputFormat.mts
+++ b/config/src/utils/outputFormat.mts
@@ -1,46 +1,31 @@
-import type {ExternalOption, GlobalsOption} from 'rollup';
-import type {RollupConfigOptions} from 'src/defineRollupConfig.mjs';
+import type {
+  NormalizedOutputOptions,
+  RollupConfigOptions,
+} from 'src/defineRollupConfig.mjs';
 
 export type OutputFormat = 'esm' | 'mjs' | 'cjs' | 'umd' | 'browser';
 
-const outputFormatByExtension = {
-  'esm.js': 'esm',
-  mjs: 'mjs',
-  cjs: 'cjs',
-  'react-native.js': 'cjs',
-  'umd.js': 'umd',
-  'umd.min.js': 'umd',
-  'browser.mjs': 'browser',
-  'browser.min.mjs': 'browser',
-} satisfies Record<string, OutputFormat>;
+const outputFormats: OutputFormat[] = ['esm', 'mjs', 'cjs', 'umd', 'browser'];
 
-const validExtensions = Object.keys(outputFormatByExtension) as Array<
-  keyof typeof outputFormatByExtension
->;
-
-export const outputFormatFromFileName = (fileName: string): OutputFormat => {
-  const extension = validExtensions.find((ext) => fileName.endsWith(ext));
-  if (!extension) {
-    throw new Error(
-      `Invalid file name ${fileName}.
-      File should be named as "floating-ui.<name>.<ext>".
-      Valid extensions are ".${Object.keys(outputFormatByExtension).join(
-        ', ',
-      )}".
-      Instead got ".${extension}".
-      `,
-    );
-  }
-  return outputFormatByExtension[extension];
-};
-
-export const globalsFromOutputFormat = (
-  format: OutputFormat,
+export const normalizeOutputOptions = (
   options: Pick<RollupConfigOptions, 'globals' | 'outputs'>,
-): GlobalsOption =>
-  (options?.outputs?.[format] || {})?.globals ?? options?.globals ?? {};
-
-export const externalFromOutputFormat = (
-  format: OutputFormat,
-  options: Pick<RollupConfigOptions, 'globals' | 'outputs'>,
-): ExternalOption => Object.keys(globalsFromOutputFormat(format, options));
+): Record<OutputFormat, NormalizedOutputOptions> =>
+  outputFormats.reduce(
+    (acc, format) => {
+      const outputOptions = options.outputs?.[format];
+      if (outputOptions === false) {
+        return {...acc, [format]: {skip: true}};
+      }
+      const {file, globals = options.globals} = outputOptions ?? {};
+      return {
+        ...acc,
+        [format]: {
+          skip: false,
+          globals,
+          file,
+          external: globals ? Object.keys(globals) : undefined,
+        },
+      };
+    },
+    {} as Record<OutputFormat, NormalizedOutputOptions>,
+  );

--- a/packages/react-native/rollup.config.mjs
+++ b/packages/react-native/rollup.config.mjs
@@ -18,5 +18,8 @@ export default defineRollupConfig({
     browser: false,
     umd: false,
     mjs: false,
+    cjs: {
+      file: './dist/floating-ui.react-native.js',
+    },
   },
 });


### PR DESCRIPTION
## Modifications

1. instead of adding an [exception for `react-native`](https://github.com/floating-ui/floating-ui/pull/2709/files#diff-c31fa8a50f1125b6d26f4823c1a48ccd99f9b0c0156f3a858dc60d4ac242e5c8L78) package on the config definition, this PR introduces the option of each configuration to [override file output](https://github.com/floating-ui/floating-ui/pull/2709/files#diff-d59b424bf8f159c419e926490be41945ae635cddcdebbe039d62a1fb5bd2358eR21-R23)

Follow up on https://github.com/floating-ui/floating-ui/commit/b340e41139ca7be956bec89576443ab68558f3a1#diff-c31fa8a50f1125b6d26f4823c1a48ccd99f9b0c0156f3a858dc60d4ac242e5c8