### PR TITLE
fix: wrap `focus` call in `act` in useFocus tests

### DIFF
--- a/.changeset/grumpy-poets-appear.md
+++ b/.changeset/grumpy-poets-appear.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix: wrap `focus` call in `act` in `useFocus` tests

--- a/packages/react/test/unit/useFocus.test.tsx
+++ b/packages/react/test/unit/useFocus.test.tsx
@@ -125,7 +125,9 @@ test('stays open when focus moves to element inside reference that is rendered i
 
   // Move focus to an element inside the reference
   const insideReference = root.getByTestId('inside-reference');
-  insideReference.focus();
+  act(() => {
+    insideReference.focus();
+  });
 
   // trigger the blur event caused by the focus move, note relatedTarget points to the shadow root here
   fireEvent.focusOut(button, {relatedTarget: container});


### PR DESCRIPTION
Running the tests throws a warning: 

```
@floating-ui/react:test: stderr | useFocus.test.tsx > stays open when focus moves to element inside reference that is rendered inside a shadow root
@floating-ui/react:test: Warning: An update to App inside a test was not wrapped in act(...).
@floating-ui/react:test:
@floating-ui/react:test: When testing, code that causes React state updates should be wrapped into act(...):
@floating-ui/react:test:
@floating-ui/react:test: act(() => {
@floating-ui/react:test:   /* fire events that update state */
@floating-ui/react:test: });
@floating-ui/react:test: /* assert on the output */
@floating-ui/react:test:
@floating-ui/react:test: This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
@floating-ui/react:test:     at App (/Users/michal/Projects/floating-ui/packages/react/test/unit/useFocus.test.tsx:28:49)
```

It is caused by an `insideReference.focus()` call not being wrapped by `act`.
This PR adds the `act` call.