### PR TITLE
Improve performance by only clearing used timeouts

### DIFF
--- a/.changeset/purple-monkeys-remain.md
+++ b/.changeset/purple-monkeys-remain.md
@@ -2,4 +2,4 @@
 "@floating-ui/react": patch
 ---
 
-Improve performance by only clearing used timeouts
+perf: improve performance by only clearing used timeouts

--- a/.changeset/purple-monkeys-remain.md
+++ b/.changeset/purple-monkeys-remain.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+Improve performance by only clearing used timeouts

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -1,6 +1,5 @@
 import {
   activeElement,
-  clearTimeoutIfSet,
   contains,
   getDocument,
   getTarget,
@@ -18,6 +17,7 @@ import type {
   OpenChangeReason,
 } from '../types';
 import {createAttribute} from '../utils/createAttribute';
+import {clearTimeoutIfSet} from '../utils/clearTimeoutIfSet';
 
 export interface UseFocusProps {
   /**

--- a/packages/react/src/hooks/useFocus.ts
+++ b/packages/react/src/hooks/useFocus.ts
@@ -1,5 +1,6 @@
 import {
   activeElement,
+  clearTimeoutIfSet,
   contains,
   getDocument,
   getTarget,
@@ -46,7 +47,7 @@ export function useFocus(
   const {enabled = true, visibleOnly = true} = props;
 
   const blockFocusRef = React.useRef(false);
-  const timeoutRef = React.useRef<number>();
+  const timeoutRef = React.useRef(-1);
   const keyboardModalityRef = React.useRef(true);
 
   React.useEffect(() => {
@@ -97,7 +98,7 @@ export function useFocus(
 
   React.useEffect(() => {
     return () => {
-      clearTimeout(timeoutRef.current);
+      clearTimeoutIfSet(timeoutRef);
     };
   }, []);
 

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -1,4 +1,5 @@
 import {
+  clearTimeoutIfSet,
   contains,
   getDocument,
   isMouseLikePointerType,
@@ -139,8 +140,8 @@ export function useHover(
 
     function onOpenChange({open}: {open: boolean}) {
       if (!open) {
-        clearTimeout(timeoutRef.current);
-        clearTimeout(restTimeoutRef.current);
+        clearTimeoutIfSet(timeoutRef);
+        clearTimeoutIfSet(restTimeoutRef);
         blockMouseMoveRef.current = true;
         restTimeoutPendingRef.current = false;
       }
@@ -189,13 +190,13 @@ export function useHover(
         pointerTypeRef.current,
       );
       if (closeDelay && !handlerRef.current) {
-        clearTimeout(timeoutRef.current);
+        clearTimeoutIfSet(timeoutRef);
         timeoutRef.current = window.setTimeout(
           () => onOpenChange(false, event, reason),
           closeDelay,
         );
       } else if (runElseBranch) {
-        clearTimeout(timeoutRef.current);
+        clearTimeoutIfSet(timeoutRef);
         onOpenChange(false, event, reason);
       }
     },
@@ -229,7 +230,7 @@ export function useHover(
     if (!enabled) return;
 
     function onMouseEnter(event: MouseEvent) {
-      clearTimeout(timeoutRef.current);
+      clearTimeoutIfSet(timeoutRef);
       blockMouseMoveRef.current = false;
 
       if (
@@ -262,13 +263,13 @@ export function useHover(
       unbindMouseMoveRef.current();
 
       const doc = getDocument(elements.floating);
-      clearTimeout(restTimeoutRef.current);
+      clearTimeoutIfSet(restTimeoutRef);
       restTimeoutPendingRef.current = false;
 
       if (handleCloseRef.current && dataRef.current.floatingContext) {
         // Prevent clearing `onScrollMouseLeave` timeout.
         if (!open) {
-          clearTimeout(timeoutRef.current);
+          clearTimeoutIfSet(timeoutRef);
         }
 
         handlerRef.current = handleCloseRef.current({
@@ -423,8 +424,8 @@ export function useHover(
   React.useEffect(() => {
     return () => {
       cleanupMouseMoveHandler();
-      clearTimeout(timeoutRef.current);
-      clearTimeout(restTimeoutRef.current);
+      clearTimeoutIfSet(timeoutRef);
+      clearTimeoutIfSet(restTimeoutRef);
       clearPointerEvents();
     };
   }, [
@@ -467,7 +468,7 @@ export function useHover(
           return;
         }
 
-        clearTimeout(restTimeoutRef.current);
+        clearTimeoutIfSet(restTimeoutRef);
 
         if (pointerTypeRef.current === 'touch') {
           handleMouseMove();
@@ -482,7 +483,7 @@ export function useHover(
   const floating: ElementProps['floating'] = React.useMemo(
     () => ({
       onMouseEnter() {
-        clearTimeout(timeoutRef.current);
+        clearTimeoutIfSet(timeoutRef);
       },
       onMouseLeave(event) {
         if (!isClickLikeOpenEvent()) {

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -1,5 +1,4 @@
 import {
-  clearTimeoutIfSet,
   contains,
   getDocument,
   isMouseLikePointerType,
@@ -20,6 +19,7 @@ import type {
   OpenChangeReason,
 } from '../types';
 import {createAttribute} from '../utils/createAttribute';
+import {clearTimeoutIfSet} from '../utils/clearTimeoutIfSet';
 import {useLatestRef} from './utils/useLatestRef';
 import {useEffectEvent} from './utils/useEffectEvent';
 

--- a/packages/react/src/hooks/useTypeahead.ts
+++ b/packages/react/src/hooks/useTypeahead.ts
@@ -1,4 +1,4 @@
-import {stopEvent} from '@floating-ui/react/utils';
+import {clearTimeoutIfSet, stopEvent} from '@floating-ui/react/utils';
 import * as React from 'react';
 import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
@@ -81,7 +81,7 @@ export function useTypeahead(
     selectedIndex = null,
   } = props;
 
-  const timeoutIdRef = React.useRef<any>();
+  const timeoutIdRef = React.useRef(-1);
   const stringRef = React.useRef('');
   const prevIndexRef = React.useRef<number | null>(
     selectedIndex ?? activeIndex ?? -1,
@@ -96,7 +96,7 @@ export function useTypeahead(
 
   useModernLayoutEffect(() => {
     if (open) {
-      clearTimeout(timeoutIdRef.current);
+      clearTimeoutIfSet(timeoutIdRef);
       matchIndexRef.current = null;
       stringRef.current = '';
     }
@@ -186,8 +186,8 @@ export function useTypeahead(
     }
 
     stringRef.current += event.key;
-    clearTimeout(timeoutIdRef.current);
-    timeoutIdRef.current = setTimeout(() => {
+    clearTimeoutIfSet(timeoutIdRef);
+    timeoutIdRef.current = window.setTimeout(() => {
       stringRef.current = '';
       prevIndexRef.current = matchIndexRef.current;
       setTypingChange(false);

--- a/packages/react/src/hooks/useTypeahead.ts
+++ b/packages/react/src/hooks/useTypeahead.ts
@@ -1,10 +1,11 @@
-import {clearTimeoutIfSet, stopEvent} from '@floating-ui/react/utils';
+import {stopEvent} from '@floating-ui/react/utils';
 import * as React from 'react';
 import useModernLayoutEffect from 'use-isomorphic-layout-effect';
 
 import type {ElementProps, FloatingRootContext} from '../types';
 import {useEffectEvent} from './utils/useEffectEvent';
 import {useLatestRef} from './utils/useLatestRef';
+import {clearTimeoutIfSet} from '../utils/clearTimeoutIfSet';
 
 export interface UseTypeaheadProps {
   /**

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -197,10 +197,3 @@ export function isTypeableCombobox(element: Element | null) {
     element.getAttribute('role') === 'combobox' && isTypeableElement(element)
   );
 }
-
-export function clearTimeoutIfSet(timeoutRef: React.MutableRefObject<number>) {
-  if (timeoutRef.current !== -1) {
-    clearTimeout(timeoutRef.current);
-    timeoutRef.current = -1;
-  }
-}

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -197,3 +197,10 @@ export function isTypeableCombobox(element: Element | null) {
     element.getAttribute('role') === 'combobox' && isTypeableElement(element)
   );
 }
+
+export function clearTimeoutIfSet(timeoutRef: React.MutableRefObject<number>) {
+  if (timeoutRef.current !== -1) {
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = -1;
+  }
+}

--- a/packages/react/src/utils/clearTimeoutIfSet.ts
+++ b/packages/react/src/utils/clearTimeoutIfSet.ts
@@ -1,0 +1,8 @@
+import type * as React from 'react';
+
+export function clearTimeoutIfSet(timeoutRef: React.MutableRefObject<number>) {
+  if (timeoutRef.current !== -1) {
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = -1;
+  }
+}

--- a/packages/react/test/visual/components/MacSelect.tsx
+++ b/packages/react/test/visual/components/MacSelect.tsx
@@ -24,7 +24,7 @@ import {flushSync} from 'react-dom';
 
 import {FloatingPortal} from '../../../src';
 import {Button} from '../lib/Button';
-import {clearTimeoutIfSet} from '@floating-ui/react/utils';
+import {clearTimeoutIfSet} from '../../../src/utils/clearTimeoutIfSet';
 
 const fruits = [
   '🍒 Cherry',

--- a/packages/react/test/visual/components/MacSelect.tsx
+++ b/packages/react/test/visual/components/MacSelect.tsx
@@ -24,6 +24,7 @@ import {flushSync} from 'react-dom';
 
 import {FloatingPortal} from '../../../src';
 import {Button} from '../lib/Button';
+import {clearTimeoutIfSet} from '@floating-ui/react/utils';
 
 const fruits = [
   '🍒 Cherry',
@@ -203,7 +204,7 @@ export function Main() {
   const overflowRef = useRef<SideObject>(null);
   const allowSelectRef = useRef(false);
   const allowMouseUpRef = useRef(true);
-  const selectTimeoutRef = useRef<any>();
+  const selectTimeoutRef = useRef(-1);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const [open, setOpen] = useState(false);
@@ -282,12 +283,12 @@ export function Main() {
 
   useLayoutEffect(() => {
     if (open) {
-      selectTimeoutRef.current = setTimeout(() => {
+      selectTimeoutRef.current = window.setTimeout(() => {
         allowSelectRef.current = true;
       }, 300);
 
       return () => {
-        clearTimeout(selectTimeoutRef.current);
+        clearTimeoutIfSet(selectTimeoutRef);
       };
     }
 
@@ -311,9 +312,9 @@ export function Main() {
 
   const handleArrowHide = () => {
     if (touch) {
-      clearTimeout(selectTimeoutRef.current);
+      clearTimeoutIfSet(selectTimeoutRef);
       setBlockSelection(true);
-      selectTimeoutRef.current = setTimeout(() => {
+      selectTimeoutRef.current = window.setTimeout(() => {
         setBlockSelection(false);
       }, 400);
     }
@@ -415,10 +416,12 @@ export function Main() {
 
                               // On touch devices, prevent the element from
                               // immediately closing `onClick` by deferring it
-                              clearTimeout(selectTimeoutRef.current);
-                              selectTimeoutRef.current = setTimeout(() => {
-                                allowSelectRef.current = true;
-                              });
+                              clearTimeoutIfSet(selectTimeoutRef);
+                              selectTimeoutRef.current = window.setTimeout(
+                                () => {
+                                  allowSelectRef.current = true;
+                                },
+                              );
                             },
                           })}
                         >


### PR DESCRIPTION
We are using floating-ui in a large react SPA with a lot of tooltips and popovers. On every page transition, we experience a big lag due to clearing timeouts from floating-ui called in the useEffect cleanup method, as you can see in the screenshot.

![image](https://github.com/user-attachments/assets/02f8eee1-b391-4533-840f-e2fee91f26d8)

This PR mitigates this performance issue by only calling clearTimeout for timeouts that are actually set before and their ref value is not equal to -1.

We tested it locally with a patch and it works as expected.

Please let me know if you have any suggestions, how to improve or refactor it to meet your requirements.