### PR TITLE
fix(useListNavigation): prevent `selectedIndex` changes from stealing focus

### DIFF
--- a/.changeset/seven-pens-reflect.md
+++ b/.changeset/seven-pens-reflect.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useListNavigation): prevent `selectedIndex` changes from stealing focus

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -309,6 +309,7 @@ export function useListNavigation(
   const latestOpenRef = useLatestRef(open);
   const scrollItemIntoViewRef = useLatestRef(scrollItemIntoView);
   const floatingRef = useLatestRef(floating);
+  const selectedIndexRef = useLatestRef(selectedIndex);
 
   const [activeId, setActiveId] = React.useState<string | undefined>();
   const [virtualId, setVirtualId] = React.useState<string | undefined>();
@@ -423,7 +424,7 @@ export function useListNavigation(
       if (activeIndex == null) {
         forceSyncFocus.current = false;
 
-        if (selectedIndex != null) {
+        if (selectedIndexRef.current != null) {
           return;
         }
 
@@ -476,7 +477,7 @@ export function useListNavigation(
     open,
     floating,
     activeIndex,
-    selectedIndex,
+    selectedIndexRef,
     nested,
     listRef,
     orientation,

--- a/packages/react/test/unit/useListNavigation.test.tsx
+++ b/packages/react/test/unit/useListNavigation.test.tsx
@@ -17,6 +17,7 @@ import type {UseListNavigationProps} from '../../src/hooks/useListNavigation';
 import {Main as ComplexGrid} from '../visual/components/ComplexGrid';
 import {Main as Grid} from '../visual/components/Grid';
 import {Main as EmojiPicker} from '../visual/components/EmojiPicker';
+import {Main as ListboxFocus} from '../visual/components/ListboxFocus';
 
 function App(props: Omit<Partial<UseListNavigationProps>, 'listRef'>) {
   const [open, setOpen] = useState(false);
@@ -1096,4 +1097,13 @@ test('grid navigation with disabled list items', async () => {
   await userEvent.keyboard('{ArrowUp}');
 
   expect(screen.getByLabelText('cherry')).toHaveAttribute('data-active');
+});
+
+test('selectedIndex changing does not steal focus', async () => {
+  render(<ListboxFocus />);
+
+  await userEvent.click(screen.getByRole('button'));
+  await act(async () => {});
+
+  expect(screen.getByTestId('reference')).toHaveFocus();
 });

--- a/packages/react/test/unit/useListNavigation.test.tsx
+++ b/packages/react/test/unit/useListNavigation.test.tsx
@@ -1102,7 +1102,7 @@ test('grid navigation with disabled list items', async () => {
 test('selectedIndex changing does not steal focus', async () => {
   render(<ListboxFocus />);
 
-  await userEvent.click(screen.getByRole('button'));
+  await userEvent.click(screen.getByTestId('reference'));
   await act(async () => {});
 
   expect(screen.getByTestId('reference')).toHaveFocus();

--- a/packages/react/test/visual/components/ListboxFocus.tsx
+++ b/packages/react/test/visual/components/ListboxFocus.tsx
@@ -1,0 +1,133 @@
+import {
+  useFloating,
+  useInteractions,
+  useListNavigation,
+  useTypeahead,
+  useListItem,
+  useRole,
+  FloatingList,
+} from '@floating-ui/react';
+import * as React from 'react';
+
+interface SelectContextValue {
+  activeIndex: number | null;
+  selectedIndex: number | null;
+  getItemProps: ReturnType<typeof useInteractions>['getItemProps'];
+  handleSelect: (index: number | null) => void;
+}
+
+const SelectContext = React.createContext<SelectContextValue>(
+  {} as SelectContextValue,
+);
+
+function Listbox({children}: {children: React.ReactNode}) {
+  const [activeIndex, setActiveIndex] = React.useState<number | null>(1);
+  const [selectedIndex, setSelectedIndex] = React.useState<number | null>(null);
+
+  const {refs, context} = useFloating({
+    open: true,
+  });
+
+  const elementsRef = React.useRef<Array<HTMLElement | null>>([]);
+  const labelsRef = React.useRef<Array<string | null>>([]);
+
+  const handleSelect = React.useCallback((index: number | null) => {
+    setSelectedIndex(index);
+  }, []);
+
+  function handleTypeaheadMatch(index: number | null) {
+    setActiveIndex(index);
+  }
+
+  const listNav = useListNavigation(context, {
+    listRef: elementsRef,
+    activeIndex,
+    selectedIndex,
+    onNavigate: setActiveIndex,
+    focusItemOnHover: false,
+  });
+  const typeahead = useTypeahead(context, {
+    listRef: labelsRef,
+    activeIndex,
+    selectedIndex,
+    onMatch: handleTypeaheadMatch,
+  });
+  const role = useRole(context, {role: 'listbox'});
+
+  const {getFloatingProps, getItemProps} = useInteractions([
+    listNav,
+    typeahead,
+    role,
+  ]);
+
+  const selectContext = React.useMemo(
+    () => ({
+      activeIndex,
+      selectedIndex,
+      getItemProps,
+      handleSelect,
+    }),
+    [activeIndex, selectedIndex, getItemProps, handleSelect],
+  );
+
+  return (
+    <>
+      <SelectContext.Provider value={selectContext}>
+        <button onClick={() => setSelectedIndex(1)} data-testid="reference">
+          Select
+        </button>
+        <div ref={refs.setFloating} {...getFloatingProps()}>
+          <FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
+            {children}
+          </FloatingList>
+        </div>
+      </SelectContext.Provider>
+    </>
+  );
+}
+
+function Option({label}: {label: string}) {
+  const {activeIndex, selectedIndex, getItemProps, handleSelect} =
+    React.useContext(SelectContext);
+
+  const {ref, index} = useListItem({label});
+
+  const isActive = activeIndex === index;
+  const isSelected = selectedIndex === index;
+
+  const isFocusable =
+    activeIndex !== null
+      ? isActive
+      : selectedIndex !== null
+        ? isSelected
+        : index === 0;
+
+  return (
+    <button
+      ref={ref}
+      role="option"
+      aria-selected={isActive && isSelected}
+      tabIndex={isFocusable ? 0 : -1}
+      style={{
+        background: isActive ? 'cyan' : '',
+        fontWeight: isSelected ? 'bold' : '',
+      }}
+      {...getItemProps({
+        onClick: () => handleSelect(index),
+      })}
+    >
+      {label}
+    </button>
+  );
+}
+
+export function Main() {
+  return (
+    <Listbox>
+      <Option label="Apple" />
+      <Option label="Blueberry" />
+      <Option label="Watermelon" />
+      <Option label="Banana" />
+    </Listbox>
+  );
+}


### PR DESCRIPTION
Fixes #2883