### PR TITLE
fix(useHover): ignore insignificant movement when resetting `restMs`

### DIFF
--- a/.changeset/hip-turkeys-film.md
+++ b/.changeset/hip-turkeys-film.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useHover): ignore insignificant movement when resetting `restMs`


### PR DESCRIPTION
https://github.com/mui/base-ui/issues/654