### PR TITLE
fix(useListNavigation): Fix list navigation for nested lists with mixed orientation

### DIFF
--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -583,9 +583,10 @@ export function useListNavigation(
     virtual,
   ]);
 
-  const parentOrientation: UseListNavigationProps['orientation'] =
-    tree?.nodesRef.current.find((node) => node.id === parentId)?.context
-      ?.dataRef?.current.orientation;
+  const getParentOrientation = React.useCallback(() => {
+    return tree?.nodesRef.current.find((node) => node.id === parentId)?.context
+      ?.dataRef?.current.orientation as UseListNavigationProps['orientation'];
+  }, [parentId, tree]);
 
   const commonOnKeyDown = useEffectEvent((event: React.KeyboardEvent) => {
     isPointerModalityRef.current = false;
@@ -613,14 +614,15 @@ export function useListNavigation(
       nested &&
       isCrossOrientationCloseKey(event.key, orientation, rtl, cols)
     ) {
-      if (isMainOrientationKey(event.key, parentOrientation)) {
+      onOpenChange(false, event.nativeEvent, 'list-navigation');
+
+      if (isMainOrientationKey(event.key, getParentOrientation())) {
         // If the nested list's close key is also the parent navigation key,
-        // let the parent navigate - this will close the nested list with from focusout.
+        // let the parent navigate.
         return;
       }
 
       stopEvent(event);
-      onOpenChange(false, event.nativeEvent, 'list-navigation');
 
       if (isHTMLElement(elements.domReference)) {
         if (virtual) {
@@ -869,7 +871,7 @@ export function useListNavigation(
         );
         const isParentCrossOpenKey = isCrossOrientationOpenKey(
           event.key,
-          parentOrientation,
+          getParentOrientation(),
           rtl,
         );
         const isMainKey = isMainOrientationKey(event.key, orientation);
@@ -938,7 +940,7 @@ export function useListNavigation(
         if (isNavigationKey) {
           const isParentMainKey = isMainOrientationKey(
             event.key,
-            parentOrientation,
+            getParentOrientation(),
           );
           keyRef.current = nested && isParentMainKey ? null : event.key;
         }
@@ -1004,7 +1006,7 @@ export function useListNavigation(
     open,
     openOnArrowKeyDown,
     orientation,
-    parentOrientation,
+    getParentOrientation,
     rtl,
     selectedIndex,
     tree,

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -614,15 +614,13 @@ export function useListNavigation(
       nested &&
       isCrossOrientationCloseKey(event.key, orientation, rtl, cols)
     ) {
-      onOpenChange(false, event.nativeEvent, 'list-navigation');
-
-      if (isMainOrientationKey(event.key, getParentOrientation())) {
-        // If the nested list's close key is also the parent navigation key,
-        // let the parent navigate.
-        return;
+      // If the nested list's close key is also the parent navigation key,
+      // let the parent navigate. Otherwise, stop propagating the event.
+      if (!isMainOrientationKey(event.key, getParentOrientation())) {
+        stopEvent(event);
       }
 
-      stopEvent(event);
+      onOpenChange(false, event.nativeEvent, 'list-navigation');
 
       if (isHTMLElement(elements.domReference)) {
         if (virtual) {

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -583,6 +583,10 @@ export function useListNavigation(
     virtual,
   ]);
 
+  const parentOrientation: UseListNavigationProps['orientation'] =
+    tree?.nodesRef.current.find((node) => node.id === parentId)?.context
+      ?.dataRef?.current.orientation;
+
   const commonOnKeyDown = useEffectEvent((event: React.KeyboardEvent) => {
     isPointerModalityRef.current = false;
     forceSyncFocusRef.current = true;
@@ -609,6 +613,12 @@ export function useListNavigation(
       nested &&
       isCrossOrientationCloseKey(event.key, orientation, rtl, cols)
     ) {
+      if (isMainOrientationKey(event.key, parentOrientation)) {
+        // If the nested list's close key is also the parent navigation key,
+        // let the parent navigate - this will close the nested list with from focusout.
+        return;
+      }
+
       stopEvent(event);
       onOpenChange(false, event.nativeEvent, 'list-navigation');
 
@@ -846,9 +856,6 @@ export function useListNavigation(
         const isArrowKey = event.key.startsWith('Arrow');
         const isHomeOrEndKey = ['Home', 'End'].includes(event.key);
         const isMoveKey = isArrowKey || isHomeOrEndKey;
-        const parentOrientation = tree?.nodesRef.current.find(
-          (node) => node.id === parentId,
-        )?.context?.dataRef?.current.orientation;
         const isCrossOpenKey = isCrossOrientationOpenKey(
           event.key,
           orientation,
@@ -997,7 +1004,7 @@ export function useListNavigation(
     open,
     openOnArrowKeyDown,
     orientation,
-    parentId,
+    parentOrientation,
     rtl,
     selectedIndex,
     tree,

--- a/packages/react/test/unit/useListNavigation.test.tsx
+++ b/packages/react/test/unit/useListNavigation.test.tsx
@@ -26,6 +26,7 @@ import {Main as Grid} from '../visual/components/Grid';
 import {Main as EmojiPicker} from '../visual/components/EmojiPicker';
 import {Main as ListboxFocus} from '../visual/components/ListboxFocus';
 import {Main as NestedMenu} from '../visual/components/Menu';
+import {HorizontalMenu} from '../visual/components/MenuOrientation';
 import {Menu, MenuItem} from '../visual/components/MenuVirtual';
 import {isJSDOM} from '../../src/utils';
 
@@ -1225,6 +1226,31 @@ test.skipIf(!isJSDOM())(
     // escape closes the submenu
     await userEvent.keyboard('{Escape}');
     expect(screen.getByText('Image')).toHaveFocus();
+  },
+);
+
+// In JSDOM it will not focus the first item, but will in the browser
+test.skipIf(!isJSDOM())(
+  'keyboard navigation in nested menus with different orientation',
+  async () => {
+    render(<HorizontalMenu />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Edit'}));
+    await act(async () => {});
+    await userEvent.keyboard('{ArrowRight}');
+    await userEvent.keyboard('{ArrowRight}');
+    await userEvent.keyboard('{ArrowRight}');
+    await userEvent.keyboard('{ArrowDown}'); // opens the Copy as submenu
+    await act(async () => {});
+
+    await userEvent.keyboard('{ArrowRight}');
+    await userEvent.keyboard('{ArrowDown}'); // opens the Share submenu
+    await act(async () => {});
+
+    expect(screen.getByText('Mail')).toHaveFocus();
+
+    await userEvent.keyboard('{ArrowLeft}');
+    expect(screen.getByText('Copy as')).toHaveFocus();
   },
 );
 

--- a/packages/react/test/visual/components/MenuOrientation.tsx
+++ b/packages/react/test/visual/components/MenuOrientation.tsx
@@ -389,7 +389,7 @@ export const Menu = React.forwardRef<
   return <MenuComponent {...props} ref={ref} />;
 });
 
-export const Main = () => {
+export const HorizontalMenu = () => {
   return (
     <>
       <h1 className="text-5xl font-bold mb-8">Horizontal menu</h1>
@@ -415,6 +415,13 @@ export const Main = () => {
           </Menu>
         </Menu>
       </div>
+    </>
+  );
+};
+
+export const VerticalMenu = () => {
+  return (
+    <>
       <h1 className="text-5xl font-bold mb-8">Vertical menu</h1>
       <div className="grid place-items-center border border-slate-400 rounded lg:w-[40rem] h-[20rem] mb-4">
         <Menu label="Edit">
@@ -438,6 +445,13 @@ export const Main = () => {
           </Menu>
         </Menu>
       </div>
+    </>
+  );
+};
+
+export const HorizontalMenuWithHorizontalSubmenus = () => {
+  return (
+    <>
       <h1 className="text-5xl font-bold mb-8">
         Horizontal menu with horizontal submenus
       </h1>
@@ -463,6 +477,16 @@ export const Main = () => {
           </Menu>
         </Menu>
       </div>
+    </>
+  );
+};
+
+export const Main = () => {
+  return (
+    <>
+      <HorizontalMenu />
+      <VerticalMenu />
+      <HorizontalMenuWithHorizontalSubmenus />
     </>
   );
 };


### PR DESCRIPTION
Keyboard navigation for nested lists with different orientation (like a horizontal menubar with vertical menus) works somewhat inconsistently. When a submenu item is focused, pressing <kbd>RightArrow</kbd> closes the submenu and focuses the next item from the parent. Pressing the <kbd>LeftArrow</kbd>, however, closes the submenu and focuses its trigger instead of the previous item.

In this PR, I detect whether the close key of a nested list is also a navigation key of the parent list. If so, the keyboard event isn't stopped, and the parent has a chance to focus on another item.

~~I'm not sure what should happen when the open submenu's trigger is the first item within the parent and `loop = false`. This solution makes the submenu stay open, as the parent won't change focus. Alternatively, we could call `onOpenChange(false, event.nativeEvent, 'list-navigation');` to make sure the submenu is closed.~~

EDIT:
After more testing, I decided that in case where an open submenu is the first item within its parent, it's more natural just to close the submenu and leave focus on its trigger than to leave it open.