### PR TITLE
bugfix: replaces React_2 for React from type generation

### DIFF
--- a/.changeset/mighty-donuts-remain.md
+++ b/.changeset/mighty-donuts-remain.md
@@ -4,4 +4,4 @@
 "@floating-ui/react-native": patch
 ---
 
-Manually replaces `React_2` for `React` in generated .d.ts files
+fix(types): replace `React_2` with `React` in generated .d.ts files

--- a/.changeset/mighty-donuts-remain.md
+++ b/.changeset/mighty-donuts-remain.md
@@ -1,0 +1,7 @@
+---
+"@floating-ui/react": patch
+"@floating-ui/react-dom": patch
+"@floating-ui/react-native": patch
+---
+
+Manually replaces `React_2` for `React` in generated .d.ts files

--- a/config/scripts/build-api.mjs
+++ b/config/scripts/build-api.mjs
@@ -40,6 +40,7 @@ echo(
 echo('');
 
 echo(chalk.cyan(`Running tsc (${chalk.greenBright(tscPaths.join(', '))})`));
+
 await Promise.all(tscPaths.map((tscPath) => $`npx tsc -b ${tscPath}`));
 
 echo(
@@ -47,6 +48,7 @@ echo(
     `Running API Extractor (${chalk.greenBright(aecPaths.join(', '))})`,
   ),
 );
+
 await Promise.all(
   aecPaths.map(async (aecPath) => {
     await $`npx api-extractor run --local --verbose -c ${aecPath}`;
@@ -56,6 +58,14 @@ await Promise.all(
         '<projectFolder>',
         configFile.projectFolder ?? '.',
       );
+      echo(
+        chalk.cyan(
+          `Replacing "React_2" for "React" from ${chalk.greenBright(path)}`,
+        ),
+      );
+      const dtsFile = await fs.readFile(path, 'utf-8');
+      await fs.writeFile(path, dtsFile.replace(/React_2/g, 'React'));
+
       const mdtsPath = path.replace(/\.d\.ts$/, '.d.mts');
       echo(
         chalk.cyan(

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/preset-typescript": "^7.23.3",
     "@changesets/cli": "^2.27.1",
     "@changesets/types": "^6.0.0",
-    "@microsoft/api-extractor": "^7.39.1",
+    "@microsoft/api-extractor": "^7.43.1",
     "@playwright/test": "^1.40.1",
     "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-babel": "^6.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       '@microsoft/api-extractor':
-        specifier: ^7.39.1
-        version: 7.39.1(@types/node@20.10.6)
+        specifier: ^7.43.1
+        version: 7.43.1(@types/node@20.10.6)
       '@playwright/test':
         specifier: ^1.40.1
         version: 1.40.1
@@ -4528,32 +4528,33 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@microsoft/api-extractor-model@7.28.4(@types/node@20.10.6):
-    resolution: {integrity: sha512-vucgyPmgHrJ/D4/xQywAmjTmSfxAx2/aDmD6TkIoLu51FdsAfuWRbijWA48AePy60OO+l+mmy9p2P/CEeBZqig==}
+  /@microsoft/api-extractor-model@7.28.14(@types/node@20.10.6):
+    resolution: {integrity: sha512-Bery/c8A8SsKPSvA82cTTuy/+OcxZbLRmKhPkk91/AJOQzxZsShcrmHFAGeiEqSIrv1nPZ3tKq9kfMLdCHmsqg==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.63.0(@types/node@20.10.6)
+      '@rushstack/node-core-library': 4.1.0(@types/node@20.10.6)
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor@7.39.1(@types/node@20.10.6):
-    resolution: {integrity: sha512-V0HtCufWa8hZZvSmlEzQZfINcJkHAU/bmpyJQj6w+zpI87EkR8DuBOW6RWrO9c7mUYFZoDaNgUTyKo83ytv+QQ==}
+  /@microsoft/api-extractor@7.43.1(@types/node@20.10.6):
+    resolution: {integrity: sha512-ohg40SsvFFgzHFAtYq5wKJc8ZDyY46bphjtnSvhSSlXpPTG7GHwyyXkn48UZiUCBwr2WC7TRC1Jfwz7nreuiyQ==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.4(@types/node@20.10.6)
+      '@microsoft/api-extractor-model': 7.28.14(@types/node@20.10.6)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.63.0(@types/node@20.10.6)
-      '@rushstack/rig-package': 0.5.1
-      '@rushstack/ts-command-line': 4.17.1
-      colors: 1.2.5
+      '@rushstack/node-core-library': 4.1.0(@types/node@20.10.6)
+      '@rushstack/rig-package': 0.5.2
+      '@rushstack/terminal': 0.10.1(@types/node@20.10.6)
+      '@rushstack/ts-command-line': 4.19.2(@types/node@20.10.6)
       lodash: 4.17.21
+      minimatch: 3.0.8
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.3.3
+      typescript: 5.4.2
     transitivePeerDependencies:
       - '@types/node'
     dev: true
@@ -6402,8 +6403,8 @@ packages:
     dev: true
     optional: true
 
-  /@rushstack/node-core-library@3.63.0(@types/node@20.10.6):
-    resolution: {integrity: sha512-Q7B3dVpBQF1v+mUfxNcNZh5uHVR8ntcnkN5GYjbBLrxUYHBGKbnCM+OdcN+hzCpFlLBH6Ob0dEHhZ0spQwf24A==}
+  /@rushstack/node-core-library@4.1.0(@types/node@20.10.6):
+    resolution: {integrity: sha512-qz4JFBZJCf1YN5cAXa1dP6Mki/HrsQxc/oYGAGx29dF2cwF2YMxHoly0FBhMw3IEnxo5fMj0boVfoHVBkpkx/w==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -6411,7 +6412,6 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.10.6
-      colors: 1.2.5
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -6420,20 +6420,35 @@ packages:
       z-schema: 5.0.5
     dev: true
 
-  /@rushstack/rig-package@0.5.1:
-    resolution: {integrity: sha512-pXRYSe29TjRw7rqxD4WS3HN/sRSbfr+tJs4a9uuaSIBAITbUggygdhuG0VrO0EO+QqH91GhYMN4S6KRtOEmGVA==}
+  /@rushstack/rig-package@0.5.2:
+    resolution: {integrity: sha512-mUDecIJeH3yYGZs2a48k+pbhM6JYwWlgjs2Ca5f2n1G2/kgdgP9D/07oglEGf6mRyXEnazhEENeYTSNDRCwdqA==}
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
     dev: true
 
-  /@rushstack/ts-command-line@4.17.1:
-    resolution: {integrity: sha512-2jweO1O57BYP5qdBGl6apJLB+aRIn5ccIRTPDyULh0KMwVzFqWtw6IZWt1qtUoZD/pD2RNkIOosH6Cq45rIYeg==}
+  /@rushstack/terminal@0.10.1(@types/node@20.10.6):
+    resolution: {integrity: sha512-C6Vi/m/84IYJTkfzmXr1+W8Wi3MmBjVF/q3za91Gb3VYjKbpALHVxY6FgH625AnDe5Z0Kh4MHKWA3Z7bqgAezA==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
     dependencies:
+      '@rushstack/node-core-library': 4.1.0(@types/node@20.10.6)
+      '@types/node': 20.10.6
+      supports-color: 8.1.1
+    dev: true
+
+  /@rushstack/ts-command-line@4.19.2(@types/node@20.10.6):
+    resolution: {integrity: sha512-cqmXXmBEBlzo9WtyUrHtF9e6kl0LvBY7aTSVX4jfnBfXWZQWnPq9JTFPlQZ+L/ZwjZ4HrNwQsOVvhe9oOucZkw==}
+    dependencies:
+      '@rushstack/terminal': 0.10.1(@types/node@20.10.6)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
-      colors: 1.2.5
       string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
     dev: true
 
   /@sideway/address@4.1.4:
@@ -9323,11 +9338,6 @@ packages:
 
   /colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
-    dev: true
-
-  /colors@1.2.5:
-    resolution: {integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==}
-    engines: {node: '>=0.1.90'}
     dev: true
 
   /combined-stream@1.0.8:
@@ -13840,6 +13850,12 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /minimatch@3.0.8:
+    resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -17382,8 +17398,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.3.3:
-    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+  /typescript@5.4.2:
+    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": [
+    "./config/scripts/build-api.mjs"
+  ],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Fixes https://github.com/floating-ui/floating-ui/issues/2863

1. manually replace `React_2` for `React` from type generation at `build-api` script
2. adds `build-api` script as global dependency on turbo configuration
3. bumps `api-extractor` to latest version
4. adds changeset for patching:
   * `@floating-ui/react`
   * `@floating-ui/react-dom`
   * `@floating-ui/react-native`