### PR TITLE
fix(useClick): fix toggle behavior with Enter key when reference element is anchor

### DIFF
--- a/.changeset/serious-dryers-juggle.md
+++ b/.changeset/serious-dryers-juggle.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useClick): fix toggle behavior with Enter key when reference element is anchor

--- a/packages/react/src/hooks/useClick.ts
+++ b/packages/react/src/hooks/useClick.ts
@@ -11,6 +11,10 @@ function isButtonTarget(event: React.KeyboardEvent<Element>) {
   return isHTMLElement(event.target) && event.target.tagName === 'BUTTON';
 }
 
+function isAnchorTarget(event: React.KeyboardEvent<Element>) {
+  return isHTMLElement(event.target) && event.target.tagName === 'A';
+}
+
 function isSpaceIgnored(element: Element | null) {
   return isTypeableElement(element);
 }
@@ -146,6 +150,10 @@ export function useClick(
           // Prevent scrolling
           event.preventDefault();
           didKeyDownRef.current = true;
+        }
+
+        if (isAnchorTarget(event)) {
+          return;
         }
 
         if (event.key === 'Enter') {


### PR DESCRIPTION
Fixes #3190.

Enter keypress on an anchor triggers onClick by default, so it is not needed then.