### PR TITLE
feat(FloatingFocusManager): `restoreFocus` prop

### DIFF
--- a/.changeset/selfish-lizards-grow.md
+++ b/.changeset/selfish-lizards-grow.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+feat(FloatingFocusManager): `restoreFocus` prop

--- a/.changeset/selfish-lizards-grow.md
+++ b/.changeset/selfish-lizards-grow.md
@@ -1,5 +1,5 @@
 ---
-"@floating-ui/react": patch
+'@floating-ui/react': patch
 ---
 
-feat(FloatingFocusManager): `restoreFocus` prop
+feat(FloatingFocusManager): `restoreFocus` prop. This enables automatic restoration of focus to the nearest tabbable element if the element that currently has focus inside the floating element is removed from the DOM.

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -309,7 +309,7 @@ export function FloatingFocusManager(
     return () => {
       floating.removeEventListener('focusin', handleFocusIn);
     };
-  }, [disabled, floating]);
+  }, [disabled, floating, getTabbableContent]);
 
   React.useEffect(() => {
     if (disabled) return;
@@ -407,6 +407,7 @@ export function FloatingFocusManager(
     onOpenChange,
     closeOnFocusOut,
     restoreFocus,
+    getTabbableContent,
   ]);
 
   React.useEffect(() => {

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -114,6 +114,12 @@ export interface FloatingFocusManagerProps {
    */
   returnFocus?: boolean;
   /**
+   * Determines if focus should be restored to the nearest tabbable element if
+   * focus inside the floating element is lost (such as due to the removal of
+   * the currently focused element from the DOM).
+   */
+  restoreFocus?: boolean;
+  /**
    * Determines if focus is “modal”, meaning focus is fully trapped inside the
    * floating element and outside content cannot be accessed. This includes
    * screen reader virtual cursors.
@@ -154,6 +160,7 @@ export function FloatingFocusManager(
     guards: _guards = true,
     initialFocus = 0,
     returnFocus = true,
+    restoreFocus = true,
     modal = true,
     visuallyHiddenDismiss = false,
     closeOnFocusOut = true,
@@ -193,6 +200,7 @@ export function FloatingFocusManager(
   const endDismissButtonRef = React.useRef<HTMLButtonElement>(null);
   const preventReturnFocusRef = React.useRef(false);
   const isPointerDownRef = React.useRef(false);
+  const tabbableIndexRef = React.useRef(-1);
 
   const isInsidePortal = portalContext != null;
   const firstElementChild = floating?.firstElementChild;
@@ -227,7 +235,8 @@ export function FloatingFocusManager(
   });
 
   React.useEffect(() => {
-    if (disabled || !modal) return;
+    if (disabled) return;
+    if (!modal) return;
 
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === 'Tab') {
@@ -283,7 +292,28 @@ export function FloatingFocusManager(
   ]);
 
   React.useEffect(() => {
-    if (disabled || !closeOnFocusOut) return;
+    if (disabled) return;
+    if (!floating) return;
+
+    function handleFocusIn(event: FocusEvent) {
+      const target = getTarget(event) as Element | null;
+      const tabbableContent = getTabbableContent() as Array<Element | null>;
+      const tabbableIndex = tabbableContent.indexOf(target);
+      if (tabbableIndex !== -1) {
+        tabbableIndexRef.current = tabbableIndex;
+      }
+    }
+
+    floating.addEventListener('focusin', handleFocusIn);
+
+    return () => {
+      floating.removeEventListener('focusin', handleFocusIn);
+    };
+  }, [disabled, floating]);
+
+  React.useEffect(() => {
+    if (disabled) return;
+    if (!closeOnFocusOut) return;
 
     // In Safari, buttons lose focus when pressing them.
     function handlePointerDown() {
@@ -316,9 +346,32 @@ export function FloatingFocusManager(
               )))
         );
 
+        if (
+          restoreFocus &&
+          activeElement(getDocument(floating)) === getDocument(floating).body
+        ) {
+          // Let `FloatingPortal` effect knows that focus is still inside the
+          // floating tree.
+          floating?.focus();
+
+          const prevTabbableIndex = tabbableIndexRef.current;
+          const tabbableContent = getTabbableContent() as Array<Element | null>;
+          const nodeToFocus =
+            tabbableContent[prevTabbableIndex] ||
+            tabbableContent[tabbableContent.length - 1] ||
+            floating;
+
+          // Restore focus to the previous tabbable element index to prevent
+          // focus from being lost outside the floating tree.
+          if (isHTMLElement(nodeToFocus)) {
+            nodeToFocus.focus();
+          }
+        }
+
         // Focus did not move inside the floating tree, and there are no tabbable
         // portal guards to handle closing.
         if (
+          !modal &&
           relatedTarget &&
           movedToUnrelatedNode &&
           !isPointerDownRef.current &&
@@ -334,12 +387,12 @@ export function FloatingFocusManager(
     if (floating && isHTMLElement(domReference)) {
       domReference.addEventListener('focusout', handleFocusOutside);
       domReference.addEventListener('pointerdown', handlePointerDown);
-      !modal && floating.addEventListener('focusout', handleFocusOutside);
+      floating.addEventListener('focusout', handleFocusOutside);
 
       return () => {
         domReference.removeEventListener('focusout', handleFocusOutside);
         domReference.removeEventListener('pointerdown', handlePointerDown);
-        !modal && floating.removeEventListener('focusout', handleFocusOutside);
+        floating.removeEventListener('focusout', handleFocusOutside);
       };
     }
   }, [
@@ -352,6 +405,7 @@ export function FloatingFocusManager(
     portalContext,
     onOpenChange,
     closeOnFocusOut,
+    restoreFocus,
   ]);
 
   React.useEffect(() => {
@@ -538,7 +592,8 @@ export function FloatingFocusManager(
   // Synchronize the `context` & `modal` value to the FloatingPortal context.
   // It will decide whether or not it needs to render its own guards.
   useModernLayoutEffect(() => {
-    if (disabled || !portalContext) return;
+    if (disabled) return;
+    if (!portalContext) return;
 
     portalContext.setFocusManagerState({
       modal,
@@ -562,22 +617,24 @@ export function FloatingFocusManager(
   ]);
 
   useModernLayoutEffect(() => {
-    if (
-      disabled ||
-      !floatingFocusNode ||
-      typeof MutationObserver !== 'function' ||
-      ignoreInitialFocus
-    ) {
-      return;
-    }
+    if (disabled) return;
+    if (!floatingFocusNode) return;
+    if (typeof MutationObserver !== 'function') return;
+    if (ignoreInitialFocus) return;
 
     const handleMutation = () => {
       const tabIndex = floatingFocusNode.getAttribute('tabindex');
+      const tabbableContent = getTabbableContent() as Array<Element | null>;
+      const activeEl = activeElement(getDocument(floating));
+      const tabbableIndex = tabbableContent.indexOf(activeEl);
+
+      if (tabbableIndex !== -1) {
+        tabbableIndexRef.current = tabbableIndex;
+      }
+
       if (
         orderRef.current.includes('floating') ||
-        (activeElement(getDocument(floatingFocusNode)) !==
-          refs.domReference.current &&
-          getTabbableContent().length === 0)
+        (activeEl !== refs.domReference.current && tabbableContent.length === 0)
       ) {
         if (tabIndex !== '0') {
           floatingFocusNode.setAttribute('tabindex', '0');

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -117,6 +117,7 @@ export interface FloatingFocusManagerProps {
    * Determines if focus should be restored to the nearest tabbable element if
    * focus inside the floating element is lost (such as due to the removal of
    * the currently focused element from the DOM).
+   * @default false
    */
   restoreFocus?: boolean;
   /**
@@ -160,7 +161,7 @@ export function FloatingFocusManager(
     guards: _guards = true,
     initialFocus = 0,
     returnFocus = true,
-    restoreFocus = true,
+    restoreFocus = false,
     modal = true,
     visuallyHiddenDismiss = false,
     closeOnFocusOut = true,

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -346,8 +346,11 @@ export function FloatingFocusManager(
               )))
         );
 
+        // Restore focus to the previous tabbable element index to prevent
+        // focus from being lost outside the floating tree.
         if (
           restoreFocus &&
+          movedToUnrelatedNode &&
           activeElement(getDocument(floating)) === getDocument(floating).body
         ) {
           // Let `FloatingPortal` effect knows that focus is still inside the
@@ -361,8 +364,6 @@ export function FloatingFocusManager(
             tabbableContent[tabbableContent.length - 1] ||
             floating;
 
-          // Restore focus to the previous tabbable element index to prevent
-          // focus from being lost outside the floating tree.
           if (isHTMLElement(nodeToFocus)) {
             nodeToFocus.focus();
           }

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -660,6 +660,7 @@ export function FloatingFocusManager(
     };
   }, [
     disabled,
+    floating,
     floatingFocusNode,
     refs,
     orderRef,

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -352,18 +352,21 @@ export function FloatingFocusManager(
         if (
           restoreFocus &&
           movedToUnrelatedNode &&
-          activeElement(getDocument(floating)) === getDocument(floating).body
+          activeElement(getDocument(floatingFocusNode)) ===
+            getDocument(floatingFocusNode).body
         ) {
           // Let `FloatingPortal` effect knows that focus is still inside the
           // floating tree.
-          floating?.focus();
+          if (isHTMLElement(floatingFocusNode)) {
+            floatingFocusNode?.focus();
+          }
 
           const prevTabbableIndex = tabbableIndexRef.current;
           const tabbableContent = getTabbableContent() as Array<Element | null>;
           const nodeToFocus =
             tabbableContent[prevTabbableIndex] ||
             tabbableContent[tabbableContent.length - 1] ||
-            floating;
+            floatingFocusNode;
 
           if (isHTMLElement(nodeToFocus)) {
             nodeToFocus.focus();
@@ -401,6 +404,7 @@ export function FloatingFocusManager(
     disabled,
     domReference,
     floating,
+    floatingFocusNode,
     modal,
     nodeId,
     tree,

--- a/packages/react/test/visual/components/Omnibox.tsx
+++ b/packages/react/test/visual/components/Omnibox.tsx
@@ -162,29 +162,6 @@ export function Main() {
     }
   }
 
-  // Restore focus to an item when one gets removed.
-  useLayoutEffect(() => {
-    if (!isOpen || removedIndexRef.current === null) {
-      return;
-    }
-
-    const restoreIndex =
-      removedIndexRef.current === options.length
-        ? removedIndexRef.current - 1
-        : removedIndexRef.current;
-
-    if (restoreIndex !== -1) {
-      setActiveIndex(null);
-      queueMicrotask(() => {
-        setActiveIndex(restoreIndex);
-      });
-    } else {
-      refs.domReference.current?.focus();
-    }
-
-    removedIndexRef.current = null;
-  }, [options, isOpen, refs]);
-
   return (
     <>
       <h1 className="text-5xl font-bold mb-8">Omnibox</h1>

--- a/packages/react/test/visual/components/Omnibox.tsx
+++ b/packages/react/test/visual/components/Omnibox.tsx
@@ -181,6 +181,7 @@ export function Main() {
           <FloatingFocusManager
             context={context}
             initialFocus={-1}
+            restoreFocus
             modal={false}
           >
             <div


### PR DESCRIPTION
Closes #2903

Currently you need to manually restore focus to the nearest element if the focused element was removed (as done in the `Omnibox` local demo), or focus the floating element itself. 

This does it automatically via a boolean prop. I'm not sure if it should be configurable, with the option to focus the entire floating element itself instead; for example, if the whole dialog's content gets replaced with a new screen, that may be preferrable?

@haagmm-ef