### PR TITLE
feat: FloatingOverlayProps

### DIFF
--- a/.changeset/short-penguins-appear.md
+++ b/.changeset/short-penguins-appear.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(types): export `FloatingOverlayProps`

--- a/packages/react/src/components/FloatingOverlay.tsx
+++ b/packages/react/src/components/FloatingOverlay.tsx
@@ -6,7 +6,7 @@ import {useId} from '../hooks/useId';
 
 const activeLocks = new Set<string>();
 
-interface FloatingOverlayProps {
+export interface FloatingOverlayProps {
   /**
    * Whether the overlay should lock scrolling on the document body.
    * @default false

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -10,6 +10,7 @@ import type {ExtendedUserProps} from './hooks/useInteractions';
 export * from '.';
 export type {FloatingArrowProps} from './components/FloatingArrow';
 export type {FloatingFocusManagerProps} from './components/FloatingFocusManager';
+export type {FloatingOverlayProps} from './components/FloatingOverlay';
 export type {UseClickProps} from './hooks/useClick';
 export type {UseClientPointProps} from './hooks/useClientPoint';
 export type {UseDismissProps} from './hooks/useDismiss';


### PR DESCRIPTION
# PR

`FloatingOverlayProps` is not currently exported.

This causes conflicts that require workarounds with libraries like `styled-components`.

Exporting `FloatingOverlayProps`:
- should not introduce backwards compatibility issues (correct me if I'm wrong)
- will not meaningfully impact bundle size or performance
- will not expose any kind of application information that isn't already available to consumers of the tool

Exporting `FloatingOverlayProps` will benefit consumers of Floating-UI in the following ways:
- Reducing the burden on adapting alternative `tsconfig.json` settings
- Workarounds like casting-`any`
- Creating a `d.ts` file that extends exported types from Floating-UI

### Final Thoughts
I don't see any philosophical reasons to avoid an export of this interface. It seems to be common place that other component interfaces are exported when needed. I think I am proposing that there is enough value in `FloatingOverlayProps` being exported that it warrants inclusion in that group of exported component props.