### PR TITLE
fix(useFloating): elements passed to `setPositionReference` should add `getClientRects` property

### DIFF
--- a/.changeset/empty-fireants-teach.md
+++ b/.changeset/empty-fireants-teach.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useFloating): prevent error with `inline` middlware when passing a real DOM element to `refs.setPositionReference` due to `element.getClientRects()` not being handled

--- a/.changeset/empty-fireants-teach.md
+++ b/.changeset/empty-fireants-teach.md
@@ -2,4 +2,4 @@
 "@floating-ui/react": patch
 ---
 
-fix(useFloating): prevent error with `inline` middlware when passing a real DOM element to `refs.setPositionReference` due to `element.getClientRects()` not being handled
+fix(useFloating): prevent error when using `inline` middleware when passing a real DOM element to `refs.setPositionReference` due to `element.getClientRects()` not being handled

--- a/packages/react/src/hooks/useFloating.ts
+++ b/packages/react/src/hooks/useFloating.ts
@@ -1,4 +1,7 @@
-import {useFloating as usePosition} from '@floating-ui/react-dom';
+import {
+  useFloating as usePosition,
+  type VirtualElement,
+} from '@floating-ui/react-dom';
 import {isElement} from '@floating-ui/utils/dom';
 import * as React from 'react';
 import useModernLayoutEffect from 'use-isomorphic-layout-effect';
@@ -63,10 +66,11 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
   const setPositionReference = React.useCallback(
     (node: ReferenceType | null) => {
       const computedPositionReference = isElement(node)
-        ? {
+        ? ({
             getBoundingClientRect: () => node.getBoundingClientRect(),
+            getClientRects: () => node.getClientRects(),
             contextElement: node,
-          }
+          } satisfies VirtualElement)
         : node;
       // Store the positionReference in state if the DOM reference is specified externally via the
       // `elements.reference` option. This ensures that it won't be overridden on future renders.

--- a/packages/react/test/unit/useFloating.test.tsx
+++ b/packages/react/test/unit/useFloating.test.tsx
@@ -5,6 +5,7 @@ import {useCallback, useLayoutEffect, useState} from 'react';
 import {vi} from 'vitest';
 
 import {
+  inline,
   useClick,
   useDismiss,
   useFloating,
@@ -125,6 +126,25 @@ describe('positionReference', () => {
 
     expect(getByTestId('reference-text').textContent).toBe('reference');
     expect(getByTestId('position-reference-text').textContent).toBe('218');
+  });
+
+  test('does not error when using `inline` middleware and setting the position reference to a real element', async () => {
+    function App() {
+      const {refs} = useFloating({
+        middleware: [inline()],
+      });
+
+      return (
+        <>
+          <div ref={refs.setReference} />
+          <div ref={refs.setPositionReference} />
+          <div ref={refs.setFloating} />
+        </>
+      );
+    }
+
+    render(<App />);
+    await act(async () => {});
   });
 });
 


### PR DESCRIPTION
Fixes #3230