### PR TITLE
fix(useDismiss): handle IME keydown events on `Escape`

### DIFF
--- a/.changeset/olive-dogs-look.md
+++ b/.changeset/olive-dogs-look.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useDismiss): handle IME keydown events on Escape

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -419,7 +419,11 @@ export function useDismiss(
           escapeKeyCapture ? closeOnEscapeKeyDownCapture : closeOnEscapeKeyDown,
           escapeKeyCapture,
         );
-        doc.removeEventListener('compositionstart', handleCompositionEnd, true);
+        doc.removeEventListener(
+          'compositionstart',
+          handleCompositionStart,
+          true,
+        );
         doc.removeEventListener('compositionend', handleCompositionEnd, true);
       }
 

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -13,6 +13,7 @@ import {
   isElement,
   isHTMLElement,
   isLastTraversableNode,
+  isWebKit,
 } from '@floating-ui/utils/dom';
 import * as React from 'react';
 
@@ -365,9 +366,14 @@ export function useDismiss(
       // Safari fires `compositionend` before `keydown`, so we need to wait
       // until the next tick to set `isComposing` to `false`.
       // https://bugs.webkit.org/show_bug.cgi?id=165004
-      compositionTimeout = window.setTimeout(() => {
-        isComposingRef.current = false;
-      });
+      compositionTimeout = window.setTimeout(
+        () => {
+          isComposingRef.current = false;
+        },
+        // 0ms or 1ms don't work in Safari. 5ms appears to consistently work.
+        // Only apply to WebKit for the test to remain 0ms.
+        isWebKit() ? 5 : 0,
+      );
     }
 
     const doc = getDocument(elements.floating);

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -378,8 +378,8 @@ export function useDismiss(
         escapeKeyCapture ? closeOnEscapeKeyDownCapture : closeOnEscapeKeyDown,
         escapeKeyCapture,
       );
-      doc.addEventListener('compositionstart', handleCompositionStart, true);
-      doc.addEventListener('compositionend', handleCompositionEnd, true);
+      doc.addEventListener('compositionstart', handleCompositionStart);
+      doc.addEventListener('compositionend', handleCompositionEnd);
     }
 
     outsidePress &&
@@ -427,12 +427,8 @@ export function useDismiss(
           escapeKeyCapture ? closeOnEscapeKeyDownCapture : closeOnEscapeKeyDown,
           escapeKeyCapture,
         );
