### PR TITLE
feat(FloatingFocusManager): Specify element to return focus to

### DIFF
--- a/.changeset/strong-coins-wink.md
+++ b/.changeset/strong-coins-wink.md
@@ -2,4 +2,4 @@
 "@floating-ui/react": patch
 ---
 
-feat(FloatingFocusManager): Specify element to return focus to
+feat(FloatingFocusManager): specify element to return focus to

--- a/.changeset/strong-coins-wink.md
+++ b/.changeset/strong-coins-wink.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+feat(FloatingFocusManager): Specify element to return focus to

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -113,7 +113,7 @@ export interface FloatingFocusManagerProps {
    * lost focus.
    * @default true
    */
-  returnFocus?: boolean;
+  returnFocus?: boolean | React.MutableRefObject<HTMLElement | null>;
   /**
    * Determines if focus should be restored to the nearest tabbable element if
    * focus inside the floating element is lost (such as due to the removal of
@@ -553,6 +553,14 @@ export function FloatingFocusManager(
       domReference.insertAdjacentElement('afterend', fallbackEl);
     }
 
+    function getReturnElement() {
+      if (typeof returnFocusRef.current === 'boolean') {
+        return getPreviouslyFocusedElement || fallbackEl;
+      }
+
+      return returnFocusRef.current.current || fallbackEl;
+    }
+
     return () => {
       events.off('openchange', onOpenChange);
 
@@ -571,7 +579,7 @@ export function FloatingFocusManager(
         addPreviouslyFocusedElement(refs.domReference.current);
       }
 
-      const returnElement = getPreviouslyFocusedElement() || fallbackEl;
+      const returnElement = getReturnElement();
 
       queueMicrotask(() => {
         if (

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -111,6 +111,7 @@ export interface FloatingFocusManagerProps {
    * floating element closes/unmounts (or if that is not available, the
    * previously focused element). This prop is ignored if the floating element
    * lost focus.
+   * It can be also set to a ref to explicitly control the element to return focus to.
    * @default true
    */
   returnFocus?: boolean | React.MutableRefObject<HTMLElement | null>;

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -555,7 +555,7 @@ export function FloatingFocusManager(
 
     function getReturnElement() {
       if (typeof returnFocusRef.current === 'boolean') {
-        return getPreviouslyFocusedElement || fallbackEl;
+        return getPreviouslyFocusedElement() || fallbackEl;
       }
 
       return returnFocusRef.current.current || fallbackEl;

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -177,6 +177,29 @@ describe('returnFocus', () => {
     expect(screen.getByTestId('reference')).not.toHaveFocus();
   });
 
+  test('ref', async () => {
+    function Test() {
+      const ref = useRef<HTMLInputElement | null>(null);
+      return (
+        <div>
+          <input />
+          <input data-testid="focus-target" ref={ref} />
+          <input />
+          <App returnFocus={ref} />
+        </div>
+      );
+    }
+
+    render(<Test />);
+    screen.getByTestId('reference').focus();
+    fireEvent.click(screen.getByTestId('reference'));
+    await act(async () => {});
+
+    fireEvent.click(screen.getByTestId('three'));
+    await act(async () => {});
+    expect(screen.getByTestId('focus-target')).toHaveFocus();
+  });
+
   test('always returns to the reference for nested elements', async () => {
     const NestedDialog: React.FC<DialogProps> = (props) => {
       const parentId = useFloatingParentNodeId();

--- a/website/pages/docs/FloatingFocusManager.mdx
+++ b/website/pages/docs/FloatingFocusManager.mdx
@@ -50,7 +50,9 @@ interface FloatingFocusManagerProps {
   initialFocus?:
     | number
     | React.MutableRefObject<HTMLElement | null>;
-  returnFocus?: boolean;
+  returnFocus?:
+    | boolean
+    | React.MutableRefObject<HTMLElement | null>;
   restoreFocus?: boolean;
   guards?: boolean;
   modal?: boolean;
@@ -140,6 +142,7 @@ default: `true{:js}`
 Determines if focus should be returned to the reference element
 (or if that is not available, the previously focused element).
 This prop is ignored if the floating element lost focus.
+It can be also set to a ref to explicitly control the element to return focus to.
 
 ```js
 <FloatingFocusManager context={context} returnFocus={false}>


### PR DESCRIPTION
Made it possible to explicitly specify the element that will be focused after FloatingFocusManager closes. This reuses the same logic that's already in place to determine when to focus an element and simply adds an ability to focus the provided item.