### PR TITLE
fix(markOthers): ignore content editable nodes

### DIFF
--- a/.changeset/cyan-geckos-grin.md
+++ b/.changeset/cyan-geckos-grin.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/react': patch
+---
+
+Avoid marking nodes within contenteditable parents as inert


### PR DESCRIPTION
I'm attempting to use Floating UI in a ProseMirror based editor, which at it's core is a `contenteditable` div with a strict schema that determines what content is valid within it.

When using a component that utilises a `FloatingFocusManager` I have been finding that it adds the attribute `data-floating-ui-inert` to nodes _within_ the contenteditable, causing ProseMirror to attempt to parse the DOM mutations it causes. This causes all the nodes within the editor to re-render, and odd behaviour.

Please let me know your thoughts.

