### PR TITLE
refactor(utils): use union type parameter instead of function overload

### DIFF
--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -68,8 +68,6 @@ export function isTopLayer(element: Element): boolean {
   });
 }
 
-export function isContainingBlock(element: Element): boolean;
-export function isContainingBlock(css: CSSStyleDeclaration): boolean;
 export function isContainingBlock(elementOrCss: Element | CSSStyleDeclaration): boolean {
   const webkit = isWebKit();
   const css = isElement(elementOrCss) ? getComputedStyle(elementOrCss) : elementOrCss;


### PR DESCRIPTION
Drops `isContainingBlock`'s function overload in favor of union type params to align with [TypeScript best practices](https://www.typescriptlang.org/docs/handbook/2/functions.html#:~:text=Always%20prefer%20parameters%20with%20union%20types%20instead%20of%20overloads%20when%20possible).
