### PR TITLE
fix(vue): ensure getter available work in vue of earlier versions

### DIFF
--- a/.changeset/funny-parrots-cheer.md
+++ b/.changeset/funny-parrots-cheer.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/vue": patch
+---
+
+fix: ensure `MaybeReadonlyRefOrGetter` works in earlier versions of Vue

--- a/packages/vue/src/arrow.ts
+++ b/packages/vue/src/arrow.ts
@@ -1,9 +1,9 @@
 import type {Middleware} from '@floating-ui/dom';
 import {arrow as apply} from '@floating-ui/dom';
-import {toValue} from 'vue-demi';
 
 import type {ArrowOptions} from './types';
 import {unwrapElement} from './utils/unwrapElement';
+import {toValue} from './utils/toValue';
 
 /**
  * Positions an inner element of the floating element such that it is centered to the reference element.

--- a/packages/vue/src/useFloating.ts
+++ b/packages/vue/src/useFloating.ts
@@ -13,7 +13,6 @@ import {
   shallowReadonly,
   shallowRef,
   watch,
-  toValue,
 } from 'vue-demi';
 
 import type {
@@ -24,6 +23,7 @@ import type {
 import {getDPR} from './utils/getDPR';
 import {roundByDPR} from './utils/roundByDPR';
 import {unwrapElement} from './utils/unwrapElement';
+import {toValue} from './utils/toValue';
 
 /**
  * Computes the `x` and `y` coordinates that will place the floating element next to a reference element when it is given a certain CSS positioning strategy.

--- a/packages/vue/src/utils/toValue.ts
+++ b/packages/vue/src/utils/toValue.ts
@@ -1,0 +1,11 @@
+import {unref} from 'vue-demi';
+import type {Ref} from 'vue-demi';
+
+type MaybeRef<T> = T | Ref<T>;
+type MaybeRefOrGetter<T> = MaybeRef<T> | (() => T);
+
+type AnyFn = (...args: any[]) => any;
+
+export function toValue<T>(source: MaybeRefOrGetter<T>): T {
+  return typeof source === 'function' ? (source as AnyFn)() : unref(source);
+}


### PR DESCRIPTION
Resolve #2959 

In Vue 2 or earlier versions of Vue 3, the `toValue` API is not supported. Therefore, this PR implements `toValue` internally to ensure proper functionality in older versions.