### PR TITLE
feat(utils): allow reuse of existing computed style in `isContainingBlock`

### DIFF
--- a/.changeset/early-emus-destroy.md
+++ b/.changeset/early-emus-destroy.md
@@ -1,5 +1,5 @@
 ---
-"@floating-ui/utils": minor
+"@floating-ui/utils": patch
 ---
 
 feat(getContainingBlock): allow `CSSStyleDeclaration` as an argument

--- a/.changeset/early-emus-destroy.md
+++ b/.changeset/early-emus-destroy.md
@@ -2,4 +2,4 @@
 "@floating-ui/utils": minor
 ---
 
-allow reuse of existing computed style in `isContainingBlock`
+feat(getContainingBlock): allow `CSSStyleDeclaration` as an argument

--- a/.changeset/early-emus-destroy.md
+++ b/.changeset/early-emus-destroy.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/utils": minor
+---
+
+allow reuse of existing computed style in `isContainingBlock`

--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -68,9 +68,11 @@ export function isTopLayer(element: Element): boolean {
   });
 }
 
-export function isContainingBlock(element: Element): boolean {
+export function isContainingBlock(element: Element): boolean;
+export function isContainingBlock(css: CSSStyleDeclaration): boolean;
+export function isContainingBlock(elementOrCss: Element | CSSStyleDeclaration): boolean {
   const webkit = isWebKit();
-  const css = getComputedStyle(element);
+  const css = isElement(elementOrCss) ? getComputedStyle(elementOrCss) : elementOrCss;
 
   // https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block
   return (


### PR DESCRIPTION
This helps avoid recomputing styles when integrating `isContainingBlock` into logic that already has them ([example](https://github.com/jcfranco/composed-offset-position/blob/main/src/index.ts#L71)).
