### PR TITLE
fix: focus always mounted nested lists with listNavigation

### DIFF
--- a/.changeset/lazy-paws-cry.md
+++ b/.changeset/lazy-paws-cry.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix: focus always mounted nested lists with listNavigation

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -298,6 +298,7 @@ export function useListNavigation(
   const isPointerModalityRef = React.useRef(true);
   const previousOnNavigateRef = React.useRef(onNavigate);
   const previousMountedRef = React.useRef(!!elements.floating);
+  const previousOpenRef = React.useRef(open);
   const forceSyncFocus = React.useRef(false);
   const forceScrollIntoViewRef = React.useRef(false);
 
@@ -428,7 +429,7 @@ export function useListNavigation(
 
         // Initial sync.
         if (
-          !previousMountedRef.current &&
+          (!previousOpenRef.current || !previousMountedRef.current) &&
           focusItemOnOpenRef.current &&
           (keyRef.current != null ||
             (focusItemOnOpenRef.current === true && keyRef.current == null))
@@ -535,6 +536,10 @@ export function useListNavigation(
     if (!open) {
       keyRef.current = null;
     }
+  }, [open]);
+
+  useModernLayoutEffect(() => {
+    previousOpenRef.current = open;
   }, [open]);
 
   const hasActiveIndex = activeIndex != null;

--- a/packages/react/test/unit/useListNavigation.test.tsx
+++ b/packages/react/test/unit/useListNavigation.test.tsx
@@ -18,6 +18,7 @@ import {Main as ComplexGrid} from '../visual/components/ComplexGrid';
 import {Main as Grid} from '../visual/components/Grid';
 import {Main as EmojiPicker} from '../visual/components/EmojiPicker';
 import {Main as ListboxFocus} from '../visual/components/ListboxFocus';
+import {Main as NestedMenu} from '../visual/components/Menu';
 
 function App(props: Omit<Partial<UseListNavigationProps>, 'listRef'>) {
   const [open, setOpen] = useState(false);
@@ -1106,4 +1107,15 @@ test('selectedIndex changing does not steal focus', async () => {
   await act(async () => {});
 
   expect(screen.getByTestId('reference')).toHaveFocus();
+});
+
+test('focus management in nested lists', async () => {
+  render(<NestedMenu />);
+  await userEvent.click(screen.getByRole('button', {name: 'Edit'}));
+  await userEvent.keyboard('{ArrowDown}');
+  await userEvent.keyboard('{ArrowDown}');
+  await userEvent.keyboard('{ArrowDown}');
+  await userEvent.keyboard('{ArrowRight}');
+
+  expect(screen.getByText('Text')).toHaveFocus();
 });

--- a/packages/react/test/visual/components/Menu.tsx
+++ b/packages/react/test/visual/components/Menu.tsx
@@ -53,12 +53,16 @@ interface MenuProps {
   label: string;
   nested?: boolean;
   children?: React.ReactNode;
+  keepMounted?: boolean;
 }
 
 export const MenuComponent = React.forwardRef<
   HTMLButtonElement,
   MenuProps & React.HTMLProps<HTMLButtonElement>
->(function Menu({children, label, ...props}, forwardedRef) {
+>(function Menu(
+  {children, label, keepMounted = false, ...props},
+  forwardedRef,
+) {
   const [isOpen, setIsOpen] = React.useState(false);
   const [activeIndex, setActiveIndex] = React.useState<number | null>(null);
   const [allowHover, setAllowHover] = React.useState(false);
@@ -239,7 +243,7 @@ export const MenuComponent = React.forwardRef<
         }}
       >
         <FloatingList elementsRef={elementsRef} labelsRef={labelsRef}>
-          {isOpen && (
+          {(keepMounted || isOpen) && (
             <FloatingPortal>
               <FloatingFocusManager
                 context={context}
@@ -250,7 +254,15 @@ export const MenuComponent = React.forwardRef<
                 <div
                   ref={refs.setFloating}
                   className="flex flex-col rounded bg-white shadow-lg outline-none p-1 border border-slate-900/10 bg-clip-padding"
-                  style={floatingStyles}
+                  style={{
+                    ...floatingStyles,
+                    visibility: !keepMounted
+                      ? undefined
+                      : isOpen
+                        ? 'visible'
+                        : 'hidden',
+                  }}
+                  aria-hidden={!isOpen}
                   {...getFloatingProps()}
                 >
                   {children}
@@ -357,10 +369,10 @@ export const Main = () => {
           <MenuItem label="Undo" onClick={() => console.log('Undo')} />
           <MenuItem label="Redo" />
           <MenuItem label="Cut" disabled />
-          <Menu label="Copy as">
+          <Menu label="Copy as" keepMounted>
             <MenuItem label="Text" />
             <MenuItem label="Video" />
-            <Menu label="Image">
+            <Menu label="Image" keepMounted>
               <MenuItem label=".png" />
               <MenuItem label=".jpg" />
               <MenuItem label=".svg" />


### PR DESCRIPTION
When building a nested menu that's always mounted in the DOM (and hidden with CSS / `aria-hidden`), `useListNavigation` doesn't focus the first item when a submenu is open. See https://codesandbox.io/p/sandbox/focused-silence-m63rxt for an example.

This is because useListNavigation sets the initial focus only if the list hasn't been mounted on the previous render.

In this PR, I added the `previousOpenRef`, so the focusing logic also works for always mounted lists.

I modified the Menu visual test to include always-mounted branches. Let me know if you'd like to keep it the way it was, and I can create a test component directly in the unit test file.