### PR TITLE
fix(useListNavigation): correct `scrollIntoView` and `focus` behavior with virtual focus and inner focused element

### DIFF
--- a/.changeset/proud-suits-kiss.md
+++ b/.changeset/proud-suits-kiss.md
@@ -2,4 +2,4 @@
 "@floating-ui/react": patch
 ---
 
-fix(useListNavigation): correct scrollIntoView and focus behavior with virtual focus and inner focused element
+fix(useListNavigation): correct `scrollIntoView` and `focus` behavior with virtual focus and inner DOM-focused element + `FloatingList`

--- a/.changeset/proud-suits-kiss.md
+++ b/.changeset/proud-suits-kiss.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useListNavigation): correct scrollIntoView and focus behavior with virtual focus and inner focused element

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -321,12 +321,12 @@ export function useListNavigation(
       function runFocus(item: HTMLElement) {
         if (virtual) {
           setActiveId(item.id);
-          tree?.events.emit('virtualfocus', initialItem);
+          tree?.events.emit('virtualfocus', item);
           if (virtualItemRef) {
-            virtualItemRef.current = initialItem;
+            virtualItemRef.current = item;
           }
         } else {
-          enqueueFocus(initialItem, {
+          enqueueFocus(item, {
             preventScroll: true,
             // Mac Safari does not move the virtual cursor unless the focus call
             // is sync. However, for the very first focus call, we need to wait
@@ -351,7 +351,7 @@ export function useListNavigation(
       }
 
       requestAnimationFrame(() => {
-        const waitedItem = listRef.current[indexRef.current];
+        const waitedItem = listRef.current[indexRef.current] || initialItem;
 
         if (!waitedItem) return;
 


### PR DESCRIPTION


Fixes #2861 