### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release-floating-ui.yml
+++ b/.github/workflows/release-floating-ui.yml
@@ -8,13 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/typescript
-      - uses: ./.github/actions/unit
-      - uses: ./.github/actions/functional
+    uses: ./.github/workflows/ci.yml
 
   release:
     name: Release


### PR DESCRIPTION
Since I pinned functional tests runner to `ubuntu-22.04` in #3210, this started failing in master.

Using the ci workflow directly means it should use the same runners that are defined there.

Could also just pin the test job here to 22.04, but it's likely better to use the same setup that's used for running tests on PRs.

Hoping to get #3210 released soon :) 