### PR TITLE
fix(useDismiss): allow native clicks to work with `referencePress`

### DIFF
--- a/.changeset/selfish-worms-study.md
+++ b/.changeset/selfish-worms-study.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useDismiss): allow native clicks to work with `referencePress`

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -490,13 +490,18 @@ export function useDismiss(
   const reference: ElementProps['reference'] = React.useMemo(
     () => ({
       onKeyDown: closeOnEscapeKeyDown,
-      [bubbleHandlerKeys[referencePressEvent]]: (
-        event: React.SyntheticEvent,
-      ) => {
-        if (referencePress) {
+      ...(referencePress && {
+        [bubbleHandlerKeys[referencePressEvent]]: (
+          event: React.SyntheticEvent,
+        ) => {
           onOpenChange(false, event.nativeEvent, 'reference-press');
-        }
-      },
+        },
+        ...(referencePressEvent !== 'click' && {
+          onClick(event) {
+            onOpenChange(false, event.nativeEvent, 'reference-press');
+          },
+        }),
+      }),
     }),
     [closeOnEscapeKeyDown, onOpenChange, referencePress, referencePressEvent],
   );

--- a/packages/react/test/unit/useDismiss.test.tsx
+++ b/packages/react/test/unit/useDismiss.test.tsx
@@ -107,6 +107,13 @@ describe('true', () => {
     cleanup();
   });
 
+  test('dismisses with native click', async () => {
+    render(<App referencePress />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    cleanup();
+  });
+
   test('dismisses with ancestor scroll', async () => {
     render(<App ancestorScroll />);
     fireEvent.scroll(window);

--- a/website/pages/docs/useDismiss.mdx
+++ b/website/pages/docs/useDismiss.mdx
@@ -125,21 +125,6 @@ useDismiss(context, {
 You likely want to ensure the `move{:.key}` option in the
 `useHover(){:js}` hook has been disabled when this is in use.
 
-#### Keyboard press dismissal
-
-If you'd like to ensure the floating element is also dismissed
-upon "pressing" the reference element via the keyboard, you can
-add in your own handler(s) for this.
-
-```js
-getReferenceProps({
-  // for a native <button>
-  onClick() {
-    setOpen(false);
-  },
-});
-```
-
 ### `referencePressEvent{:.key}`
 
 default: `'pointerdown'{:js}`


### PR DESCRIPTION
Mostly addresses https://github.com/mui/base-ui/issues/891