### PR TITLE
fix: ignore `clippingAncestors` for top layer elements

### DIFF
--- a/.changeset/few-news-pay.md
+++ b/.changeset/few-news-pay.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/dom": patch
+---
+
+fix: ignore `clippingAncestors` collision boundary for top layer elements

--- a/packages/dom/src/platform/getClippingRect.ts
+++ b/packages/dom/src/platform/getClippingRect.ts
@@ -26,6 +26,7 @@ import {getViewportRect} from '../utils/getViewportRect';
 import {getVisualOffsets} from '../utils/getVisualOffsets';
 import {getScale} from './getScale';
 import {isElement} from './isElement';
+import {isTopLayer} from '../utils/isTopLayer';
 
 type PlatformWithCache = Platform & {
   _c: Map<ReferenceElement, Element[]>;
@@ -170,7 +171,9 @@ export function getClippingRect(
 ): Rect {
   const elementClippingAncestors =
     boundary === 'clippingAncestors'
-      ? getClippingElementAncestors(element, this._c)
+      ? isTopLayer(element)
+        ? []
+        : getClippingElementAncestors(element, this._c)
       : [].concat(boundary);
   const clippingAncestors = [...elementClippingAncestors, rootBoundary];
   const firstClippingAncestor = clippingAncestors[0];


### PR DESCRIPTION
Fixes #2858