### PR TITLE
fix(getClippingRect): allow passing DOMRect as boundary

### DIFF
--- a/.changeset/ten-bears-protect.md
+++ b/.changeset/ten-bears-protect.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/dom": patch
+---
+
+fix(getClippingRect): allow passing `DOMRect` as a `boundary`

--- a/packages/dom/src/platform/getClippingRect.ts
+++ b/packages/dom/src/platform/getClippingRect.ts
@@ -70,9 +70,10 @@ function getClientRectFromClippingAncestor(
   } else {
     const visualOffsets = getVisualOffsets(element);
     rect = {
-      ...clippingAncestor,
       x: clippingAncestor.x - visualOffsets.x,
       y: clippingAncestor.y - visualOffsets.y,
+      width: clippingAncestor.width,
+      height: clippingAncestor.height,
     };
   }
 


### PR DESCRIPTION
This pr allows passing `DOMRect` objects a the [boundary](https://floating-ui.com/docs/detectOverflow#boundary)/[rootBoundary](https://floating-ui.com/docs/detectOverflow#rootboundary) option in `detectOverflow`.
While `DOMRect` is compatible with the expected `Rect` interface, its properties are not enumerable and can't be used with the spread operator.

In other words, this code will work without NaNs:
```ts
computePosition(referenceEl, floatingEl, {
  middleware: [
    shift({
      boundary: myContainer.getBoundingClientRect()
    })
  ]
})
```