### PR TITLE
chore(.github): update github actions 'uses' to latest version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,13 +4,12 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version-file: '.nvmrc'
         registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v4
       with:
-        version: 8
         run_install: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Linting and type checking
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/typescript
 
@@ -18,7 +18,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/unit
 
@@ -26,6 +26,6 @@ jobs:
     name: Functional tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/functional

--- a/.github/workflows/release-floating-ui.yml
+++ b/.github/workflows/release-floating-ui.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/typescript
       - uses: ./.github/actions/unit
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - name: Publish to npm
         id: changesets

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -9,11 +9,11 @@ jobs:
     name: Functional
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - run: npx playwright install --with-deps chromium
       - run: pnpm run playwright:update
-      - uses: EndBug/add-and-commit@v7
+      - uses: EndBug/add-and-commit@v9
         with:
           add: '.'
           author_name: 'GitHub Actions'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@floating-ui/monorepo",
   "private": true,
+  "packageManager": "pnpm@8.13.1",
   "version": "0.0.0",
   "description": "Floating UI monorepo",
   "engines": {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7415e2f6-eea8-44df-877c-70157e79929b)

* github actions is now using node version 20 but actions/checkout@v3, pnpm/action-setup@v2, actions/setup-nodes@v3 are using node verion 16 which is deprecated in github actions, so i update it all v4, you can see [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)