### PR TITLE
fix(types): revert `React.JSX.Element` back to `JSX.Element`

### DIFF
--- a/.changeset/olive-bananas-run.md
+++ b/.changeset/olive-bananas-run.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(types): revert `React.JSX.Element` back to `JSX.Element`

--- a/packages/react/src/components/Composite.tsx
+++ b/packages/react/src/components/Composite.tsx
@@ -42,8 +42,8 @@ const CompositeContext = React.createContext<{
 });
 
 type RenderProp =
-  | React.JSX.Element
-  | ((props: React.HTMLAttributes<HTMLElement>) => React.JSX.Element);
+  | JSX.Element
+  | ((props: React.HTMLAttributes<HTMLElement>) => JSX.Element);
 
 interface CompositeProps {
   /**

--- a/packages/react/src/components/FloatingArrow.tsx
+++ b/packages/react/src/components/FloatingArrow.tsx
@@ -52,7 +52,7 @@ export interface FloatingArrowProps extends React.ComponentPropsWithRef<'svg'> {
 export const FloatingArrow = React.forwardRef(function FloatingArrow(
   props: FloatingArrowProps,
   ref: React.ForwardedRef<SVGSVGElement>,
-): React.JSX.Element | null {
+): JSX.Element | null {
   const {
     context: {
       placement,

--- a/packages/react/src/components/FloatingDelayGroup.tsx
+++ b/packages/react/src/components/FloatingDelayGroup.tsx
@@ -63,9 +63,9 @@ interface FloatingDelayGroupProps {
  * `delay`.
  * @see https://floating-ui.com/docs/FloatingDelayGroup
  */
-export const FloatingDelayGroup = (
+export function FloatingDelayGroup(
   props: FloatingDelayGroupProps,
-): React.JSX.Element => {
+): JSX.Element {
   const {children, delay, timeoutMs = 0} = props;
 
   const [state, setState] = React.useReducer(
@@ -111,7 +111,7 @@ export const FloatingDelayGroup = (
       {children}
     </FloatingDelayGroupContext.Provider>
   );
-};
+}
 
 interface UseGroupOptions {
   id?: any;

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -76,7 +76,7 @@ const VisuallyHiddenDismiss = React.forwardRef(function VisuallyHiddenDismiss(
 export interface FloatingFocusManagerProps<
   RT extends ReferenceType = ReferenceType,
 > {
-  children: React.JSX.Element;
+  children: JSX.Element;
   /**
    * The floating context returned from `useFloating`.
    */
@@ -145,7 +145,7 @@ export interface FloatingFocusManagerProps<
  */
 export function FloatingFocusManager<RT extends ReferenceType = ReferenceType>(
   props: FloatingFocusManagerProps<RT>,
-): React.JSX.Element {
+): JSX.Element {
   const {
     context,
     children,

--- a/packages/react/src/components/FloatingList.tsx
+++ b/packages/react/src/components/FloatingList.tsx
@@ -67,7 +67,7 @@ interface FloatingListProps {
  * Provides context for a list of items within the floating element.
  * @see https://floating-ui.com/docs/FloatingList
  */
-export function FloatingList(props: FloatingListProps): React.JSX.Element {
+export function FloatingList(props: FloatingListProps): JSX.Element {
   const {children, elementsRef, labelsRef} = props;
 
   const [map, setMap] = React.useState(() => new Map<Node, number | null>());

--- a/packages/react/src/components/FloatingPortal.tsx
+++ b/packages/react/src/components/FloatingPortal.tsx
@@ -134,7 +134,7 @@ interface FloatingPortalProps {
  * while retaining its location in the React tree.
  * @see https://floating-ui.com/docs/FloatingPortal
  */
-export function FloatingPortal(props: FloatingPortalProps): React.JSX.Element {
+export function FloatingPortal(props: FloatingPortalProps): JSX.Element {
   const {children, id, root = null, preserveTabOrder = true} = props;
 
   const portalNode = useFloatingPortalNode({id, root});

--- a/packages/react/src/components/FloatingTree.tsx
+++ b/packages/react/src/components/FloatingTree.tsx
@@ -51,7 +51,7 @@ export function useFloatingNodeId(customParentId?: string): string {
 export function FloatingNode(props: {
   children?: React.ReactNode;
   id: string;
-}): React.JSX.Element {
+}): JSX.Element {
   const {children, id} = props;
 
   const parentId = useFloatingParentNodeId();
@@ -75,9 +75,7 @@ export function FloatingNode(props: {
  * - Custom communication between parent and child floating elements
  * @see https://floating-ui.com/docs/FloatingTree
  */
-export function FloatingTree(props: {
-  children?: React.ReactNode;
-}): React.JSX.Element {
+export function FloatingTree(props: {children?: React.ReactNode}): JSX.Element {
   const {children} = props;
 
   const nodesRef = React.useRef<Array<FloatingNodeType>>([]);


### PR DESCRIPTION
Fixes #2866