### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'master'
   pull_request:
+  workflow_call:
 
 jobs:
   checks:


### PR DESCRIPTION
Follow-up to #3217, the ci workflow needs to allow itself to be called that way. Sorry I missed this before.