### PR TITLE
fix(useHover): prevent floating element from closing when close to reference

### DIFF
--- a/.changeset/small-seals-lie.md
+++ b/.changeset/small-seals-lie.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useHover): prevent floating element unexpectedly closing when close to reference element when not using `safePolygon()` and a close delay

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -229,7 +229,7 @@ export function useHover(
   React.useEffect(() => {
     if (!enabled) return;
 
-    function onMouseEnter(event: MouseEvent) {
+    function onReferenceMouseEnter(event: MouseEvent) {
       clearTimeoutIfSet(timeoutRef);
       blockMouseMoveRef.current = false;
 
@@ -257,7 +257,7 @@ export function useHover(
       }
     }
 
-    function onMouseLeave(event: MouseEvent) {
+    function onReferenceMouseLeave(event: MouseEvent) {
       if (isClickLikeOpenEvent()) return;
 
       unbindMouseMoveRef.current();
@@ -344,26 +344,29 @@ export function useHover(
       const reference = elements.domReference as unknown as HTMLElement;
       const floating = elements.floating;
 
-      reference.addEventListener('mouseenter', onMouseEnter);
-      reference.addEventListener('mouseleave', onMouseLeave);
+      reference.addEventListener('mouseenter', onReferenceMouseEnter);
+      reference.addEventListener('mouseleave', onReferenceMouseLeave);
       open && reference.addEventListener('mouseleave', onScrollMouseLeave);
       move &&
-        reference.addEventListener('mousemove', onMouseEnter, {once: true});
+        reference.addEventListener('mousemove', onReferenceMouseEnter, {
+          once: true,
+        });
 
       if (floating) {
-        floating.addEventListener('mouseleave', onFloatingMouseLeave);
         floating.addEventListener('mouseenter', onFloatingMouseEnter);
+        floating.addEventListener('mouseleave', onFloatingMouseLeave);
       }
 
       return () => {
-        reference.removeEventListener('mouseenter', onMouseEnter);
-        reference.removeEventListener('mouseleave', onMouseLeave);
+        reference.removeEventListener('mouseenter', onReferenceMouseEnter);
+        reference.removeEventListener('mouseleave', onReferenceMouseLeave);
         open && reference.removeEventListener('mouseleave', onScrollMouseLeave);
-        move && reference.removeEventListener('mousemove', onMouseEnter);
+        move &&
+          reference.removeEventListener('mousemove', onReferenceMouseEnter);
 
         if (floating) {
-          floating.removeEventListener('mouseleave', onFloatingMouseLeave);
           floating.removeEventListener('mouseenter', onFloatingMouseEnter);
+          floating.removeEventListener('mouseleave', onFloatingMouseLeave);
         }
       };
     }

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -358,6 +358,7 @@ export function useHover(
       reference.addEventListener('mouseleave', onReferenceMouseLeave);
 
       if (floating) {
+        floating.addEventListener('mouseleave', onScrollMouseLeave);
         floating.addEventListener('mouseenter', onFloatingMouseEnter);
         floating.addEventListener('mouseleave', onFloatingMouseLeave);
       }
@@ -375,6 +376,7 @@ export function useHover(
         reference.removeEventListener('mouseleave', onReferenceMouseLeave);
 
         if (floating) {
+          floating.removeEventListener('mouseleave', onScrollMouseLeave);
           floating.removeEventListener('mouseenter', onFloatingMouseEnter);
           floating.removeEventListener('mouseleave', onFloatingMouseLeave);
         }

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -344,13 +344,18 @@ export function useHover(
       const reference = elements.domReference as unknown as HTMLElement;
       const floating = elements.floating;
 
-      reference.addEventListener('mouseenter', onReferenceMouseEnter);
-      reference.addEventListener('mouseleave', onReferenceMouseLeave);
-      open && reference.addEventListener('mouseleave', onScrollMouseLeave);
-      move &&
+      if (open) {
+        reference.addEventListener('mouseleave', onScrollMouseLeave);
+      }
+
+      if (move) {
         reference.addEventListener('mousemove', onReferenceMouseEnter, {
           once: true,
         });
+      }
+
+      reference.addEventListener('mouseenter', onReferenceMouseEnter);
+      reference.addEventListener('mouseleave', onReferenceMouseLeave);
 
       if (floating) {
         floating.addEventListener('mouseenter', onFloatingMouseEnter);
@@ -358,11 +363,16 @@ export function useHover(
       }
 
       return () => {
+        if (open) {
+          reference.removeEventListener('mouseleave', onScrollMouseLeave);
+        }
+
+        if (move) {
+          reference.removeEventListener('mousemove', onReferenceMouseEnter);
+        }
+
         reference.removeEventListener('mouseenter', onReferenceMouseEnter);
         reference.removeEventListener('mouseleave', onReferenceMouseLeave);
-        open && reference.removeEventListener('mouseleave', onScrollMouseLeave);
-        move &&
-          reference.removeEventListener('mousemove', onReferenceMouseEnter);
 
         if (floating) {
           floating.removeEventListener('mouseenter', onFloatingMouseEnter);


### PR DESCRIPTION
Fixes #3257

The problem arises when mixing native DOM listeners and React's event props. React's run first, and so the `mouseenter` of the floating element fires _before_ the `mouseleave` of the reference element, causing the close timer not to be cleared.

https://codesandbox.io/p/sandbox/floating-ui-react-dom-template-forked-q7gq8l