### PR TITLE
fix(FloatingFocusManager): check for floating focus root element

### DIFF
--- a/.changeset/stale-lemons-doubt.md
+++ b/.changeset/stale-lemons-doubt.md
@@ -2,4 +2,4 @@
 '@floating-ui/react': patch
 ---
 
-fix(FloatingFocusManager): use `contains` check for tree ancestors on focus out
+fix(FloatingFocusManager): check for floating focus root element

--- a/.changeset/stale-lemons-doubt.md
+++ b/.changeset/stale-lemons-doubt.md
@@ -2,4 +2,4 @@
 '@floating-ui/react': patch
 ---
 
-fix(FloatingFocusManager): check for floating focus root element
+fix(FloatingFocusManager): check for ancestor floating focus element during `closeOnFocusOut`

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -340,14 +340,7 @@ export function FloatingFocusManager(
     }
 
     function handleFocusOutside(event: FocusEvent) {
-      const relatedTarget = event.relatedTarget as Element | null;
-
-      function nodeContainsRelatedTarget(node: FloatingNodeType) {
-        return (
-          contains(node.context?.elements.floating, relatedTarget) ||
-          contains(node.context?.elements.domReference, relatedTarget)
-        );
-      }
+      const relatedTarget = event.relatedTarget as HTMLElement | null;
 
       queueMicrotask(() => {
         const movedToUnrelatedNode = !(
@@ -358,10 +351,17 @@ export function FloatingFocusManager(
           relatedTarget?.hasAttribute(createAttribute('focus-guard')) ||
           (tree &&
             (getChildren(tree.nodesRef.current, nodeId).find(
-              nodeContainsRelatedTarget,
+              (node) =>
+                contains(node.context?.elements.floating, relatedTarget) ||
+                contains(node.context?.elements.domReference, relatedTarget),
             ) ||
               getAncestors(tree.nodesRef.current, nodeId).find(
-                nodeContainsRelatedTarget,
+                (node) =>
+                  [
+                    node.context?.elements.floating,
+                    getFloatingFocusElement(node.context?.elements.floating),
+                  ].includes(relatedTarget) ||
+                  node.context?.elements.domReference === relatedTarget,
               )))
         );
 

--- a/packages/react/src/utils/getFloatingFocusElement.ts
+++ b/packages/react/src/utils/getFloatingFocusElement.ts
@@ -1,7 +1,7 @@
 export const FOCUSABLE_ATTRIBUTE = 'data-floating-ui-focusable';
 
 export function getFloatingFocusElement(
-  floatingElement: HTMLElement | null,
+  floatingElement: HTMLElement | null | undefined,
 ): HTMLElement | null {
   if (!floatingElement) {
     return null;


### PR DESCRIPTION
Change to #3157. You want focused items inside the ancestor to still trigger a close

ref: https://github.com/mui/base-ui/issues/1078