### PR TITLE
fix(FloatingFocusManager): set inert attribute value to empty string instead of "true"

### DIFF
--- a/.changeset/lucky-deers-laugh.md
+++ b/.changeset/lucky-deers-laugh.md
@@ -2,4 +2,4 @@
 "@floating-ui/react": patch
 ---
 
-fix(FloatingFocusManager): set inert attribute value to empty string instead of "true"
+fix(FloatingFocusManager): set `inert` attribute value to empty string instead of `"true"`

--- a/.changeset/lucky-deers-laugh.md
+++ b/.changeset/lucky-deers-laugh.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(FloatingFocusManager): set inert attribute value to empty string instead of "true"

--- a/packages/react/src/utils/markOthers.ts
+++ b/packages/react/src/utils/markOthers.ts
@@ -99,7 +99,10 @@ function applyAttributeToOthers(
         }
 
         if (!alreadyHidden && controlAttribute) {
-          node.setAttribute(controlAttribute, 'true');
+          node.setAttribute(
+            controlAttribute,
+            controlAttribute === 'inert' ? '' : 'true',
+          );
         }
       }
     });

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -537,7 +537,7 @@ describe('guards', () => {
     await userEvent.tab();
     await userEvent.tab();
 
-    expect(document.activeElement).toHaveAttribute('inert');
+    expect(document.activeElement).toHaveAttribute('inert', '');
   });
 });
 


### PR DESCRIPTION
It's not a bug per say, but it would be more correct to use empty string for inert value:
- inert is a boolean property, meaning that the value does not generally matter
- for boolean properties, it's recommended to set them to either empty string or the attribute value (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute#value) or [HTML spec](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes))
- since this is in the context of React, which itself sets boolean properties to empty string, it would be best to align with that

Context for this change: we use [html-validate](https://html-validate.org/) to validate the rendered HTML of our components. The tool has both [attribute-allowed-values](https://html-validate.org/rules/attribute-allowed-values.html) and [attribute-boolean-style](https://html-validate.org/rules/attribute-boolean-style.html) rules to validate such things, which we currently have enabled.

Not a huge deal if you don't want to accept this, but I think it does not hurt to align better to HTML spec recommendations.