### PR TITLE
refactor: `floating-focus-out` -> `focus-out` reason

### DIFF
--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -386,7 +386,7 @@ export function FloatingFocusManager(
           relatedTarget !== getPreviouslyFocusedElement()
         ) {
           preventReturnFocusRef.current = true;
-          onOpenChange(false, event, 'floating-focus-out');
+          onOpenChange(false, event, 'focus-out');
         }
       });
     }

--- a/packages/react/src/components/FloatingPortal.tsx
+++ b/packages/react/src/components/FloatingPortal.tsx
@@ -250,7 +250,7 @@ export function FloatingPortal(props: FloatingPortalProps): JSX.Element {
                 focusManagerState?.onOpenChange(
                   false,
                   event.nativeEvent,
-                  'floating-focus-out',
+                  'focus-out',
                 );
             }
           }}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -107,7 +107,7 @@ export type OpenChangeReason =
   | 'click'
   | 'hover'
   | 'focus'
-  | 'floating-focus-out'
+  | 'focus-out'
   | 'list-navigation'
   | 'safe-polygon';
 


### PR DESCRIPTION
fyi  @oleksandr-danylchenko I'm changing this because it can close if the reference element lost focus instead (when tabbing backwards to the trigger, then back)