### PR TITLE
bugfix: resolve errors once document is inspected

### DIFF
--- a/.changeset/thin-mayflies-deliver.md
+++ b/.changeset/thin-mayflies-deliver.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/devtools": patch
+---
+
+bugfix: devtools controller emits event once the selected element is removed

--- a/.changeset/thin-mayflies-deliver.md
+++ b/.changeset/thin-mayflies-deliver.md
@@ -2,4 +2,4 @@
 "@floating-ui/devtools": patch
 ---
 
-bugfix: devtools controller emits event once the selected element is removed
+fix: devtools controller emits event once the selected element is removed


### PR DESCRIPTION
1. communicates to extension once the current selected element is removed from the DOM
2. ensures all errors will be resolved once the current document is inspected

Fixes https://github.com/floating-ui/floating-ui/issues/2726