-        doc.removeEventListener(
-          'compositionstart',
-          handleCompositionStart,
-          true,
-        );
-        doc.removeEventListener('compositionend', handleCompositionEnd, true);
+        doc.removeEventListener('compositionstart', handleCompositionStart);
+        doc.removeEventListener('compositionend', handleCompositionEnd);
       }
 
       outsidePress &&

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -350,16 +350,24 @@ export function useDismiss(
     dataRef.current.__escapeKeyBubbles = escapeKeyBubbles;
     dataRef.current.__outsidePressBubbles = outsidePressBubbles;
 
+    let compositionTimeout = -1;
+
     function onScroll(event: Event) {
       onOpenChange(false, event, 'ancestor-scroll');
     }
 
     function handleCompositionStart() {
+      window.clearTimeout(compositionTimeout);
       isComposingRef.current = true;
     }
 
     function handleCompositionEnd() {
-      isComposingRef.current = false;
+      // Safari fires `compositionend` before `keydown`, so we need to wait
+      // until the next tick to set `isComposing` to `false`.
+      // https://bugs.webkit.org/show_bug.cgi?id=165004
+      compositionTimeout = window.setTimeout(() => {
+        isComposingRef.current = false;
+      });
     }
 
     const doc = getDocument(elements.floating);

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -446,6 +446,8 @@ export function useDismiss(
       ancestors.forEach((ancestor) => {
         ancestor.removeEventListener('scroll', onScroll);
       });
+
+      window.clearTimeout(compositionTimeout);
     };
   }, [
     dataRef,

--- a/packages/react/test/unit/useDismiss.test.tsx
+++ b/packages/react/test/unit/useDismiss.test.tsx
@@ -67,7 +67,7 @@ describe('true', () => {
     cleanup();
   });
 
-  test('does not dismiss with escape key if IME is active', () => {
+  test('does not dismiss with escape key if IME is active', async () => {
     const onClose = vi.fn();
 
     render(<App onClose={onClose} escapeKey />);
@@ -82,9 +82,14 @@ describe('true', () => {
     fireEvent.compositionStart(textbox);
     fireEvent.keyDown(textbox, {key: 'Escape'});
     fireEvent.compositionEnd(textbox);
+
+    // Wait for the compositionend timeout tick due to Safari
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     expect(onClose).toHaveBeenCalledTimes(0);
 
     fireEvent.keyDown(textbox, {key: 'Escape'});
+
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/react/test/unit/useDismiss.test.tsx
+++ b/packages/react/test/unit/useDismiss.test.tsx
@@ -51,7 +51,9 @@ function App(
     <>
       <button {...getReferenceProps({ref: refs.setReference})} />
       {open && (
-        <div role="tooltip" {...getFloatingProps({ref: refs.setFloating})} />
+        <div role="tooltip" {...getFloatingProps({ref: refs.setFloating})}>
+          <input />
+        </div>
       )}
     </>
   );

--- a/packages/react/test/unit/useDismiss.test.tsx
+++ b/packages/react/test/unit/useDismiss.test.tsx
@@ -2,6 +2,7 @@ import {act, cleanup, fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {ReactNode} from 'react';
 import {useState} from 'react';
+import {vi} from 'vitest';
 
 import {
   FloatingFocusManager,
@@ -18,7 +19,11 @@ import {
 import type {UseDismissProps} from '../../src/hooks/useDismiss';
 import {normalizeProp} from '../../src/hooks/useDismiss';
 
-function App(props: UseDismissProps) {
+function App(
+  props: UseDismissProps & {
+    onClose?: () => void;
+  },
+) {
   const [open, setOpen] = useState(true);
   const {refs, context} = useFloating({
     open,
@@ -28,6 +33,9 @@ function App(props: UseDismissProps) {
         expect(reason).toBe('outside-press');
       } else if (props.escapeKey) {
         expect(reason).toBe('escape-key');
+        if (!open) {
+          props.onClose?.();
+        }
       } else if (props.referencePress) {
         expect(reason).toBe('reference-press');
       } else if (props.ancestorScroll) {
@@ -55,6 +63,27 @@ describe('true', () => {
     fireEvent.keyDown(document.body, {key: 'Escape'});
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     cleanup();
+  });
+
+  test('does not dismiss with escape key if IME is active', () => {
+    const onClose = vi.fn();
+
+    render(<App onClose={onClose} escapeKey />);
+
+    const textbox = screen.getByRole('textbox');
+
+    fireEvent.focus(textbox);
+
+    // Simulate behavior when "あ" (Japanese) is entered and Esc is pressed for IME
+    // cancellation.
+    fireEvent.change(textbox, {target: {value: 'あ'}});
+    fireEvent.compositionStart(textbox);
+    fireEvent.keyDown(textbox, {key: 'Escape'});
+    fireEvent.compositionEnd(textbox);
+    expect(onClose).toHaveBeenCalledTimes(0);
+
+    fireEvent.keyDown(textbox, {key: 'Escape'});
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   test('dismisses with outside pointer press', async () => {


### PR DESCRIPTION
https://github.com/mui/material-ui/pull/39713

- `event.isComposing` can't be used in Safari due to the order of events.
- `event.which === 229` can't be used since event listeners are added on the floating element AND document and fires it twice, the second with `event.which === 0` and thus doesn't end up preventing the keypress.

A ref using `compositionstart`/`compositionend` events solves the above issues