### PR TITLE
chore: add biome configuration file to react and utils workspace

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,12 @@
       "./**/*.json",
       "./**/*.jsonc"
     ],
-    "ignore": ["./**/node_modules", "./**/dist", "./extension/dist"],
+    "ignore": [
+      "./**/node_modules",
+      "./**/dist",
+      "./**/out-tsc",
+      "./extension/dist"
+    ],
     "ignoreUnknown": true
   },
   "organizeImports": {

--- a/packages/react/biome.json
+++ b/packages/react/biome.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../node_modules/@biomejs/biome/configuration_schema.json",
+  "extends": [
+    "../../biome.json"
+  ],
+  "files": {
+    "ignore": [
+      "./**/node_modules",
+      "./**/dist",
+      "./utils",
+      "./out-tsc"
+    ]
+  }
+}

--- a/packages/utils/biome.json
+++ b/packages/utils/biome.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../node_modules/@biomejs/biome/configuration_schema.json",
+  "extends": [
+    "../../biome.json"
+  ],
+  "files": {
+    "ignore": [
+      "./**/node_modules",
+      "./**/dist",
+      "./dom",
+      "./out-tsc"
+    ]
+  }
+}


### PR DESCRIPTION
Running the command `pnpm run lint` after `pnpm run prepack` will fail as biome is not properly filtering the distribution folders from `packages/utils` and `packages/react`

1. adds biome configuration file to those packages (react, and utils) including their own specific ignore patterns adn extending the main configuration file