### PR TITLE
fix(useListNavigation): ignore duplicate arrow navigation when composing

### DIFF
--- a/.changeset/large-crabs-cheat.md
+++ b/.changeset/large-crabs-cheat.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useListNavigation): ignore duplicate arrow navigation when composing

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -845,8 +845,7 @@ export function useListNavigation(
       onKeyDown(event) {
         isPointerModalityRef.current = false;
 
-        const isHomeOrEnd = ['Home', 'End'].includes(event.key);
-        const isArrowKey = event.key.indexOf('Arrow') === 0 || isHomeOrEnd;
+        const isArrowKey = event.key.indexOf('Arrow') === 0;
         const isCrossOpenKey = isCrossOrientationOpenKey(
           event.key,
           orientation,
@@ -857,8 +856,7 @@ export function useListNavigation(
           orientation,
           rtl,
         );
-        const isMainKey =
-          isMainOrientationKey(event.key, orientation) || isHomeOrEnd;
+        const isMainKey = isMainOrientationKey(event.key, orientation);
         const isNavigationKey =
           (nested ? isCrossOpenKey : isMainKey) ||
           event.key === 'Enter' ||

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -598,6 +598,14 @@ export function useListNavigation(
     isPointerModalityRef.current = false;
     forceSyncFocus.current = true;
 
+    // When composing a character, Chrome fires ArrowDown twice. Firefox/Safari
+    // don't appear to suffer from this. `event.isComposing` is avoided due to
+    // Safari not supporting it properly (although it's not needed in the first
+    // place for Safari, just avoiding any possible issues).
+    if (event.which === 229) {
+      return;
+    }
+
     // If the floating element is animating out, ignore navigation. Otherwise,
     // the `activeIndex` gets set to 0 despite not being open so the next time
     // the user ArrowDowns, the first item won't be focused.
@@ -837,7 +845,8 @@ export function useListNavigation(
       onKeyDown(event) {
         isPointerModalityRef.current = false;
 
-        const isArrowKey = event.key.indexOf('Arrow') === 0;
+        const isHomeOrEnd = ['Home', 'End'].includes(event.key);
+        const isArrowKey = event.key.indexOf('Arrow') === 0 || isHomeOrEnd;
         const isCrossOpenKey = isCrossOrientationOpenKey(
           event.key,
           orientation,
@@ -848,7 +857,8 @@ export function useListNavigation(
           orientation,
           rtl,
         );
-        const isMainKey = isMainOrientationKey(event.key, orientation);
+        const isMainKey =
+          isMainOrientationKey(event.key, orientation) || isHomeOrEnd;
         const isNavigationKey =
           (nested ? isCrossOpenKey : isMainKey) ||
           event.key === 'Enter' ||


### PR DESCRIPTION
Fixes #3077

From testing, Safari/Firefox don't have this issue, just Chrome/ium