### PR TITLE
docs: Fix typo in useFloating width: max-content

### DIFF
--- a/website/pages/docs/useFloating.mdx
+++ b/website/pages/docs/useFloating.mdx
@@ -197,7 +197,7 @@ floating element a wrapper to avoid the conflict:
 
 <Notice>
   When using layout instead of transforms, ensure that the
-  floating element has a fixed width or sets a `width: max-width{:sass}` to
+  floating element has a fixed width or sets a `width: max-content{:sass}` to
   prevent it from resizing.
 </Notice>
 


### PR DESCRIPTION
Fix a typo in the `useFloating` docs based on the information in [this ResizeObserver issue](https://github.com/floating-ui/floating-ui/issues/1740#issuecomment-1151773854).

The docs say `width: max-width` instead of the `width: max-content` that the issue recommends.