### PR TITLE
fix(vue): useFloating types

### DIFF
--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -8,6 +8,7 @@ import type {
   Strategy,
 } from '@floating-ui/dom';
 import type {ComponentPublicInstance, Ref} from 'vue-demi';
+import type {unwrapElement} from './utils/unwrapElement';
 
 export type {
   AlignedPlacement,
@@ -55,7 +56,11 @@ export type MaybeReadonlyRef<T> = T | Readonly<Ref<T>>;
 
 export type MaybeElement<T> = T | ComponentPublicInstance | null | undefined;
 
-export type UseFloatingOptions<T extends ReferenceElement = ReferenceElement> =
+export type VueReferenceElement = ReferenceElement | ComponentPublicInstance;
+
+export type VueFloatingElement = FloatingElement | ComponentPublicInstance;
+
+export type UseFloatingOptions<T extends VueReferenceElement = VueReferenceElement> =
   {
     /**
      * Represents the open/close state of the floating element.
@@ -88,7 +93,7 @@ export type UseFloatingOptions<T extends ReferenceElement = ReferenceElement> =
      * @default undefined
      */
     whileElementsMounted?: (
-      reference: T,
+      reference: Exclude<ReturnType<typeof unwrapElement<T>>, null | undefined>,
       floating: FloatingElement,
       update: () => void,
     ) => () => void;

--- a/packages/vue/src/useFloating.ts
+++ b/packages/vue/src/useFloating.ts
@@ -20,6 +20,8 @@ import type {
   MaybeElement,
   UseFloatingOptions,
   UseFloatingReturn,
+  VueReferenceElement,
+  VueFloatingElement,
 } from './types';
 import {getDPR} from './utils/getDPR';
 import {roundByDPR} from './utils/roundByDPR';
@@ -32,10 +34,10 @@ import {unwrapElement} from './utils/unwrapElement';
  * @param options The floating options.
  * @see https://floating-ui.com/docs/vue
  */
-export function useFloating<T extends ReferenceElement = ReferenceElement>(
+export function useFloating<T extends VueReferenceElement = VueReferenceElement>(
   reference: Readonly<Ref<MaybeElement<T>>>,
-  floating: Readonly<Ref<MaybeElement<FloatingElement>>>,
-  options: UseFloatingOptions<T> = {},
+  floating: Readonly<Ref<MaybeElement<VueFloatingElement>>>,
+  options: UseFloatingOptions = {},
 ): UseFloatingReturn {
   const whileElementsMountedOption = options.whileElementsMounted;
   const openOption = computed(() => unref(options.open) ?? true);

--- a/packages/vue/test/index.test.ts
+++ b/packages/vue/test/index.test.ts
@@ -4,18 +4,18 @@ import {defineComponent, effectScope, ref, toRef} from 'vue';
 
 import {arrow, offset, useFloating} from '../src';
 import type {
-  FloatingElement,
   Middleware,
   Placement,
-  ReferenceElement,
   Strategy,
+  VueReferenceElement,
+  VueFloatingElement,
 } from '../src/types';
 import type {ArrowOptions, UseFloatingOptions} from '../src/types';
 
 describe('useFloating', () => {
   function setup(options?: UseFloatingOptions) {
-    const reference = ref<ReferenceElement | null>(null);
-    const floating = ref<FloatingElement | null>(null);
+    const reference = ref<VueReferenceElement | null>(null);
+    const floating = ref<VueFloatingElement | null>(null);
     const position = useFloating(reference, floating, options);
 
     return {reference, floating, ...position};
@@ -701,8 +701,8 @@ describe('useFloating', () => {
 
 describe('arrow', () => {
   function setup(options?: Omit<ArrowOptions, 'element'>) {
-    const reference = ref<ReferenceElement | null>(null);
-    const floating = ref<FloatingElement | null>(null);
+    const reference = ref<VueReferenceElement | null>(null);
+    const floating = ref<VueFloatingElement | null>(null);
     const floatingArrow = ref<HTMLElement | null>(null);
     const position = useFloating(reference, floating, {
       middleware: [arrow({...options, element: floatingArrow})],


### PR DESCRIPTION
Since `useFloating` uses `unwrapElement` which calls `$el` on a Vue component, `useFloating`'s types should accept Vue components as `reference` and `floating`.

Since `T` extended `ReferenceElement` from `@floating-ui/dom`, it would not allow Vue components as `reference`. The same goes for `floating` which used `FloatingElement`.

The `VueReferenceElement` and `VueFloatingElement` types were added to support the Vue supported types.