### PR TITLE
chore(eslint): remove the duplicate config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,12 +11,10 @@ export default tseslint.config(
   {
     languageOptions: {
       globals: {
-        ...globals.browser,
-        ...globals.commonjs,
-        ...globals.es2021,
         ...globals.node,
+        ...globals.browser,
+        ...globals.es2021,
       },
-      parser: tseslint.parser,
       parserOptions: {
         ecmaVersion: 'latest',
       },


### PR DESCRIPTION
* `globals.node` has `globals.commonjs` already, it's duplecated so i remove it
  * https://github.com/sindresorhus/globals/blob/main/data/node.mjs#L7
* `tseslint.parser` already exists in `tseslint.configs.recommended`