### PR TITLE
fix(useHover): `restMs` option for `useHover` causes SyntheticEvent warning on React < 17

### DIFF
--- a/.changeset/unlucky-geese-switch.md
+++ b/.changeset/unlucky-geese-switch.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useHover): fix restMs options throwing SyntheticEvent warning on React < 17

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -437,9 +437,11 @@ export function useHover(
         onPointerDown: setPointerRef,
         onPointerEnter: setPointerRef,
         onMouseMove(event) {
+          const { nativeEvent } = event;
+
           function handleMouseMove() {
             if (!blockMouseMoveRef.current) {
-              onOpenChange(true, event.nativeEvent, 'hover');
+              onOpenChange(true, nativeEvent, 'hover');
             }
           }
 


### PR DESCRIPTION
Fixes #2923 