### PR TITLE
refactor: rename to useModernLayoutEffect

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -58,7 +58,21 @@
       },
       "nursery": { "noUnusedImports": "off" },
       "performance": { "noAccumulatingSpread": "off" },
-      "correctness": { "noUndeclaredVariables": "off" },
+      "correctness": {
+        "noUndeclaredVariables": "off",
+        "useExhaustiveDependencies": {
+          "level": "error",
+          "options": {
+            "hooks": [
+              {
+                "name": "useModernLayoutEffect",
+                "closureIndex": 0,
+                "dependenciesIndex": 1
+              }
+            ]
+          }
+        }
+      },
       "suspicious": {
         "noExplicitAny": "off",
         "noEmptyInterface": "off",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.23.7",
     "@babel/preset-typescript": "^7.23.3",
-    "@biomejs/biome": "^1.5.0",
+    "@biomejs/biome": "^1.5.2",
     "@changesets/cli": "^2.27.1",
     "@microsoft/api-extractor": "^7.39.1",
     "@playwright/test": "^1.40.1",

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -1,7 +1,7 @@
 import {computePosition} from '@floating-ui/dom';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import type {
   ComputePositionConfig,
@@ -104,7 +104,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
     );
   }, [latestMiddleware, placement, strategy, platformRef]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (open === false && dataRef.current.isPositioned) {
       dataRef.current.isPositioned = false;
       setData((data) => ({...data, isPositioned: false}));
@@ -112,14 +112,15 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
   }, [open]);
 
   const isMountedRef = React.useRef(false);
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
     };
   }, []);
 
