### PR TITLE
fix: replace `left` with `insetInlineStart`

### DIFF
--- a/.changeset/silver-rings-double.md
+++ b/.changeset/silver-rings-double.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/react-dom': patch
+---
+
+- Fixes `floatingStyles` positioning to use `insetInlineStart` instead of `left`

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -156,7 +156,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
   const floatingStyles = React.useMemo(() => {
     const initialStyles = {
       position: strategy,
-      left: 0,
+      insetInlineStart: 0,
       top: 0,
     };
 
@@ -177,7 +177,7 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
 
     return {
       position: strategy,
-      left: x,
+      insetInlineStart: x,
       top: y,
     };
   }, [strategy, transform, elements.floating, data.x, data.y]);


### PR DESCRIPTION
Currently `floatingStyles` returned from `useFloating` is overwriting placement styles and preventing `-start` to truly adapt to RTL layouts.

See https://github.com/TypeCellOS/BlockNote/pull/922#issuecomment-2233768520