### PR TITLE
feat(FloatingFocusManager): support returning focus to the first focusable descendent of the reference

### DIFF
--- a/.changeset/cyan-insects-know.md
+++ b/.changeset/cyan-insects-know.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+Enhances the return focus functionality of FloatingFocusManager to return focus to the first focusable descendant of the reference element, if the reference element itself is not focusable

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -39,11 +39,11 @@ function addPreviouslyFocusedElement(element: Element | null) {
     (el) => el.isConnected,
   );
   let targetEl = element;
-  if(targetEl && getNodeName(targetEl) !== 'body' && !isTabbable(targetEl)) {
-	// If the element itself is not tabbable, try to find the first tabbable node inside it.
-    targetEl = tabbable(targetEl, getTabbableOptions())[0];
-  }
   if (targetEl && getNodeName(targetEl) !== 'body') {
+    if (!isTabbable(targetEl, getTabbableOptions())) {
+      // If the element itself is not tabbable, try to find the first tabbable node inside it.
+      targetEl = tabbable(targetEl, getTabbableOptions())[0];
+    }
     previouslyFocusedElements.push(targetEl);
     if (previouslyFocusedElements.length > LIST_LIMIT) {
       previouslyFocusedElements = previouslyFocusedElements.slice(-LIST_LIMIT);

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -54,6 +54,21 @@ function getPreviouslyFocusedElement() {
     .find((el) => el.isConnected);
 }
 
+const focusableElementsQuery = 'a, button:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled), details, [tabindex]:not([tabindex="-1"])';
+
+function isElementFocusable(node: Element) {
+	if (!(node instanceof HTMLElement) || !node.isConnected) {
+		return false;
+	}
+	return node.matches(focusableElementsQuery);
+}
+
+function getFirstFocusableElement(node: Element) {
+	const focusable = Array.from(node.querySelectorAll(focusableElementsQuery))
+	  .filter(isElementFocusable);
+	return focusable[0];
+}
+
 const VisuallyHiddenDismiss = React.forwardRef(function VisuallyHiddenDismiss(
   props: React.ButtonHTMLAttributes<HTMLButtonElement>,
   ref: React.Ref<HTMLButtonElement>,
@@ -482,8 +497,12 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
         addPreviouslyFocusedElement(refs.domReference.current);
       }
 
-      const returnElement = getPreviouslyFocusedElement();
+      let returnElement = getPreviouslyFocusedElement();
 
+	  // if the returnElement is not focusable, attempt to find a focusable element within it's tree
+	  if (returnElement && !isElementFocusable(returnElement)) {
+		returnElement = getFirstFocusableElement(returnElement);
+	  }
       if (
         returnFocusRef.current &&
         !preventReturnFocusRef.current &&

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -39,7 +39,7 @@ function addPreviouslyFocusedElement(element: Element | null) {
     (el) => el.isConnected,
   );
   let targetEl = element;
-  if (!targetEl || getNodeName(targetEl) !== 'body') {
+  if (!targetEl || getNodeName(targetEl) === 'body') {
     return;
   }
   if (!isTabbable(targetEl, getTabbableOptions())) {

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -38,12 +38,13 @@ function addPreviouslyFocusedElement(element: Element | null) {
   previouslyFocusedElements = previouslyFocusedElements.filter(
     (el) => el.isConnected,
   );
-  if(element && getNodeName(element) !== 'body' && !isTabbable(element)) {
+  let targetEl = element;
+  if(targetEl && getNodeName(targetEl) !== 'body' && !isTabbable(targetEl)) {
 	// If the element itself is not tabbable, try to find the first tabbable node inside it.
-    element = tabbable(element, getTabbableOptions())[0];
+    targetEl = tabbable(targetEl, getTabbableOptions())[0];
   }
-  if (element && getNodeName(element) !== 'body') {
-    previouslyFocusedElements.push(element);
+  if (targetEl && getNodeName(targetEl) !== 'body') {
+    previouslyFocusedElements.push(targetEl);
     if (previouslyFocusedElements.length > LIST_LIMIT) {
       previouslyFocusedElements = previouslyFocusedElements.slice(-LIST_LIMIT);
     }
@@ -485,7 +486,7 @@ export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
         addPreviouslyFocusedElement(refs.domReference.current);
       }
 
-      let returnElement = getPreviouslyFocusedElement();
+      const returnElement = getPreviouslyFocusedElement();
 
       if (
         returnFocusRef.current &&

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -39,15 +39,16 @@ function addPreviouslyFocusedElement(element: Element | null) {
     (el) => el.isConnected,
   );
   let targetEl = element;
-  if (targetEl && getNodeName(targetEl) !== 'body') {
-    if (!isTabbable(targetEl, getTabbableOptions())) {
-      // If the element itself is not tabbable, try to find the first tabbable node inside it.
-      targetEl = tabbable(targetEl, getTabbableOptions())[0];
-    }
-    previouslyFocusedElements.push(targetEl);
-    if (previouslyFocusedElements.length > LIST_LIMIT) {
-      previouslyFocusedElements = previouslyFocusedElements.slice(-LIST_LIMIT);
-    }
+  if (!targetEl || getNodeName(targetEl) !== 'body') {
+    return;
+  }
+  if (!isTabbable(targetEl, getTabbableOptions())) {
+    // If the element itself is not tabbable, try to find the first tabbable node inside it.
+    targetEl = tabbable(targetEl, getTabbableOptions())[0] ?? targetEl;
+  }
+  previouslyFocusedElements.push(targetEl);
+  if (previouslyFocusedElements.length > LIST_LIMIT) {
+    previouslyFocusedElements = previouslyFocusedElements.slice(-LIST_LIMIT);
   }
 }
 

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -38,15 +38,14 @@ function addPreviouslyFocusedElement(element: Element | null) {
   previouslyFocusedElements = previouslyFocusedElements.filter(
     (el) => el.isConnected,
   );
-  let targetEl = element;
-  if (!targetEl || getNodeName(targetEl) === 'body') {
-    return;
+  let tabbableEl = element;
+  if (!tabbableEl || getNodeName(tabbableEl) === 'body') return;
+  if (!isTabbable(tabbableEl, getTabbableOptions())) {
+    const tabbableChild = tabbable(tabbableEl, getTabbableOptions())[0];
+    if (!tabbableChild) return;
+    tabbableEl = tabbableChild;
   }
-  if (!isTabbable(targetEl, getTabbableOptions())) {
-    // If the element itself is not tabbable, try to find the first tabbable node inside it.
-    targetEl = tabbable(targetEl, getTabbableOptions())[0] ?? targetEl;
-  }
-  previouslyFocusedElements.push(targetEl);
+  previouslyFocusedElements.push(tabbableEl);
   if (previouslyFocusedElements.length > LIST_LIMIT) {
     previouslyFocusedElements = previouslyFocusedElements.slice(-LIST_LIMIT);
   }

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -2,7 +2,6 @@ import {act, cleanup, fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {cloneElement, useRef, useState} from 'react';
 import {Context as ResponsiveContext} from 'react-responsive';
-
 import {
   FloatingFocusManager,
   FloatingNode,
@@ -67,46 +66,46 @@ function App(
 }
 
 interface DialogProps {
-	open?: boolean;
-	render: (props: {close: () => void}) => React.ReactNode;
-	children: JSX.Element;
-  }
+  open?: boolean;
+  render: (props: {close: () => void}) => React.ReactNode;
+  children: JSX.Element;
+}
 
-  const Dialog = ({render, open: passedOpen = false, children}: DialogProps) => {
-	const [open, setOpen] = useState(passedOpen);
-	const nodeId = useFloatingNodeId();
+const Dialog = ({render, open: passedOpen = false, children}: DialogProps) => {
+  const [open, setOpen] = useState(passedOpen);
+  const nodeId = useFloatingNodeId();
 
-	const {refs, context} = useFloating({
-	  open,
-	  onOpenChange: setOpen,
-	  nodeId,
-	});
+  const {refs, context} = useFloating({
+    open,
+    onOpenChange: setOpen,
+    nodeId,
+  });
 
-	const {getReferenceProps, getFloatingProps} = useInteractions([
-	  useClick(context),
-	  useDismiss(context, {bubbles: false}),
-	]);
+  const {getReferenceProps, getFloatingProps} = useInteractions([
+    useClick(context),
+    useDismiss(context, {bubbles: false}),
+  ]);
 
-	return (
-	  <FloatingNode id={nodeId}>
-		{cloneElement(
-		  children,
-		  getReferenceProps({ref: refs.setReference, ...children.props}),
-		)}
-		<FloatingPortal>
-		  {open && (
-			<FloatingFocusManager context={context}>
-			  <div {...getFloatingProps({ref: refs.setFloating})}>
-				{render({
-				  close: () => setOpen(false),
-				})}
-			  </div>
-			</FloatingFocusManager>
-		  )}
-		</FloatingPortal>
-	  </FloatingNode>
-	);
-  };
+  return (
+    <FloatingNode id={nodeId}>
+      {cloneElement(
+        children,
+        getReferenceProps({ref: refs.setReference, ...children.props}),
+      )}
+      <FloatingPortal>
+        {open && (
+          <FloatingFocusManager context={context}>
+            <div {...getFloatingProps({ref: refs.setFloating})}>
+              {render({
+                close: () => setOpen(false),
+              })}
+            </div>
+          </FloatingFocusManager>
+        )}
+      </FloatingPortal>
+    </FloatingNode>
+  );
+};
 
 describe('initialFocus', () => {
   test('number', async () => {
@@ -234,12 +233,13 @@ describe('returnFocus', () => {
           </>
         )}
       >
-        <div data-testid="non-focusable-reference"><button data-testid="open-dialog" /></div>
+        <div data-testid="non-focusable-reference">
+          <button data-testid="open-dialog" />
+        </div>
       </Dialog>,
     );
-	screen.getByTestId('open-dialog').focus();
-	await userEvent.keyboard('{Enter}');
-
+    screen.getByTestId('open-dialog').focus();
+    await userEvent.keyboard('{Enter}');
 
     expect(screen.queryByTestId('close-dialog')).toBeInTheDocument();
 
@@ -247,7 +247,7 @@ describe('returnFocus', () => {
 
     expect(screen.queryByTestId('close-dialog')).not.toBeInTheDocument();
 
-	expect(screen.getByTestId('open-dialog')).toHaveFocus();
+    expect(screen.getByTestId('open-dialog')).toHaveFocus();
   });
 });
 

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -247,7 +247,6 @@ describe('returnFocus', () => {
 
     expect(screen.queryByTestId('close-dialog')).not.toBeInTheDocument();
 
-    expect(screen.queryByTestId('close-dialog')).not.toBeInTheDocument();
 	expect(screen.getByTestId('open-dialog')).toHaveFocus();
   });
 });

--- a/packages/react/test/unit/setupTests.ts
+++ b/packages/react/test/unit/setupTests.ts
@@ -56,3 +56,19 @@ Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
     return this.parentNode;
   },
 });
+
+// Mock tabbable options - see https://github.com/focus-trap/tabbable#testing-in-jsdom
+vi.mock('tabbable', async (importOriginal) => {
+	const lib = await importOriginal<typeof import('tabbable')>();
+	const tabbableMock: typeof lib['tabbable'] = (node, options) => lib.tabbable(node, { ...options, displayCheck: 'none' });
+	const focusableMock: typeof lib['focusable'] = (node, options) => lib.focusable(node, { ...options, displayCheck: 'none' });
+	const isFocusableMock: typeof lib['isFocusable'] = (node, options) => lib.isFocusable(node, { ...options, displayCheck: 'none' });
+	const isTabbableMock: typeof lib['isTabbable'] = (node, options) => lib.isTabbable(node, { ...options, displayCheck: 'none' });
+	return {
+		...lib,
+		tabbable: tabbableMock,
+		focusable: focusableMock,
+		isFocusable: isFocusableMock,
+		isTabbable: isTabbableMock
+	};
+});

--- a/packages/react/test/unit/setupTests.ts
+++ b/packages/react/test/unit/setupTests.ts
@@ -56,19 +56,3 @@ Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
     return this.parentNode;
   },
 });
-
-// Mock tabbable options - see https://github.com/focus-trap/tabbable#testing-in-jsdom
-vi.mock('tabbable', async (importOriginal) => {
-	const lib = await importOriginal<typeof import('tabbable')>();
-	const tabbableMock: typeof lib['tabbable'] = (node, options) => lib.tabbable(node, { ...options, displayCheck: 'none' });
-	const focusableMock: typeof lib['focusable'] = (node, options) => lib.focusable(node, { ...options, displayCheck: 'none' });
-	const isFocusableMock: typeof lib['isFocusable'] = (node, options) => lib.isFocusable(node, { ...options, displayCheck: 'none' });
-	const isTabbableMock: typeof lib['isTabbable'] = (node, options) => lib.isTabbable(node, { ...options, displayCheck: 'none' });
-	return {
-		...lib,
-		tabbable: tabbableMock,
-		focusable: focusableMock,
-		isFocusable: isFocusableMock,
-		isTabbable: isTabbableMock
-	};
-});


### PR DESCRIPTION
Updates `<FloatingFocusManager />` to support returning focus to the first focusable descendant of the reference node, when the reference node itself is not focusable. 

This would be beneficial for utilizing patterns like [Popover](https://github.com/floating-ui/floating-ui/blob/master/packages/react/test/visual/components/Popover.tsx) with reference components like a wrapped input (`<div><input /></div>`). 

Related discussion: https://github.com/floating-ui/floating-ui/discussions/2825