### PR TITLE
ci(.github/actions/setup): add caching in pnpm and nodejs setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,13 +3,15 @@ description: Setup node and install dependencies
 runs:
   using: composite
   steps:
-    - name: Checkout
+    - name: Setup Pnpm
+      uses: pnpm/action-setup@v4
+
+    - name: Install Node.js
       uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
+        cache: 'pnpm'
         registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies
-      uses: pnpm/action-setup@v4
-      with:
-        run_install: true
+      run: pnpm install

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,4 +14,5 @@ runs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies
+      shell: sh
       run: pnpm install


### PR DESCRIPTION
* Add caching in pnpm and nodejs setup action
  * https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data
  * pnpm caching is not woring now, if we set, our action time will reduce
  
  
![image](https://github.com/user-attachments/assets/f9c946da-920f-4fda-8669-287b68792e43)

Now we can see our first cache