### PR TITLE
chore(eslint): add 'dist' to 'ignores' in config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,9 @@ import tseslint from 'typescript-eslint';
 import prettierRecommended from 'eslint-plugin-prettier/recommended';
 
 export default tseslint.config(
+  {
+    ignores: ['**/dist/'],
+  },
   eslint.configs.recommended,
   react.configs.flat.recommended,
   tseslint.configs.recommended,


### PR DESCRIPTION
* Add `**/dist/` to `ignores` in `eslint.config.mjs` to prevent checking all `dist` files