### PR TITLE
docs(FloatingArrow): fix strokeWidth description

### DIFF
--- a/website/pages/docs/FloatingArrow.mdx
+++ b/website/pages/docs/FloatingArrow.mdx
@@ -196,8 +196,7 @@ The color of the arrow.
 
 default: `"none"{:js}`
 
-The stroke (border) color of the arrow. This must match (or be
-less than) the floating element's border width.
+The stroke (border) color of the arrow.
 
 ```js
 <FloatingArrow ref={arrowRef} context={context} stroke="red" />
@@ -207,7 +206,8 @@ less than) the floating element's border width.
 
 default: `0{:js}`
 
-The stroke (border) width of the arrow.
+The stroke (border) width of the arrow. This must match (or be
+less than) the floating element's border width.
 
 ```js
 <FloatingArrow


### PR DESCRIPTION
I believe the stroke width requirement was falsely under the stroke color?