### PR TITLE
Fix a bug `useListNavigation` no longer correctly scroll to the selected index

### DIFF
--- a/.changeset/beige-scissors-work.md
+++ b/.changeset/beige-scissors-work.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useFloating): correctly scroll to the selected index on open

--- a/.changeset/beige-scissors-work.md
+++ b/.changeset/beige-scissors-work.md
@@ -2,4 +2,4 @@
 "@floating-ui/react": patch
 ---
 
-fix(useFloating): correctly scroll to the selected index on open
+fix(useListNavigation): correctly scroll to the selected item on open when using a pointer and `FloatingFocusManager` `initialFocus` is not in use

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -344,6 +344,7 @@ export function useListNavigation(
     }
 
     const initialItem = listRef.current[indexRef.current];
+    const forceScrollIntoView = forceScrollIntoViewRef.current;
 
     if (initialItem) {
       runFocus(initialItem);
@@ -366,7 +367,7 @@ export function useListNavigation(
       const shouldScrollIntoView =
         scrollIntoViewOptions &&
         item &&
-        (forceScrollIntoViewRef.current || !isPointerModalityRef.current);
+        (forceScrollIntoView || !isPointerModalityRef.current);
 
       if (shouldScrollIntoView) {
         // JSDOM doesn't support `.scrollIntoView()` but it's widely supported

--- a/packages/react/test/unit/useListNavigation.test.tsx
+++ b/packages/react/test/unit/useListNavigation.test.tsx
@@ -410,26 +410,24 @@ describe('focusItemOnOpen', () => {
 
 describe('selectedIndex', () => {
   test('scrollIntoView on open', ({onTestFinished}) => {
-    const origins = {
-      requestAnimationFrame: vi
-        .mocked(requestAnimationFrame)
-        .getMockImplementation() as typeof requestAnimationFrame,
-      scrollIntoView: HTMLElement.prototype.scrollIntoView,
-    };
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 0);
+    const scrollIntoView = vi.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
     onTestFinished(() => {
-      HTMLElement.prototype.scrollIntoView = origins.scrollIntoView;
-      vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
-        origins.requestAnimationFrame,
-      );
+      requestAnimationFrame.mockRestore();
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
     });
-    const spy = vi.fn();
-    vi.useFakeTimers({toFake: ['requestAnimationFrame']});
-    HTMLElement.prototype.scrollIntoView = spy;
-    vi.mocked(requestAnimationFrame).mockRestore();
+
     render(<App selectedIndex={0} />);
     fireEvent.click(screen.getByRole('button'));
-    vi.advanceTimersToNextFrame();
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(requestAnimationFrame).toHaveBeenCalled();
+    // Run the timer
+    requestAnimationFrame.mock.calls.forEach((call) => call[0](0));
+    expect(scrollIntoView).toHaveBeenCalled();
     cleanup();
   });
 });

--- a/packages/react/test/unit/useListNavigation.test.tsx
+++ b/packages/react/test/unit/useListNavigation.test.tsx
@@ -408,6 +408,32 @@ describe('focusItemOnOpen', () => {
   });
 });
 
+describe('selectedIndex', () => {
+  test('scrollIntoView on open', ({onTestFinished}) => {
+    const origins = {
+      requestAnimationFrame: vi
+        .mocked(requestAnimationFrame)
+        .getMockImplementation() as typeof requestAnimationFrame,
+      scrollIntoView: HTMLElement.prototype.scrollIntoView,
+    };
+    onTestFinished(() => {
+      HTMLElement.prototype.scrollIntoView = origins.scrollIntoView;
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
+        origins.requestAnimationFrame,
+      );
+    });
+    const spy = vi.fn();
+    vi.useFakeTimers({toFake: ['requestAnimationFrame']});
+    HTMLElement.prototype.scrollIntoView = spy;
+    vi.mocked(requestAnimationFrame).mockRestore();
+    render(<App selectedIndex={0} />);
+    fireEvent.click(screen.getByRole('button'));
+    vi.advanceTimersToNextFrame();
+    expect(spy).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+});
+
 describe('allowEscape + virtual', () => {
   test('true', () => {
     render(<App allowEscape={true} virtual loop />);


### PR DESCRIPTION
As titled, this PR fixes a bug `useListNavigation` does not scroll to the selected index on open.

It is because `forceScrollIntoViewRef.current` is set to false right after `focusItem` is called while scroll [can run asynchronously](https://github.com/floating-ui/floating-ui/blob/46f6464cc38b30aa63209ea4eb9f5f413fe6f777/packages/react/src/hooks/useListNavigation.ts#L460).

Related: https://github.com/floating-ui/floating-ui/pull/3141