### PR TITLE
fix(dom)!: remove check for containerType in isContainingBlock

### DIFF
--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -100,7 +100,6 @@ export function isContainingBlock(
           ? css[value as keyof CSSStyleDeclaration] !== 'none'
           : false,
     ) ||
-    (css.containerType ? css.containerType !== 'normal' : false) ||
     (!webkit && (css.backdropFilter ? css.backdropFilter !== 'none' : false)) ||
     (!webkit && (css.filter ? css.filter !== 'none' : false)) ||
     ['transform', 'translate', 'scale', 'rotate', 'perspective', 'filter'].some(


### PR DESCRIPTION
This change removes the condition `css.containerType !== 'normal'`, as browser vendors are moving away from this behavior. While MDN is a helpful resource, it is not the definitive source of truth for browser implementation details or CSS specifications. Therefore, aligning with the current state of browser implementations makes the code more robust and consistent.

The logic still retains the check for the contain property, which explicitly relates to the intended creation of a containing block. This ensures that the behavior remains aligned with the specification and the actual implementation of the contain property, providing the desired functionality without relying on deprecated or inconsistent behavior.

By adapting to this reality, we simplify the code and reduce reliance on outdated assumptions while maintaining the core functionality.

this is BREAKING CHANGE

https://github.com/floating-ui/floating-ui/issues/3067
https://github.com/w3c/csswg-drafts/issues/10102#issuecomment-2377653411
