### PR TITLE
fix(FloatingFocusManager): fallback to container

### DIFF
--- a/.changeset/proud-socks-look.md
+++ b/.changeset/proud-socks-look.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(FloatingFocusManager): correctly fallback to container

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -63,7 +63,7 @@ function getFirstTabbableElement(container: Element) {
     return container;
   }
 
-  return tabbable(container, tabbableOptions)[0];
+  return tabbable(container, tabbableOptions)[0] || container;
 }
 
 const VisuallyHiddenDismiss = React.forwardRef(function VisuallyHiddenDismiss(


### PR DESCRIPTION
After #3131, the reference may not be tabbable but focusable, which becomes tabbable after the return