### PR TITLE
Export FloatingPortalProps

### DIFF
--- a/.changeset/nine-flies-accept.md
+++ b/.changeset/nine-flies-accept.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(types): export `FloatingPortalProps`, `CompositeProps`, `CompositeItemProps`

--- a/packages/react/src/components/Composite.tsx
+++ b/packages/react/src/components/Composite.tsx
@@ -46,7 +46,7 @@ type RenderProp =
   | JSX.Element
   | ((props: React.HTMLAttributes<HTMLElement>) => JSX.Element);
 
-interface CompositeProps {
+export interface CompositeProps {
   /**
    * Determines the element to render.
    * @example
@@ -300,7 +300,7 @@ export const Composite = React.forwardRef<
   );
 });
 
-interface CompositeItemProps {
+export interface CompositeItemProps {
   /**
    * Determines the element to render.
    * @example

--- a/packages/react/src/components/FloatingPortal.tsx
+++ b/packages/react/src/components/FloatingPortal.tsx
@@ -112,7 +112,7 @@ export function useFloatingPortalNode(
   return portalNode;
 }
 
-interface FloatingPortalProps {
+export interface FloatingPortalProps {
   children?: React.ReactNode;
   /**
    * Optionally selects the node with the id if it exists, or create it and

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -11,6 +11,8 @@ export * from '.';
 export type {FloatingArrowProps} from './components/FloatingArrow';
 export type {FloatingFocusManagerProps} from './components/FloatingFocusManager';
 export type {FloatingOverlayProps} from './components/FloatingOverlay';
+export type {FloatingPortalProps} from './components/FloatingPortal';
+export type {CompositeProps, CompositeItemProps} from './components/Composite';
 export type {UseClickProps} from './hooks/useClick';
 export type {UseClientPointProps} from './hooks/useClientPoint';
 export type {UseDismissProps} from './hooks/useDismiss';


### PR DESCRIPTION
This is an amazing project, thank you! 

I just noted that `FloatingFocusManagerProps`, `UseFloatingOptions` etc are all exported except for FloatingPortalProps. This PR proposes that.

Please let me know if this doesn't make sense!