### PR TITLE
fix(FloatingPortal): allow `root` to be reactive from `null` to an element

### DIFF
--- a/.changeset/young-oranges-behave.md
+++ b/.changeset/young-oranges-behave.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(FloatingPortal): allow `root` to be reactive from `null` to an element

--- a/packages/react/src/components/FloatingPortal.tsx
+++ b/packages/react/src/components/FloatingPortal.tsx
@@ -83,6 +83,9 @@ export function useFloatingPortalNode(props: UseFloatingPortalNodeProps = {}) {
   }, [id, uniqueId]);
 
   useModernLayoutEffect(() => {
+    // Wait for the root to exist before creating the portal node. The root must
+    // be stored in state, not a ref, for this to work reactively.
+    if (root === null) return;
     if (!uniqueId) return;
     if (portalNodeRef.current) return;
 
@@ -140,7 +143,7 @@ export interface FloatingPortalProps {
  * @see https://floating-ui.com/docs/FloatingPortal
  */
 export function FloatingPortal(props: FloatingPortalProps): React.JSX.Element {
-  const {children, id, root = null, preserveTabOrder = true} = props;
+  const {children, id, root, preserveTabOrder = true} = props;
 
   const portalNode = useFloatingPortalNode({id, root});
   const [focusManagerState, setFocusManagerState] =

--- a/packages/react/test/unit/FloatingPortal.test.tsx
+++ b/packages/react/test/unit/FloatingPortal.test.tsx
@@ -83,3 +83,30 @@ test('allows refs as roots', async () => {
   expect(parent?.parentElement).toBe(el);
   document.body.removeChild(el);
 });
+
+test('allows roots to be initially null', async () => {
+  function RootApp() {
+    const [root, setRoot] = useState<HTMLElement | null>(null);
+    const [renderRoot, setRenderRoot] = useState(false);
+
+    React.useEffect(() => {
+      setRenderRoot(true);
+    }, []);
+
+    return (
+      <>
+        {renderRoot && <div ref={setRoot} data-testid="root" />}
+        <App root={root} />;
+      </>
+    );
+  }
+
+  render(<RootApp />);
+
+  fireEvent.click(screen.getByTestId('reference'));
+  await act(async () => {});
+
+  const subRoot = screen.getByTestId('floating').parentElement;
+  const root = screen.getByTestId('root');
+  expect(root).toBe(subRoot?.parentElement);
+});

--- a/website/pages/docs/FloatingPortal.mdx
+++ b/website/pages/docs/FloatingPortal.mdx
@@ -71,6 +71,13 @@ appended to.
 <FloatingPortal root={rootNodeRef} />
 ```
 
+<Notice>
+  If the `rootNode` doesn't exist when the portal is mounted,
+  ensure you pass an element directly (not a ref) and specify
+  `null` as the default value before it is set. This lets it wait
+  for the root to be available.
+</Notice>
+
 ### `id{:.keyword}`
 
 Optionally selects the node with the id if it exists, or create


### PR DESCRIPTION
Fixes #3099