### PR TITLE
refactor: `JSX.Element` -> `React.JSX.Element`

### DIFF
--- a/.changeset/pretty-carrots-repair.md
+++ b/.changeset/pretty-carrots-repair.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+refactor: use React.JSX.Element types

--- a/.changeset/pretty-carrots-repair.md
+++ b/.changeset/pretty-carrots-repair.md
@@ -2,4 +2,4 @@
 "@floating-ui/react": patch
 ---
 
-refactor: use React.JSX.Element types
+refactor: use `React.JSX.Element` types. Ensure you've upgraded to the latest `@types/react` patches (versions since May 6, 2023)

--- a/packages/react/src/components/Composite.tsx
+++ b/packages/react/src/components/Composite.tsx
@@ -43,8 +43,8 @@ const CompositeContext = React.createContext<{
 });
 
 type RenderProp =
-  | JSX.Element
-  | ((props: React.HTMLAttributes<HTMLElement>) => JSX.Element);
+  | React.JSX.Element
+  | ((props: React.HTMLAttributes<HTMLElement>) => React.JSX.Element);
 
 export interface CompositeProps {
   /**

--- a/packages/react/src/components/FloatingArrow.tsx
+++ b/packages/react/src/components/FloatingArrow.tsx
@@ -55,7 +55,7 @@ export interface FloatingArrowProps extends React.ComponentPropsWithRef<'svg'> {
 export const FloatingArrow = React.forwardRef(function FloatingArrow(
   props: FloatingArrowProps,
   ref: React.ForwardedRef<SVGSVGElement>,
-): JSX.Element | null {
+): React.JSX.Element | null {
   const {
     context: {
       placement,
@@ -156,7 +156,7 @@ export const FloatingArrow = React.forwardRef(function FloatingArrow(
           isVerticalSide || isCustomShape
             ? '100%'
             : `calc(100% - ${computedStrokeWidth / 2}px)`,
-        transform: [rotation, transform].filter(t => !!t).join(' '),
+        transform: [rotation, transform].filter((t) => !!t).join(' '),
         ...restStyle,
       }}
     >

--- a/packages/react/src/components/FloatingDelayGroup.tsx
+++ b/packages/react/src/components/FloatingDelayGroup.tsx
@@ -65,7 +65,7 @@ interface FloatingDelayGroupProps {
  */
 export function FloatingDelayGroup(
   props: FloatingDelayGroupProps,
-): JSX.Element {
+): React.JSX.Element {
   const {children, delay, timeoutMs = 0} = props;
 
   const [state, setState] = React.useReducer(

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -78,7 +78,7 @@ const VisuallyHiddenDismiss = React.forwardRef(function VisuallyHiddenDismiss(
 });
 
 export interface FloatingFocusManagerProps {
-  children: JSX.Element;
+  children: React.JSX.Element;
   /**
    * The floating context returned from `useFloating`.
    */
@@ -154,7 +154,7 @@ export interface FloatingFocusManagerProps {
  */
 export function FloatingFocusManager(
   props: FloatingFocusManagerProps,
-): JSX.Element {
+): React.JSX.Element {
   const {
     context,
     children,

--- a/packages/react/src/components/FloatingList.tsx
+++ b/packages/react/src/components/FloatingList.tsx
@@ -67,7 +67,7 @@ interface FloatingListProps {
  * Provides context for a list of items within the floating element.
  * @see https://floating-ui.com/docs/FloatingList
  */
-export function FloatingList(props: FloatingListProps): JSX.Element {
+export function FloatingList(props: FloatingListProps): React.JSX.Element {
   const {children, elementsRef, labelsRef} = props;
 
   const [map, setMap] = React.useState(() => new Map<Node, number | null>());

--- a/packages/react/src/components/FloatingPortal.tsx
+++ b/packages/react/src/components/FloatingPortal.tsx
@@ -139,7 +139,7 @@ export interface FloatingPortalProps {
  * while retaining its location in the React tree.
  * @see https://floating-ui.com/docs/FloatingPortal
  */
-export function FloatingPortal(props: FloatingPortalProps): JSX.Element {
+export function FloatingPortal(props: FloatingPortalProps): React.JSX.Element {
   const {children, id, root = null, preserveTabOrder = true} = props;
 
   const portalNode = useFloatingPortalNode({id, root});

--- a/packages/react/src/components/FloatingTree.tsx
+++ b/packages/react/src/components/FloatingTree.tsx
@@ -53,7 +53,7 @@ export interface FloatingNodeProps {
  * Provides parent node context for nested floating elements.
  * @see https://floating-ui.com/docs/FloatingTree
  */
-export function FloatingNode(props: FloatingNodeProps): JSX.Element {
+export function FloatingNode(props: FloatingNodeProps): React.JSX.Element {
   const {children, id} = props;
 
   const parentId = useFloatingParentNodeId();
@@ -81,7 +81,7 @@ export interface FloatingTreeProps {
  * - Custom communication between parent and child floating elements
  * @see https://floating-ui.com/docs/FloatingTree
  */
-export function FloatingTree(props: FloatingTreeProps): JSX.Element {
+export function FloatingTree(props: FloatingTreeProps): React.JSX.Element {
   const {children} = props;
 
   const nodesRef = React.useRef<Array<FloatingNodeType>>([]);

--- a/packages/react/test/unit/FloatingDelayGroup.test.tsx
+++ b/packages/react/test/unit/FloatingDelayGroup.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {act, fireEvent, render, screen} from '@testing-library/react';
 import {cloneElement, useState} from 'react';
 import {vi} from 'vitest';
@@ -14,7 +15,7 @@ vi.useFakeTimers();
 
 interface Props {
   label: string;
-  children: JSX.Element;
+  children: React.JSX.Element;
 }
 
 export const Tooltip = ({children, label}: Props) => {

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {act, cleanup, fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {cloneElement, useRef, useState} from 'react';
@@ -68,7 +69,7 @@ function App(
 interface DialogProps {
   open?: boolean;
   render: (props: {close: () => void}) => React.ReactNode;
-  children: JSX.Element;
+  children: React.JSX.Element;
 }
 
 const Dialog = ({render, open: passedOpen = false, children}: DialogProps) => {
@@ -571,8 +572,8 @@ describe('modal', () => {
       open?: boolean;
       modal?: boolean;
       render: (props: {close: () => void}) => React.ReactNode;
-      children?: JSX.Element;
-      sideChildren?: JSX.Element;
+      children?: React.JSX.Element;
+      sideChildren?: React.JSX.Element;
     }
 
     const Dialog = ({

--- a/packages/react/test/unit/useFocus.test.tsx
+++ b/packages/react/test/unit/useFocus.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {
   act,
   cleanup,
@@ -155,7 +156,7 @@ test('does not open when window blurs then receives focus', async () => {
 test('blurs when hitting an "inside" focus guard', async () => {
   vi.useRealTimers();
 
-  function Tooltip({children}: {children: JSX.Element}) {
+  function Tooltip({children}: {children: React.JSX.Element}) {
     const [open, setOpen] = useState(false);
 
     const {refs, context} = useFloating({


### PR DESCRIPTION
React 19 requires this. React 16 + 17 already support this type in their latest `@types/react` patch versions.

In React 16, the `JSX` namespace has been added under the `React` namespace since `@types/react@16.14.41` in May 2023