### PR TITLE
fix(offset): avoid NaN when mainAxis or crossAxis is undefined

### DIFF
--- a/.changeset/silver-foxes-return.md
+++ b/.changeset/silver-foxes-return.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/core": patch
+---
+
+fix(offset): avoid NaN when mainAxis or crossAxis is undefined

--- a/packages/core/src/middleware/offset.ts
+++ b/packages/core/src/middleware/offset.ts
@@ -59,7 +59,11 @@ export async function convertValueToCoords(
   let {mainAxis, crossAxis, alignmentAxis} =
     typeof rawValue === 'number'
       ? {mainAxis: rawValue, crossAxis: 0, alignmentAxis: null}
-      : {mainAxis: 0, crossAxis: 0, alignmentAxis: null, ...rawValue};
+      : {
+          mainAxis: rawValue.mainAxis ?? 0,
+          crossAxis: rawValue.crossAxis ?? 0,
+          alignmentAxis: rawValue.alignmentAxis,
+        };
 
   if (alignment && typeof alignmentAxis === 'number') {
     crossAxis = alignment === 'end' ? alignmentAxis * -1 : alignmentAxis;

--- a/packages/core/src/middleware/offset.ts
+++ b/packages/core/src/middleware/offset.ts
@@ -60,8 +60,8 @@ export async function convertValueToCoords(
     typeof rawValue === 'number'
       ? {mainAxis: rawValue, crossAxis: 0, alignmentAxis: null}
       : {
-          mainAxis: rawValue.mainAxis ?? 0,
-          crossAxis: rawValue.crossAxis ?? 0,
+          mainAxis: rawValue.mainAxis || 0,
+          crossAxis: rawValue.crossAxis || 0,
           alignmentAxis: rawValue.alignmentAxis,
         };
 


### PR DESCRIPTION
The coords become NaN when we use `offset` middleware and pass undefined to `option.mainAxis` or `option.crossAxis`. This behavior can cause problem when the option was optional value, like `offset({ mainAxis: offsetOrUndefined })`.