-  useLayoutEffect(() => {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `hasWhileElementsMounted` is intentionally included.
+  useModernLayoutEffect(() => {
     if (referenceEl) referenceRef.current = referenceEl;
     if (floatingEl) floatingRef.current = floatingEl;
 

--- a/packages/react-dom/src/utils/useLatestRef.ts
+++ b/packages/react-dom/src/utils/useLatestRef.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 export function useLatestRef<T>(value: T) {
   const ref = React.useRef(value);
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     ref.current = value;
   });
   return ref;

--- a/packages/react/src/components/FloatingDelayGroup.tsx
+++ b/packages/react/src/components/FloatingDelayGroup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import {getDelay} from '../hooks/useHover';
 import type {FloatingContext} from '../types';
@@ -73,7 +73,7 @@ export const FloatingDelayGroup = ({
     setState({currentId});
   }, []);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (state.currentId) {
       if (initialCurrentIdRef.current === null) {
         initialCurrentIdRef.current = state.currentId;
@@ -109,7 +109,7 @@ export const useDelayGroup = (
   const {currentId, setCurrentId, initialDelay, setState, timeoutMs} =
     useDelayGroupContext();
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (currentId) {
       setState({
         delay: {
@@ -124,7 +124,7 @@ export const useDelayGroup = (
     }
   }, [id, onOpenChange, setState, currentId, initialDelay]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     function unset() {
       onOpenChange(false);
       setState({delay: initialDelay, currentId: null});
@@ -142,7 +142,7 @@ export const useDelayGroup = (
     }
   }, [open, setState, currentId, id, onOpenChange, initialDelay, timeoutMs]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (open) {
       setCurrentId(id);
     }

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -12,7 +12,7 @@ import {getNodeName, isHTMLElement} from '@floating-ui/utils/dom';
 import * as React from 'react';
 import type {FocusableElement} from 'tabbable';
 import {tabbable} from 'tabbable';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import {useLatestRef} from '../hooks/utils/useLatestRef';
 import type {FloatingContext, OpenChangeReason, ReferenceType} from '../types';
@@ -335,7 +335,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
     guards,
   ]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (disabled || !floating) return;
 
     const doc = getDocument(floating);
@@ -367,7 +367,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
     initialFocusRef,
   ]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (disabled || !floating) return;
 
     let preventReturnFocusScroll = false;
@@ -458,7 +458,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
 
   // Synchronize the `context` & `modal` value to the FloatingPortal context.
   // It will decide whether or not it needs to render its own guards.
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (disabled || !portalContext) return;
 
     portalContext.setFocusManagerState({
@@ -482,7 +482,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
     closeOnFocusOut,
   ]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (
       disabled ||
       !floating ||

--- a/packages/react/src/components/FloatingList.tsx
+++ b/packages/react/src/components/FloatingList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 function sortByDocumentPosition(a: Node, b: Node) {
   const position = a.compareDocumentPosition(b);
@@ -78,7 +78,7 @@ export function FloatingList({
     });
   }, []);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     const newMap = new Map(map);
     const nodes = Array.from(newMap.keys()).sort(sortByDocumentPosition);
 
@@ -133,7 +133,7 @@ export function useListItem({label}: UseListItemProps = {}): {
     [index, elementsRef, labelsRef, label],
   );
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     const node = componentRef.current;
     if (node) {
       register(node);
@@ -143,7 +143,7 @@ export function useListItem({label}: UseListItemProps = {}): {
     }
   }, [register, unregister]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     const index = componentRef.current ? map.get(componentRef.current) : null;
     if (index != null) {
       setIndex(index);

--- a/packages/react/src/components/FloatingOverlay.tsx
+++ b/packages/react/src/components/FloatingOverlay.tsx
@@ -1,6 +1,6 @@
 import {getPlatform} from '@floating-ui/react/utils';
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import {useId} from '../hooks/useId';
 
@@ -18,7 +18,7 @@ export const FloatingOverlay = React.forwardRef<
 >(function FloatingOverlay({lockScroll = false, ...rest}, ref) {
   const lockId = useId();
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (!lockScroll) return;
 
     activeLocks.add(lockId);

--- a/packages/react/src/components/FloatingPortal.tsx
+++ b/packages/react/src/components/FloatingPortal.tsx
@@ -1,7 +1,7 @@
 import {isElement} from '@floating-ui/utils/dom';
 import * as React from 'react';
 import {createPortal} from 'react-dom';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import {useId} from '../hooks/useId';
 import type {ExtendedRefs, OpenChangeReason} from '../types';
@@ -52,13 +52,14 @@ export function useFloatingPortalNode({
 
   const dataRef = React.useRef<typeof data>();
 
-  useLayoutEffect(() => {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `data` is intentionally specified
+  useModernLayoutEffect(() => {
     return () => {
       portalNode?.remove();
     };
   }, [portalNode, data]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (dataRef.current === data) return;
 
     dataRef.current = data;

--- a/packages/react/src/components/FloatingTree.tsx
+++ b/packages/react/src/components/FloatingTree.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import {useId} from '../hooks/useId';
 import type {FloatingNodeType, FloatingTreeType, ReferenceType} from '../types';
@@ -24,7 +24,7 @@ export function useFloatingNodeId(customParentId?: string): string {
   const reactParentId = useFloatingParentNodeId();
   const parentId = customParentId || reactParentId;
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     const node = {id, parentId};
     tree?.addNode(node);
     return () => {

--- a/packages/react/src/components/FocusGuard.tsx
+++ b/packages/react/src/components/FocusGuard.tsx
@@ -1,6 +1,6 @@
 import {isSafari} from '@floating-ui/react/utils';
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import {createAttribute} from '../utils/createAttribute';
 
@@ -37,7 +37,7 @@ export const FocusGuard = React.forwardRef<
 >(function FocusGuard(props, ref) {
   const [role, setRole] = React.useState<'button' | undefined>();
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (isSafari()) {
       // Unlike other screen readers such as NVDA and JAWS, the virtual cursor
       // on VoiceOver does trigger the onFocus event, so we can use the focus

--- a/packages/react/src/hooks/useClientPoint.ts
+++ b/packages/react/src/hooks/useClientPoint.ts
@@ -5,7 +5,7 @@ import {
 } from '@floating-ui/react/utils';
 import {getWindow} from '@floating-ui/utils/dom';
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import type {
   ContextData,
@@ -219,7 +219,7 @@ export function useClientPoint<RT extends ReferenceType = ReferenceType>(
     }
   }, [enabled, open]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (enabled && (x != null || y != null)) {
       initialRef.current = false;
       setReference(x, y);

--- a/packages/react/src/hooks/useFloating.ts
+++ b/packages/react/src/hooks/useFloating.ts
@@ -1,7 +1,7 @@
 import {useFloating as usePosition} from '@floating-ui/react-dom';
 import {isElement} from '@floating-ui/utils/dom';
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import {
   useFloatingParentNodeId,
@@ -144,7 +144,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
     [position, nodeId, floatingId, events, open, onOpenChange, refs, elements],
   );
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     const node = tree?.nodesRef.current.find((node) => node.id === nodeId);
     if (node) {
       node.context = context;

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -5,7 +5,7 @@ import {
 } from '@floating-ui/react/utils';
 import {isElement} from '@floating-ui/utils/dom';
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import {
   useFloatingParentNodeId,
@@ -332,7 +332,7 @@ export function useHover<RT extends ReferenceType = ReferenceType>(
   // while the floating element is open and has a `handleClose` handler. Also
   // handles nested floating elements.
   // https://github.com/floating-ui/floating-ui/issues/1722
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (!enabled) {
       return;
     }
@@ -375,11 +375,10 @@ export function useHover<RT extends ReferenceType = ReferenceType>(
     domReference,
     tree,
     handleCloseRef,
-    dataRef,
     isHoverOpen,
   ]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (!open) {
       pointerTypeRef.current = undefined;
       cleanupMouseMoveHandler();

--- a/packages/react/src/hooks/useId.ts
+++ b/packages/react/src/hooks/useId.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 let serverHandoffComplete = false;
 let count = 0;
@@ -10,7 +10,8 @@ function useFloatingId() {
     serverHandoffComplete ? genId() : undefined,
   );
 
-  useLayoutEffect(() => {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
+  useModernLayoutEffect(() => {
     if (id == null) {
       setId(genId());
     }

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -11,7 +11,7 @@ import {
 } from '@floating-ui/react/utils';
 import {isHTMLElement} from '@floating-ui/utils/dom';
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import {
   useFloatingParentNodeId,
@@ -278,7 +278,7 @@ export function useListNavigation<RT extends ReferenceType = ReferenceType>(
     },
   );
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     document.createElement('div').focus({
       get preventScroll() {
         isPreventScrollSupported = true;
@@ -289,7 +289,7 @@ export function useListNavigation<RT extends ReferenceType = ReferenceType>(
 
   // Sync `selectedIndex` to be the `activeIndex` upon opening the floating
   // element. Also, reset `activeIndex` upon closing the floating element.
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (!enabled) {
       return;
     }
@@ -313,7 +313,7 @@ export function useListNavigation<RT extends ReferenceType = ReferenceType>(
 
   // Sync `activeIndex` to be the focused item while the floating element is
   // open.
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (!enabled) {
       return;
     }
@@ -387,7 +387,7 @@ export function useListNavigation<RT extends ReferenceType = ReferenceType>(
 
   // Ensure the parent floating element has focus when a nested child closes
   // to allow arrow key navigation to work after the pointer leaves the child.
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (
       !enabled ||
       floating ||
@@ -412,7 +412,7 @@ export function useListNavigation<RT extends ReferenceType = ReferenceType>(
     }
   }, [enabled, floating, tree, parentId, virtual]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (!enabled || !tree || !virtual || parentId) return;
 
     function handleVirtualFocus(item: HTMLElement) {
@@ -429,12 +429,12 @@ export function useListNavigation<RT extends ReferenceType = ReferenceType>(
     };
   }, [enabled, tree, virtual, parentId, virtualItemRef]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     previousOnNavigateRef.current = onNavigate;
     previousMountedRef.current = !!floating;
   });
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (!open) {
       keyRef.current = null;
     }

--- a/packages/react/src/hooks/useTransition.ts
+++ b/packages/react/src/hooks/useTransition.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import type {FloatingContext, Placement, ReferenceType, Side} from '../types';
 import {useLatestRef} from './utils/useLatestRef';
@@ -71,13 +71,13 @@ export function useTransitionStatus<RT extends ReferenceType = ReferenceType>(
   // <FloatingPortal />. This call is necessary to ensure subsequent opens
   // after the initial one allows the correct side animation to play when the
   // placement has changed.
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (initiated && !isMounted) {
       setStatus('unmounted');
     }
   }, [initiated, isMounted]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (!floating) return;
 
     if (open) {
@@ -151,7 +151,7 @@ export function useTransitionStyles<RT extends ReferenceType = ReferenceType>(
   const closeRef = useLatestRef(unstable_close);
   const commonRef = useLatestRef(unstable_common);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     const initialStyles = execWithArgsOrReturn(initialRef.current, fnArgs);
     const closeStyles = execWithArgsOrReturn(closeRef.current, fnArgs);
     const commonStyles = execWithArgsOrReturn(commonRef.current, fnArgs);

--- a/packages/react/src/hooks/useTypeahead.ts
+++ b/packages/react/src/hooks/useTypeahead.ts
@@ -1,6 +1,6 @@
 import {stopEvent} from '@floating-ui/react/utils';
 import * as React from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import type {ElementProps, FloatingContext, ReferenceType} from '../types';
 import {useEffectEvent} from './utils/useEffectEvent';
@@ -58,7 +58,7 @@ export function useTypeahead<RT extends ReferenceType = ReferenceType>(
   const findMatchRef = useLatestRef(findMatch);
   const ignoreKeysRef = useLatestRef(ignoreKeys);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     if (open) {
       clearTimeout(timeoutIdRef.current);
       matchIndexRef.current = null;
@@ -66,7 +66,7 @@ export function useTypeahead<RT extends ReferenceType = ReferenceType>(
     }
   }, [open]);
 
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     // Sync arrow key navigation but not typeahead navigation.
     if (open && stringRef.current === '') {
       prevIndexRef.current = selectedIndex ?? activeIndex ?? -1;

--- a/packages/react/src/hooks/utils/useLatestRef.ts
+++ b/packages/react/src/hooks/utils/useLatestRef.ts
@@ -1,9 +1,9 @@
 import {useRef} from 'react';
-import useLayoutEffect from 'use-isomorphic-layout-effect';
+import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 export function useLatestRef<T>(value: T) {
   const ref = useRef<T>(value);
-  useLayoutEffect(() => {
+  useModernLayoutEffect(() => {
     ref.current = value;
   });
   return ref;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^7.23.3
         version: 7.23.3(@babel/core@7.23.7)
       '@biomejs/biome':
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: ^1.5.2
+        version: 1.5.2
       '@changesets/cli':
         specifier: ^2.27.1
         version: 2.27.1
@@ -2112,24 +2112,24 @@ packages:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
     dev: true
 
-  /@biomejs/biome@1.5.0:
-    resolution: {integrity: sha512-ln+o5jbs109qpeDoA+5n+vlAPai3DhlK0tHtZXzQvu4tswFgxNiJCeIXmlW1DYHziTmtBImV3Y0uhbm2iVSE3Q==}
+  /@biomejs/biome@1.5.2:
+    resolution: {integrity: sha512-LhycxGQBQLmfv6M3e4tMfn/XKcUWyduDYOlCEBrHXJ2mMth2qzYt1JWypkWp+XmU/7Hl2dKvrP4mZ5W44+nWZw==}
     engines: {node: '>=14.*'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.5.0
-      '@biomejs/cli-darwin-x64': 1.5.0
-      '@biomejs/cli-linux-arm64': 1.5.0
-      '@biomejs/cli-linux-arm64-musl': 1.5.0
-      '@biomejs/cli-linux-x64': 1.5.0
-      '@biomejs/cli-linux-x64-musl': 1.5.0
-      '@biomejs/cli-win32-arm64': 1.5.0
-      '@biomejs/cli-win32-x64': 1.5.0
+      '@biomejs/cli-darwin-arm64': 1.5.2
+      '@biomejs/cli-darwin-x64': 1.5.2
+      '@biomejs/cli-linux-arm64': 1.5.2
+      '@biomejs/cli-linux-arm64-musl': 1.5.2
+      '@biomejs/cli-linux-x64': 1.5.2
+      '@biomejs/cli-linux-x64-musl': 1.5.2
+      '@biomejs/cli-win32-arm64': 1.5.2
+      '@biomejs/cli-win32-x64': 1.5.2
     dev: true
 
-  /@biomejs/cli-darwin-arm64@1.5.0:
-    resolution: {integrity: sha512-3+D7axf04dpadGMOaqb2q+zyQnhWW0o/Imt7TJBWsoE0N3/+28Wht8g3UEHHcUL5FPuGIfsE+NcYntBaaAsEIg==}
+  /@biomejs/cli-darwin-arm64@1.5.2:
+    resolution: {integrity: sha512-3JVl08aHKsPyf0XL9SEj1lssIMmzOMAn2t1zwZKBiy/mcZdb0vuyMSTM5haMQ/90wEmrkYN7zux777PHEGrGiw==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [darwin]
@@ -2137,8 +2137,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-darwin-x64@1.5.0:
-    resolution: {integrity: sha512-8k5aaLWE/B6ZAXLC+z/Vwh9ogyiSaiRIfvg+F9foxuneHl2R/D/2Iy7pvd3Yoi4Kf6/MBdowekPVezGP4/Kbcw==}
+  /@biomejs/cli-darwin-x64@1.5.2:
+    resolution: {integrity: sha512-QAPW9rZb/AgucUx+ogMg+9eJNipQDqvabktC5Tx4Aqb/mFzS6eDqNP7O0SbGz3DtC5Y2LATEj6o6zKIQ4ZT+3w==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [darwin]
@@ -2146,8 +2146,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-arm64-musl@1.5.0:
-    resolution: {integrity: sha512-+1B3J8tWLTOvP3+00Cap+XhEXMvxwCHvVfuywUsB7Sqd66NWic3wKJuGbGcS3PuCWtGuIFsiQMNAGqiOXG4uBQ==}
+  /@biomejs/cli-linux-arm64-musl@1.5.2:
+    resolution: {integrity: sha512-Z29SjaOyO4QfajplNXSjLx17S79oPN42D094zjE24z7C7p3NxvLhKLygtSP9emgaXkcoESe2chOzF4IrGy/rlg==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [linux]
@@ -2155,8 +2155,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-arm64@1.5.0:
-    resolution: {integrity: sha512-RiecxG71E1jnqiJZ3FaikVBDRkk2ohIxBo0O4o68g87y6Hug//G0S83sj6Wqyn8DgKMCRWQg+XYMgk5CwLVowA==}
+  /@biomejs/cli-linux-arm64@1.5.2:
+    resolution: {integrity: sha512-fVLrUgIlo05rO4cNu+Py5EwwmXnXhWH+8KrNlWkr2weMYjq85SihUsuWWKpmqU+bUVR+m5gwfcIXZVWYVCJMHw==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [linux]
@@ -2164,8 +2164,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-x64-musl@1.5.0:
-    resolution: {integrity: sha512-4S2rLluc0WT+XTbLTgcm9+5EEFwJmoGiUEzR6N0P2sIjZD8c5KNf9Ou46BP1Pdg5AgqV+IIClGPK1I80ApSh1Q==}
+  /@biomejs/cli-linux-x64-musl@1.5.2:
+    resolution: {integrity: sha512-ZolquPEjWYUmGeERS8svHOOT7OXEeoriPnV8qptgWJmYF9EO9HUGRn1UtCvdVziDYK+u1A7PxjOdkY1B00ty5A==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [linux]
@@ -2173,8 +2173,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-x64@1.5.0:
-    resolution: {integrity: sha512-TlTsG+ptSmnDTUsAAYsXyGOXMcFiF8SiwhPdj4YsNkJRgx9M2curEVcTVm66FINIPK6VJTUcEDahFlx3NPUOzA==}
+  /@biomejs/cli-linux-x64@1.5.2:
+    resolution: {integrity: sha512-ixqJtUHtF0ho1+1DTZQLAEwHGSqvmvHhAAFXZQoaSdABn+IcITYExlFVA3bGvASy/xtPjRhTx42hVwPtLwMHwg==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [linux]
@@ -2182,8 +2182,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-win32-arm64@1.5.0:
-    resolution: {integrity: sha512-sWOi1SR+YqJuXElBncGRnWBR7IN7ni6GQY4Zm/vTpP6nVA0dX5C301eQUW1N/VnFQb6fyrJTcBslDUKyemsN/g==}
+  /@biomejs/cli-win32-arm64@1.5.2:
+    resolution: {integrity: sha512-DN4cXSAoFTdjOoh7f+JITj1uQgQSXt+1pVea9bFrpbgip+ZwkONqQq+jUcmFMMehbp9LuiVtNXFz/ReHn6FY7A==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [win32]
@@ -2191,8 +2191,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-win32-x64@1.5.0:
-    resolution: {integrity: sha512-OoqgUXyzmRwX466bklOsWS7WdcvWtBuxF94DXATNe7bUiBa2tlW8QX7VVZvPnMKH57E5J619AkB3b5fhzyUhXA==}
+  /@biomejs/cli-win32-x64@1.5.2:
+    resolution: {integrity: sha512-YvWWXZmk936FdrXqc2jcP6rfsXsNBIs9MKBQQoVXIihwNNRiAaBD9Iwa/ouU1b7Zxq2zETgeuRewVJickFuVOw==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [win32]

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,6 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
     "postinstall": "patch-package"
   },
   "author": "",


### PR DESCRIPTION
Biome doesn't lint `useLayoutEffect` dependencies when it's from a custom package, but works when it's a different name.

React recently removed the SSR warning with the built-in hook (although this is not relevant for libraries until React 19 is released AND has high usage 🫠 ), hence `modern` (preferable over the traditional `isomorphic` name since effects can't be isomorphic).