### PR TITLE
Do not close the floating element when focus moves inside shadow roots

### DIFF
--- a/.changeset/four-windows-work.md
+++ b/.changeset/four-windows-work.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+Do not close the floating element when focus moves inside shadow roots

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -170,9 +170,13 @@ export function useFocus<RT extends ReferenceType = ReferenceType>(
             // When focusing the reference element (e.g. regular click), then
             // clicking into the floating element, prevent it from hiding.
             // Note: it must be focusable, e.g. `tabindex="-1"`.
+            // We can not rely on relatedTarget to point to the correct element
+            // as it will only point to the shadow host of the newly focused element
+            // and not the element that actually has received focus if it is located
+            // inside a shadow root.
             if (
-              contains(refs.floating.current, relatedTarget) ||
-              contains(domReference, relatedTarget) ||
+              contains(refs.floating.current, activeEl) ||
+              contains(domReference, activeEl) ||
               movedToFocusGuard
             ) {
               return;


### PR DESCRIPTION
This fixes a bug where floating elements are closed when the focus is moved from the reference element to any other element inside the reference or tooltip while the whole thing is rendered inside a shadow root. The issue is that the `relatedTarget` property of the focusOut event points to the shadow root instead of the actually focused element.