### PR TITLE
feat(vue): support `MaybeReadonlyRefOrGetter` in `useFloating`

### DIFF
--- a/.changeset/green-apricots-eat.md
+++ b/.changeset/green-apricots-eat.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/vue": minor
+---
+
+feat: support `MaybeReadonlyRefOrGetter` in `useFloating`

--- a/packages/vue/src/arrow.ts
+++ b/packages/vue/src/arrow.ts
@@ -1,6 +1,6 @@
 import type {Middleware} from '@floating-ui/dom';
 import {arrow as apply} from '@floating-ui/dom';
-import {unref} from 'vue-demi';
+import {toValue} from 'vue-demi';
 
 import type {ArrowOptions} from './types';
 import {unwrapElement} from './utils/unwrapElement';
@@ -15,7 +15,7 @@ export function arrow(options: ArrowOptions): Middleware {
     name: 'arrow',
     options,
     fn(args) {
-      const element = unwrapElement(unref(options.element));
+      const element = unwrapElement(toValue(options.element));
 
       if (element == null) {
         return {};

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -53,6 +53,8 @@ export type {
 
 export type MaybeReadonlyRef<T> = T | Readonly<Ref<T>>;
 
+export type MaybeReadonlyRefOrGetter<T> = MaybeReadonlyRef<T> | (() => T);
+
 export type MaybeElement<T> = T | ComponentPublicInstance | null | undefined;
 
 export type UseFloatingOptions<T extends ReferenceElement = ReferenceElement> =
@@ -61,28 +63,28 @@ export type UseFloatingOptions<T extends ReferenceElement = ReferenceElement> =
      * Represents the open/close state of the floating element.
      * @default true
      */
-    open?: MaybeReadonlyRef<boolean | undefined>;
+    open?: MaybeReadonlyRefOrGetter<boolean | undefined>;
     /**
      * Where to place the floating element relative to its reference element.
      * @default 'bottom'
      */
-    placement?: MaybeReadonlyRef<Placement | undefined>;
+    placement?: MaybeReadonlyRefOrGetter<Placement | undefined>;
     /**
      * The type of CSS position property to use.
      * @default 'absolute'
      */
-    strategy?: MaybeReadonlyRef<Strategy | undefined>;
+    strategy?: MaybeReadonlyRefOrGetter<Strategy | undefined>;
     /**
      * These are plain objects that modify the positioning coordinates in some fashion, or provide useful data for the consumer to use.
      * @default undefined
      */
-    middleware?: MaybeReadonlyRef<Middleware[] | undefined>;
+    middleware?: MaybeReadonlyRefOrGetter<Middleware[] | undefined>;
     /**
      * Whether to use `transform` instead of `top` and `left` styles to
      * position the floating element (`floatingStyles`).
      * @default true
      */
-    transform?: MaybeReadonlyRef<boolean | undefined>;
+    transform?: MaybeReadonlyRefOrGetter<boolean | undefined>;
     /**
      * Callback to handle mounting/unmounting of the elements.
      * @default undefined
@@ -142,7 +144,7 @@ export type ArrowOptions = {
    * The arrow element or template ref to be positioned.
    * @required
    */
-  element: MaybeReadonlyRef<MaybeElement<Element>>;
+  element: MaybeReadonlyRefOrGetter<MaybeElement<Element>>;
   /**
    * The padding between the arrow element and the floating element edges. Useful when the floating element has rounded corners.
    * @default 0

--- a/packages/vue/src/useFloating.ts
+++ b/packages/vue/src/useFloating.ts
@@ -12,8 +12,8 @@ import {
   ref,
   shallowReadonly,
   shallowRef,
-  unref,
   watch,
+  toValue,
 } from 'vue-demi';
 
 import type {
@@ -38,11 +38,15 @@ export function useFloating<T extends ReferenceElement = ReferenceElement>(
   options: UseFloatingOptions<T> = {},
 ): UseFloatingReturn {
   const whileElementsMountedOption = options.whileElementsMounted;
-  const openOption = computed(() => unref(options.open) ?? true);
-  const middlewareOption = computed(() => unref(options.middleware));
-  const placementOption = computed(() => unref(options.placement) ?? 'bottom');
-  const strategyOption = computed(() => unref(options.strategy) ?? 'absolute');
-  const transformOption = computed(() => unref(options.transform) ?? true);
+  const openOption = computed(() => toValue(options.open) ?? true);
+  const middlewareOption = computed(() => toValue(options.middleware));
+  const placementOption = computed(
+    () => toValue(options.placement) ?? 'bottom',
+  );
+  const strategyOption = computed(
+    () => toValue(options.strategy) ?? 'absolute',
+  );
+  const transformOption = computed(() => toValue(options.transform) ?? true);
   const referenceElement = computed(() => unwrapElement(reference.value));
   const floatingElement = computed(() => unwrapElement(floating.value));
   const x = ref(0);

--- a/packages/vue/test/index.test.ts
+++ b/packages/vue/test/index.test.ts
@@ -141,12 +141,137 @@ describe('useFloating', () => {
     });
   });
 
+  test('updates floating coords when placement is a getter function', async () => {
+    const App = defineComponent({
+      name: 'App',
+      props: ['placement'],
+      setup(props: {placement?: Placement}) {
+        return setup({
+          placement: () => props.placement,
+          middleware: [offset(5)],
+        });
+      },
+      template: /* HTML */ `
+        <div ref="reference" />
+        <div ref="floating" />
+        <div data-testid="x">{{x}}</div>
+        <div data-testid="y">{{y}}</div>
+      `,
+    });
+
+    const {rerender, getByTestId} = render(App, {
+      props: {placement: 'bottom'},
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('x').textContent).toBe('0');
+      expect(getByTestId('y').textContent).toBe('5');
+    });
+
+    await rerender({placement: 'right'});
+
+    await waitFor(() => {
+      expect(getByTestId('x').textContent).toBe('5');
+      expect(getByTestId('y').textContent).toBe('0');
+    });
+  });
+
+  test('updates floating coords when middleware is a getter function', async () => {
+    const App = defineComponent({
+      name: 'App',
+      props: ['middleware'],
+      setup(props) {
+        return setup({middleware: () => props.middleware});
+      },
+      template: /* HTML */ `
+        <div ref="reference" />
+        <div ref="floating" />
+        <div data-testid="x">{{x}}</div>
+        <div data-testid="y">{{y}}</div>
+      `,
+    });
+
+    const {rerender, getByTestId} = render(App, {
+      props: {middleware: []},
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('x').textContent).toBe('0');
+      expect(getByTestId('y').textContent).toBe('0');
+    });
+
+    await rerender({middleware: [offset(10)]});
+
+    await waitFor(() => {
+      expect(getByTestId('x').textContent).toBe('0');
+      expect(getByTestId('y').textContent).toBe('10');
+    });
+  });
+
+  test('updates floating position when strategy is a getter function', async () => {
+    const App = defineComponent({
+      name: 'App',
+      props: ['strategy'],
+      setup(props: {strategy?: Strategy}) {
+        return setup({strategy: () => props.strategy});
+      },
+      template: /* HTML */ `
+        <div ref="reference" />
+        <div ref="floating" />
+        <div data-testid="position">{{strategy}}</div>
+      `,
+    });
+
+    const {rerender, getByTestId} = render(App, {
+      props: {strategy: 'absolute'},
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('position').textContent).toBe('absolute');
+    });
+
+    await rerender({strategy: 'fixed'});
+
+    await waitFor(() => {
+      expect(getByTestId('position').textContent).toBe('fixed');
+    });
+  });
+
   test('resets `isPositioned` on open change', async () => {
     const App = defineComponent({
       name: 'App',
       props: ['open'],
       setup(props: {open?: boolean}) {
         return setup({open: toRef(props, 'open')});
+      },
+      template: /* HTML */ `
+        <div ref="reference" />
+        <div ref="floating" />
+        <div data-testid="isPositioned">{{isPositioned}}</div>
+      `,
+    });
+
+    const {rerender, getByTestId} = render(App, {
+      props: {open: true},
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('isPositioned').textContent).toBe('true');
+    });
+
+    await rerender({open: false});
+
+    await waitFor(() => {
+      expect(getByTestId('isPositioned').textContent).toBe('false');
+    });
+  });
+
+  test('resets `isPositioned` on open change and open is a getter function', async () => {
+    const App = defineComponent({
+      name: 'App',
+      props: ['open'],
+      setup(props: {open?: boolean}) {
+        return setup({open: () => props.open});
       },
       template: /* HTML */ `
         <div ref="reference" />


### PR DESCRIPTION
When we encapsulate `useFloating` into a Vue component, we hope to allow users to pass in settings such as `offset` and `arrow` from outside the component. Currently, we need to pass in `Ref` to keep `useFloating` responsive with the component.

```ts
useFloating(refrenceRef, popoverRef, {
  // or use `toRef(() => [offset(props.offset)])`
  middleware: computed(() => [offset(props.offset)])
})
```

`MaybeRefOrGetter` is already widely used by developers. It would be wonderful if Floating UI could also adopt it!

By adopting `MaybeRefOrGetter`, we can simplify the usage slightly:

```ts
useFloating(refrenceRef, popoverRef, {
  middleware: () => [offset(props.offset)]
})
```

This PR introduces `MaybeReadonlyRefOrGetter` and retains `MaybeReadonlyRef` to ensure complete backward compatibility.

Please let me know if there are any aspects I have overlooked. Thanks!