### PR TITLE
refactor: use `scrollX`/`scrollY` instead of deprecated `pageXOffset`/`pageYOffset`

### DIFF
--- a/.changeset/chatty-pens-cough.md
+++ b/.changeset/chatty-pens-cough.md
@@ -1,0 +1,6 @@
+---
+"@floating-ui/react": patch
+"@floating-ui/utils": patch
+---
+
+refactor: use `scrollX`/`scrollY` instead of deprecated `pageXOffset`/`pageYOffset`

--- a/packages/react/src/components/FloatingOverlay.tsx
+++ b/packages/react/src/components/FloatingOverlay.tsx
@@ -44,10 +44,8 @@ export const FloatingOverlay = React.forwardRef(function FloatingOverlay(
       window.innerWidth - document.documentElement.clientWidth;
     const scrollX = bodyStyle.left
       ? parseFloat(bodyStyle.left)
-      : window.pageXOffset;
-    const scrollY = bodyStyle.top
-      ? parseFloat(bodyStyle.top)
-      : window.pageYOffset;
+      : window.scrollX;
+    const scrollY = bodyStyle.top ? parseFloat(bodyStyle.top) : window.scrollY;
 
     bodyStyle.overflow = 'hidden';
 

--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -131,8 +131,8 @@ export function getNodeScroll(element: Element | Window): {
   }
 
   return {
-    scrollLeft: element.pageXOffset,
-    scrollTop: element.pageYOffset,
+    scrollLeft: element.scrollX,
+    scrollTop: element.scrollY,
   };
 }
 


### PR DESCRIPTION
The `pageXOffset` and `pageYOffset` properties have been deprecated. In this PR, I have replaced `element.pageXOffset` with `element.scrollX` and `element.pageYOffset` with `element.scrollY`.

The `scrollX` and `scrollY` properties are supported by most modern browsers, with the only exception being Internet Explorer. However, according to the [Floating UI support list](https://floating-ui.com/docs/misc), our project no longer requires support for IE. This allows us to utilize these modern properties.