### PR TITLE
fix(getClippingRect): correct clipping ancestor element detection

### DIFF
--- a/packages/dom/src/platform/getClippingRect.ts
+++ b/packages/dom/src/platform/getClippingRect.ts
@@ -121,7 +121,7 @@ function getClippingElementAncestors(
     const computedStyle = getComputedStyle(currentNode);
     const currentNodeIsContaining = isContainingBlock(currentNode);
 
-    if (!currentNodeIsContaining && computedStyle.position === 'fixed') {
+    if (!currentNodeIsContaining) {
       currentContainingBlockComputedStyle = null;
     }
 


### PR DESCRIPTION
Fixes #2934