### PR TITLE
Prevent `setIsMounted` Infinite Loop in React 18

### DIFF
--- a/packages/react/src/hooks/useTransition.ts
+++ b/packages/react/src/hooks/useTransition.ts
@@ -22,9 +22,11 @@ function execWithArgsOrReturn<Value extends object | undefined, SidePlacement>(
 function useDelayUnmount(open: boolean, durationMs: number): boolean {
   const [isMounted, setIsMounted] = React.useState(open);
 
-  if (open && !isMounted) {
-    setIsMounted(true);
-  }
+  useModernLayoutEffect(() => {
+    if (open) {
+      setIsMounted(true);
+    }
+  }, [open]);
 
   React.useEffect(() => {
     if (!open) {


### PR DESCRIPTION
We're upgrading a React application to React 18, and we use `floating-ui`. In doing the upgrade, we encountered an infinite loop that occurs when some elements are hovered over. After doing some digging, we found that the root cause of the problem was:

```ts
function useDelayUnmount(open: boolean, durationMs: number): boolean {
  const [isMounted, setIsMounted] = React.useState(open);

  if (open && !isMounted) {
    setIsMounted(true); <- side effect executes during render
  }
```

We've validated that after wrapping the `setIsMounted` call in a `useLayoutEffect` (or, more accurately, a `useModernLayoutEffect`), the issue ceases to exist.