### PR TITLE
feat(FloatingFocusManager): `outsideElementsInert` prop

### DIFF
--- a/.changeset/hungry-rats-push.md
+++ b/.changeset/hungry-rats-push.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+feat(FloatingFocusManager): add `outsideElementsInert` prop

--- a/.changeset/hungry-rats-push.md
+++ b/.changeset/hungry-rats-push.md
@@ -1,5 +1,5 @@
 ---
-"@floating-ui/react": patch
+'@floating-ui/react': patch
 ---
 
-feat(FloatingFocusManager): add `outsideElementsInert` prop
+feat(FloatingFocusManager): add `outsideElementsInert` prop. This enables pointer modality without a backdrop.

--- a/.changeset/tricky-coins-relax.md
+++ b/.changeset/tricky-coins-relax.md
@@ -1,5 +1,0 @@
----
-"@floating-ui/react": minor
----
-
-feat(FloatingFocusManager): add the `inert` attribute on outside nodes when `guards=true` instead of `aria-hidden`. This enables pointer modality without a backdrop.

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -203,7 +203,7 @@ export function FloatingFocusManager(
   // Force the guards to be rendered if the `inert` attribute is not supported.
   const inertSupported = supportsInert();
   const guards = inertSupported ? _guards : true;
-  const useAriaHidden = !inertSupported || !outsideElementsInert;
+  const useInert = !guards || (inertSupported && outsideElementsInert);
 
   const orderRef = useLatestRef(order);
   const initialFocusRef = useLatestRef(initialFocus);
@@ -466,7 +466,7 @@ export function FloatingFocusManager(
 
       const cleanup =
         modal || isUntrappedTypeableCombobox
-          ? markOthers(insideElements, useAriaHidden, !useAriaHidden)
+          ? markOthers(insideElements, !useInert, useInert)
           : markOthers(insideElements);
 
       return () => {
@@ -482,7 +482,7 @@ export function FloatingFocusManager(
     portalContext,
     isUntrappedTypeableCombobox,
     guards,
-    useAriaHidden,
+    useInert,
   ]);
 
   useModernLayoutEffect(() => {

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -528,10 +528,10 @@ describe('modal', () => {
     fireEvent.focus(screen.getByTestId('reference'));
     await act(async () => {});
 
-    expect(screen.getByTestId('reference')).not.toHaveAttribute('inert');
-    expect(screen.getByTestId('floating')).not.toHaveAttribute('inert');
-    expect(screen.getByTestId('btn-1')).toHaveAttribute('inert');
-    expect(screen.getByTestId('btn-2')).toHaveAttribute('inert');
+    expect(screen.getByTestId('reference')).not.toHaveAttribute('aria-hidden');
+    expect(screen.getByTestId('floating')).not.toHaveAttribute('aria-hidden');
+    expect(screen.getByTestId('btn-1')).toHaveAttribute('aria-hidden');
+    expect(screen.getByTestId('btn-2')).toHaveAttribute('aria-hidden');
   });
 
   test('false - comboboxes do not hide all other nodes', async () => {
@@ -705,7 +705,7 @@ describe('modal', () => {
     expect(screen.queryByTestId('close-nested-dialog')).toBeInTheDocument();
   });
 
-  test('true - applies inert to outside nodes', async () => {
+  test('true - applies aria-hidden to outside nodes', async () => {
     function App() {
       const [isOpen, setIsOpen] = useState(false);
       const {refs, context} = useFloating({
@@ -739,18 +739,21 @@ describe('modal', () => {
     fireEvent.click(screen.getByTestId('reference'));
     await act(async () => {});
 
-    expect(screen.getByTestId('reference')).toHaveAttribute('inert', 'true');
+    expect(screen.getByTestId('reference')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
     expect(screen.getByTestId('floating')).not.toHaveAttribute('inert');
     expect(screen.getByTestId('aria-live')).not.toHaveAttribute('inert');
-    expect(screen.getByTestId('btn-1')).toHaveAttribute('inert', 'true');
-    expect(screen.getByTestId('btn-2')).toHaveAttribute('inert', 'true');
+    expect(screen.getByTestId('btn-1')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('btn-2')).toHaveAttribute('aria-hidden', 'true');
 
     fireEvent.click(screen.getByTestId('reference'));
 
-    expect(screen.getByTestId('reference')).not.toHaveAttribute('inert');
-    expect(screen.getByTestId('aria-live')).not.toHaveAttribute('inert');
-    expect(screen.getByTestId('btn-1')).not.toHaveAttribute('inert');
-    expect(screen.getByTestId('btn-2')).not.toHaveAttribute('inert');
+    expect(screen.getByTestId('reference')).not.toHaveAttribute('aria-hidden');
+    expect(screen.getByTestId('aria-live')).not.toHaveAttribute('aria-hidden');
+    expect(screen.getByTestId('btn-1')).not.toHaveAttribute('aria-hidden');
+    expect(screen.getByTestId('btn-2')).not.toHaveAttribute('aria-hidden');
   });
 
   test('false - does not apply inert to outside nodes', async () => {

--- a/website/pages/docs/FloatingFocusManager.mdx
+++ b/website/pages/docs/FloatingFocusManager.mdx
@@ -58,6 +58,7 @@ interface FloatingFocusManagerProps {
   modal?: boolean;
   visuallyHiddenDismiss?: boolean | string;
   closeOnFocusOut?: boolean;
+  outsideElementsInert?: boolean;
   order?: Array<'reference' | 'floating' | 'content'>;
 }
 ```
@@ -141,8 +142,9 @@ default: `true{:js}`
 
 Determines if focus should be returned to the reference element
 (or if that is not available, the previously focused element).
-This prop is ignored if the floating element lost focus.
-It can be also set to a ref to explicitly control the element to return focus to.
+This prop is ignored if the floating element lost focus. It can
+be also set to a ref to explicitly control the element to return
+focus to.
 
 ```js
 <FloatingFocusManager context={context} returnFocus={false}>
@@ -267,6 +269,12 @@ floating elements. This affects non-modal focus management.
   {/* floating element */}
 </FloatingFocusManager>
 ```
+
+### `outsideElementsInert{:.keyword}`
+
+Determines whether outside elements are `inert` when
+`modal{:.keyword}` is enabled. This enables pointer modality
+without a backdrop.
 
 ### `order{:.keyword}`
 


### PR DESCRIPTION
Re-add configurability to #3131 to prevent unwanted side effects by default, namely with combobox modality and other unforeseen components