### PR TITLE
chore: publish canary packages with pkg.pr.new

### DIFF
--- a/.github/actions/canary-publish/action.yml
+++ b/.github/actions/canary-publish/action.yml
@@ -1,0 +1,11 @@
+name: Canary publish
+description: Publishes canary packages to pkg.pr.new
+runs:
+  using: composite
+  steps:
+    - name: Build packages
+      shell: sh
+      run: pnpm prepack
+    - name: Publish to pkg-pr-new
+      shell: sh
+      run: pnpm dlx pkg-pr-new publish './packages/core' './packages/dom' './packages/react' './packages/react-dom' './packages/react-native' './packages/utils' './packages/vue' --compact --pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+      - name: Build packages
+        run: pnpm prepack
       - name: Publish canary packages
         run: pnpm dlx pkg-pr-new publish './packages/core' './packages/dom' './packages/react' './packages/react-dom' './packages/utils' --compact --pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - name: Publish canary packages
-        run: pnpm dlx pkg-pr-new publish './packages/*' --compact --pnpm
+        run: pnpm dlx pkg-pr-new publish './packages/core' './packages/dom' './packages/react' './packages/react-dom' './packages/react-native' './packages/utils' './packages/vue' --compact --pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-      - name: Build packages
-        run: pnpm prepack
-      - name: Publish canary packages
-        run: pnpm dlx pkg-pr-new publish './packages/core' './packages/dom' './packages/react' './packages/react-dom' './packages/react-native' './packages/utils' './packages/vue' --compact --pnpm
+      - uses: ./.github/actions/canary-publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - name: Publish canary packages
-        run: pnpm dlx pkg-pr-new publish './packages/core' './packages/dom' './packages/react' './packages/react-dom' './packages/react-native' './packages/utils' './packages/vue' --compact --pnpm
+        run: pnpm dlx pkg-pr-new publish './packages/core' './packages/dom' './packages/react' './packages/react-dom' './packages/utils' --compact --pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,12 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - name: Run browser tests for @floating-ui/react
         run: pnpm --filter @floating-ui/react run test:browser
+
+  canary-publish:
+    name: Publish canary packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - name: Publish canary packages
+        run: pnpm dlx pkg-pr-new publish './packages/*' --compact --pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,4 @@ jobs:
       - name: Build packages
         run: pnpm prepack
       - name: Publish canary packages
-        run: pnpm dlx pkg-pr-new publish './packages/core' './packages/dom' './packages/react' './packages/react-dom' './packages/utils' --compact --pnpm
+        run: pnpm dlx pkg-pr-new publish './packages/core' './packages/dom' './packages/react' './packages/react-dom' './packages/react-native' './packages/utils' './packages/vue' --compact --pnpm

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -34,6 +34,11 @@
     "**/*.d.mts"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/floating-ui/floating-ui.git",
+    "directory": "packages/devtools"
+  },
   "peerDependencies": {
     "@floating-ui/dom": "^1.0.0"
   },

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -34,11 +34,6 @@
     "**/*.d.mts"
   ],
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/floating-ui/floating-ui.git",
-    "directory": "packages/devtools"
-  },
   "peerDependencies": {
     "@floating-ui/dom": "^1.0.0"
   },


### PR DESCRIPTION
Set up publishing PR and master packages to pkg.pr.new.

I excluded the @floating-ui/devtools package as it is published to npm without the repository field in its package.json and because of this, it can't be published with the `--compact` flag. Once the version with the repository field is published, we should be able to publish all packages (`./packages/*`).