### PR TITLE
Arrow: Add test components & documentation

### DIFF
--- a/.changeset/rude-pugs-peel.md
+++ b/.changeset/rude-pugs-peel.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(FloatingArrow): avoid requiring leading space for manually specified `transform` style property

--- a/packages/react/src/components/FloatingArrow.tsx
+++ b/packages/react/src/components/FloatingArrow.tsx
@@ -30,6 +30,8 @@ export interface FloatingArrowProps extends React.ComponentPropsWithRef<'svg'> {
   tipRadius?: number;
   /**
    * Forces a static offset over dynamic positioning under a certain condition.
+   * If the shift() middleware causes the popover to shift, this value will be
+   * ignored.
    */
   staticOffset?: string | number | null;
   /**
@@ -154,7 +156,7 @@ export const FloatingArrow = React.forwardRef(function FloatingArrow(
           isVerticalSide || isCustomShape
             ? '100%'
             : `calc(100% - ${computedStrokeWidth / 2}px)`,
-        transform: `${rotation}${transform ?? ''}`,
+        transform: [rotation, transform].filter(t => !!t).join(' '),
         ...restStyle,
       }}
     >

--- a/website/pages/docs/FloatingArrow.mdx
+++ b/website/pages/docs/FloatingArrow.mdx
@@ -152,7 +152,8 @@ default: `undefined{:js}` (use dynamic position)
 A static offset override of the arrow from the floating element
 edge. Often desirable if the floating element is smaller than the
 reference element along the relevant axis and has an edge
-alignment (`'start'{:js}`/`'end'{:js}`).
+alignment (`'start'{:js}`/`'end'{:js}`). This is ignored if the
+shift() middleware caused the floating element to shift.
 
 ```js
 <FloatingArrow

--- a/website/pages/docs/arrow.mdx
+++ b/website/pages/docs/arrow.mdx
@@ -253,7 +253,7 @@ To help you understand how this middleware works, here is a
 ## Order
 
 `arrow(){:js}` should generally be placed toward the end of your
-middleware array, after `shift(){:js}` (if used).
+middleware array, after `shift(){:js}` or `autoPlacement(){:js}` (if used).
 
 ## Placement
 


### PR DESCRIPTION
Add test components and documentation regarding arrow() middleware when used with the shift() or autoPlacement() middleware.