### PR TITLE
fix(utils/dom): make element utils ssr-friendly

### DIFF
--- a/.changeset/red-dolls-provide.md
+++ b/.changeset/red-dolls-provide.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/utils": patch
+---
+
+fix: make element utils ssr-friendly

--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -1,5 +1,9 @@
 type OverflowAncestors = Array<Element | Window | VisualViewport>;
 
+function hasWindow() {
+  return typeof window !== 'undefined';
+}
+
 export function getNodeName(node: Node | Window): string {
   if (isNode(node)) {
     return (node.nodeName || '').toLowerCase();
@@ -21,14 +25,26 @@ export function getDocumentElement(node: Node | Window): HTMLElement {
 }
 
 export function isNode(value: unknown): value is Node {
+  if (!hasWindow()) {
+    return false;
+  }
+
   return value instanceof Node || value instanceof getWindow(value).Node;
 }
 
 export function isElement(value: unknown): value is Element {
+  if (!hasWindow()) {
+    return false;
+  }
+
   return value instanceof Element || value instanceof getWindow(value).Element;
 }
 
 export function isHTMLElement(value: unknown): value is HTMLElement {
+  if (!hasWindow()) {
+    return false;
+  }
+
   return (
     value instanceof HTMLElement ||
     value instanceof getWindow(value).HTMLElement
@@ -36,8 +52,7 @@ export function isHTMLElement(value: unknown): value is HTMLElement {
 }
 
 export function isShadowRoot(value: unknown): value is ShadowRoot {
-  // Browsers without `ShadowRoot` support.
-  if (typeof ShadowRoot === 'undefined') {
+  if (!hasWindow() || typeof ShadowRoot === 'undefined') {
     return false;
   }
 


### PR DESCRIPTION
Since these allow `any`/`unknown` values, they don't need to have passed an actual element or perform the check for existence themselves at the callsite. This could cause an unexpected error at runtime in server environments.