### PR TITLE
chore(extension): manually bump version

### DIFF
--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "description": "Devtools to help debugging Floating UI elements",
   "manifest_version": 3,
   "name": "Floating UI Devtools",
-  "version": "1.2",
+  "version": "1.2.1",
   "devtools_page": "devtools-page.html",
   "icons": {
     "16": "./images/favicon-16x16.png",


### PR DESCRIPTION
Manually bumps extension version from 1.2.0 to 1.2.1, this PR should follow after https://github.com/floating-ui/floating-ui/pull/2728