### PR TITLE
fix(useFloating): avoid setting `isPositioned` to true when `open` is false

### DIFF
--- a/.changeset/nasty-moles-sneeze.md
+++ b/.changeset/nasty-moles-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/vue': patch
+---
+
+fix(useFloating): avoid setting `isPositioned` to true when `open` is false

--- a/packages/vue/src/useFloating.ts
+++ b/packages/vue/src/useFloating.ts
@@ -91,6 +91,8 @@ export function useFloating<T extends ReferenceElement = ReferenceElement>(
       return;
     }
 
+    const open = openOption.value;
+
     computePosition(referenceElement.value, floatingElement.value, {
       middleware: middlewareOption.value,
       placement: placementOption.value,
@@ -101,7 +103,13 @@ export function useFloating<T extends ReferenceElement = ReferenceElement>(
       strategy.value = position.strategy;
       placement.value = position.placement;
       middlewareData.value = position.middlewareData;
-      isPositioned.value = true;
+      /**
+       * The floating element's position may be recomputed while it's closed
+       * but still mounted (such as when transitioning out). To ensure
+       * `isPositioned` will be `false` initially on the next open, avoid
+       * setting it to `true` when `open === false` (must be specified).
+       */
+      isPositioned.value = open !== false;
     });
   }
 
@@ -136,9 +144,13 @@ export function useFloating<T extends ReferenceElement = ReferenceElement>(
     }
   }
 
-  watch([middlewareOption, placementOption, strategyOption], update, {
-    flush: 'sync',
-  });
+  watch(
+    [middlewareOption, placementOption, strategyOption, openOption],
+    update,
+    {
+      flush: 'sync',
+    },
+  );
   watch([referenceElement, floatingElement], attach, {flush: 'sync'});
   watch(openOption, reset, {flush: 'sync'});
 

--- a/packages/vue/test/index.test.ts
+++ b/packages/vue/test/index.test.ts
@@ -237,6 +237,35 @@ describe('useFloating', () => {
     });
   });
 
+  test('updates `isPositioned` on open change', async () => {
+    const App = defineComponent({
+      name: 'App',
+      props: ['open'],
+      setup(props: {open?: boolean}) {
+        return setup({open: toRef(props, 'open')});
+      },
+      template: /* HTML */ `
+        <div ref="reference" />
+        <div ref="floating" />
+        <div data-testid="isPositioned">{{isPositioned}}</div>
+      `,
+    });
+
+    const {rerender, getByTestId} = render(App, {
+      props: {open: false},
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('isPositioned').textContent).toBe('false');
+    });
+
+    await rerender({open: true});
+
+    await waitFor(() => {
+      expect(getByTestId('isPositioned').textContent).toBe('true');
+    });
+  });
+
   test('resets `isPositioned` on open change', async () => {
     const App = defineComponent({
       name: 'App',
@@ -291,6 +320,41 @@ describe('useFloating', () => {
     await rerender({open: false});
 
     await waitFor(() => {
+      expect(getByTestId('isPositioned').textContent).toBe('false');
+    });
+  });
+
+  test('does not set `isPositioned` to true when open is false', async () => {
+    const App = defineComponent({
+      name: 'App',
+      props: ['open', 'strategy'],
+      setup(props: {open?: boolean; strategy?: Strategy}) {
+        return setup({
+          open: toRef(props, 'open'),
+          strategy: toRef(props, 'strategy'),
+        });
+      },
+      template: /* HTML */ `
+        <div ref="reference" />
+        <div ref="floating" />
+        <div data-testid="position">{{strategy}}</div>
+        <div data-testid="isPositioned">{{isPositioned}}</div>
+      `,
+    });
+
+    const {rerender, getByTestId} = render(App, {
+      props: {open: false, strategy: 'absolute'},
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('position').textContent).toBe('absolute');
+      expect(getByTestId('isPositioned').textContent).toBe('false');
+    });
+
+    await rerender({strategy: 'fixed'});
+
+    await waitFor(() => {
+      expect(getByTestId('position').textContent).toBe('fixed');
       expect(getByTestId('isPositioned').textContent).toBe('false');
     });
   });


### PR DESCRIPTION
Closes https://github.com/floating-ui/floating-ui/issues/3017

Sync with https://github.com/floating-ui/floating-ui/pull/3042