### PR TITLE
ancestorResize uses ResizeObserver when available

### DIFF
--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -150,10 +150,17 @@ export function autoUpdate(
         ]
       : [];
 
+  const ancestorResizeObserver =
+    typeof ResizeObserver === 'function' ? new ResizeObserver(update) : null;
   ancestors.forEach((ancestor) => {
     ancestorScroll &&
       ancestor.addEventListener('scroll', update, {passive: true});
-    ancestorResize && ancestor.addEventListener('resize', update);
+    if (ancestorResize) {
+      ancestor.addEventListener('resize', update);
+      if (ancestor instanceof Element) {
+        ancestorResizeObserver?.observe(ancestor);
+      }
+    }
   });
 
   const cleanupIo =
@@ -217,6 +224,7 @@ export function autoUpdate(
     cleanupIo?.();
     resizeObserver?.disconnect();
     resizeObserver = null;
+    ancestorResizeObserver?.disconnect();
 
     if (animationFrame) {
       cancelAnimationFrame(frameId);


### PR DESCRIPTION
just dropping this here to see if it's a welcome addition / curious why it's not implemented this way.

I had to add this logic to my own project to get my floaties to follow their target element correctly.

Will flesh it out (changeset? tests?) if the change is desired. ❤️