### PR TITLE
fix(useHover): `blockPointerEvents` on `ownerDocument` instead of `document`

### DIFF
--- a/.changeset/sharp-cheetahs-whisper.md
+++ b/.changeset/sharp-cheetahs-whisper.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useHover): `blockPointerEvents` no longer adds `pointer-events: none` to unintended `<body>` elements.

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -371,13 +371,14 @@ export function useHover(
       handleCloseRef.current?.__options.blockPointerEvents &&
       isHoverOpen()
     ) {
-      const body = getDocument(elements.floating).body;
-      body.setAttribute(safePolygonIdentifier, '');
-      body.style.pointerEvents = 'none';
       performedPointerEventsMutationRef.current = true;
       const floatingEl = elements.floating;
 
       if (isElement(elements.domReference) && floatingEl) {
+        const body = getDocument(elements.floating).body;
+        body.setAttribute(safePolygonIdentifier, '');
+        body.style.pointerEvents = 'none';
+
         const ref = elements.domReference as unknown as
           | HTMLElement
           | SVGSVGElement;

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -377,7 +377,6 @@ export function useHover(
       if (isElement(elements.domReference) && floatingEl) {
         const body = getDocument(elements.floating).body;
         body.setAttribute(safePolygonIdentifier, '');
-        body.style.pointerEvents = 'none';
 
         const ref = elements.domReference as unknown as
           | HTMLElement
@@ -391,10 +390,12 @@ export function useHover(
           parentFloating.style.pointerEvents = '';
         }
 
+        body.style.pointerEvents = 'none';
         ref.style.pointerEvents = 'auto';
         floatingEl.style.pointerEvents = 'auto';
 
         return () => {
+          body.style.pointerEvents = '';
           ref.style.pointerEvents = '';
           floatingEl.style.pointerEvents = '';
         };


### PR DESCRIPTION
Fixes #3013.

As suggested by @atomiks in https://github.com/floating-ui/floating-ui/issues/3013#issuecomment-2299935268, I moved the code in `useHover` that adds `pointer-events: none` to the body inside the if-statement that verifies that `elements.floating` is set.

That way, `pointer-events: none` is always set on `ownerDocument` instead of `document`. This prevents `pointer-events: none` from being applied to incorrect `<body>` elements and thus making them unclickable until the page is refreshed.

I also removed the `pointer-events` in the effect's cleanup function.

I confirmed that this PR fixes the issue (#3013) in our app (by making this change in the node_modules).