### PR TITLE
fix(useHover): clean up blockPointerEvents when opened with click after hover

### DIFF
--- a/.changeset/clean-beans-hug.md
+++ b/.changeset/clean-beans-hug.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useHover): clean up blockPointerEvents when opened with click after hover

--- a/packages/react/src/hooks/useHover.ts
+++ b/packages/react/src/hooks/useHover.ts
@@ -258,7 +258,10 @@ export function useHover(
     }
 
     function onMouseLeave(event: MouseEvent) {
-      if (isClickLikeOpenEvent()) return;
+      if (isClickLikeOpenEvent()) {
+        clearPointerEvents();
+        return;
+      }
 
       unbindMouseMoveRef.current();
 

--- a/packages/react/test/visual/components/Popover.tsx
+++ b/packages/react/test/visual/components/Popover.tsx
@@ -7,12 +7,14 @@ import {
   FloatingPortal,
   FloatingTree,
   offset,
+  safePolygon,
   shift,
   useClick,
   useDismiss,
   useFloating,
   useFloatingNodeId,
   useFloatingParentNodeId,
+  useHover,
   useId,
   useInteractions,
   useRole,
@@ -116,6 +118,7 @@ interface Props {
   modal?: boolean;
   children?: React.ReactElement<HTMLElement>;
   bubbles?: boolean;
+  hover?: boolean;
 }
 
 function PopoverComponent({
@@ -124,6 +127,7 @@ function PopoverComponent({
   placement,
   modal = true,
   bubbles = true,
+  hover = false,
 }: Props) {
   const [open, setOpen] = useState(false);
 
@@ -142,6 +146,10 @@ function PopoverComponent({
   const descriptionId = `${id}-description`;
 
   const {getReferenceProps, getFloatingProps} = useInteractions([
+    useHover(context, {
+      enabled: hover,
+      handleClose: safePolygon({blockPointerEvents: true}),
+    }),
     useClick(context),
     useRole(context),
     useDismiss(context, {


### PR DESCRIPTION
Hope the test kind of explains itself, but putting it here as well: if a floating element has both hover and click hooks, pointer events are blocked on reference hover. If the user then clicks the reference element, it switches off the mouseleave handlers, instead waiting for a outside click or some other dismiss event. But, as currently the pointer events remain blocked, this breaks when such floating components are nested - clicking on the parent floating element when pointer events are blocked also closes the parent, as it considers it an outside press then.

Fairly easy to reproduce in the playground Popover component:
1. Open the Popover playground
2. Turn off modal focus management
3. Enable hover on the second level Popover in source
4. Open the first level Popover
5. Open the second level Popover via hover, then click the reference element (this "switches" useHover to a "click" state)
6. Click first level Popover - see that both popovers close, even though it should only close the second level popover.

The lint/typecheck failure does not seem to be my fault?