### PR TITLE
perf(autoUpdate): throttle clipped updates to 1s

### DIFF
--- a/.changeset/popular-rats-repair.md
+++ b/.changeset/popular-rats-repair.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/dom": patch
+---
+
+perf(autoUpdate): reduce layoutShift update checks while reference is clipped from view

--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -89,9 +89,11 @@ function observeMove(element: Element, onMove: () => void) {
         }
 
         if (!ratio) {
+          // If the reference is clipped, the ratio is 0. Throttle the refresh
+          // to prevent an infinite loop of updates.
           timeoutId = setTimeout(() => {
             refresh(false, 1e-7);
-          }, 100);
+          }, 1000);
         } else {
           refresh(false, ratio);
         }


### PR DESCRIPTION
A couple of issues have brought up this loop; increasing the throttle from 0.1s to 1s to reduce strain if the reference is clipped while the floating element is open for extended periods. It's not critical for this to be quick, since a layout shift is unlikely to matter while the reference is clipped, and unlikely to occur <1s after it gets unclipped.