### PR TITLE
fix(useListNavigation): reset focusOnOpen when popup is closed

### DIFF
--- a/.changeset/angry-baboons-run.md
+++ b/.changeset/angry-baboons-run.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useListNavigation): reset internal `focusOnOpen` state when floating element is closed. This prevents the first item being highlighted on open under certain conditions when it shouldn't be.

--- a/.changeset/angry-baboons-run.md
+++ b/.changeset/angry-baboons-run.md
@@ -2,4 +2,4 @@
 "@floating-ui/react": patch
 ---
 
-fix(useListNavigation): reset internal `focusOnOpen` state when floating element is closed. This prevents the first item being highlighted on open under certain conditions when it shouldn't be.
+fix(useListNavigation): reset internal `focusItemOnOpen` state when floating element is closed. This prevents the first item being highlighted on open under certain conditions when it shouldn't be.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -94,6 +94,7 @@
     "react-responsive": "^9.0.2",
     "react-router-dom": "^6.21.1",
     "resize-observer-polyfill": "^1.5.1",
-    "use-isomorphic-layout-effect": "^1.1.2"
+    "use-isomorphic-layout-effect": "^1.1.2",
+    "vitest-browser-react": "^0.1.1"
   }
 }

--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -542,8 +542,9 @@ export function useListNavigation(
   useModernLayoutEffect(() => {
     if (!open) {
       keyRef.current = null;
+      focusItemOnOpenRef.current = focusItemOnOpen;
     }
-  }, [open]);
+  }, [open, focusItemOnOpen]);
 
   const hasActiveIndex = activeIndex != null;
 

--- a/packages/react/test/visual/components/Menu.tsx
+++ b/packages/react/test/visual/components/Menu.tsx
@@ -22,6 +22,7 @@ import {
   useMergeRefs,
   useRole,
   useTypeahead,
+  useFocus,
 } from '@floating-ui/react';
 import {ChevronRightIcon} from '@radix-ui/react-icons';
 import c from 'clsx';
@@ -56,6 +57,7 @@ interface MenuProps {
   keepMounted?: boolean;
   orientation?: 'vertical' | 'horizontal' | 'both';
   cols?: number;
+  openOnFocus?: boolean;
 }
 
 export const MenuComponent = React.forwardRef<
@@ -68,6 +70,7 @@ export const MenuComponent = React.forwardRef<
     keepMounted = false,
     cols,
     orientation: orientationOption,
+    openOnFocus = false,
     ...props
   },
   forwardedRef,
@@ -112,6 +115,7 @@ export const MenuComponent = React.forwardRef<
     toggle: !isNested || !allowHover,
     ignoreMouse: isNested,
   });
+  const focus = useFocus(context, {enabled: openOnFocus});
   const role = useRole(context, {role: 'menu'});
   const dismiss = useDismiss(context, {bubbles: true});
   const listNavigation = useListNavigation(context, {
@@ -133,6 +137,7 @@ export const MenuComponent = React.forwardRef<
     click,
     role,
     dismiss,
+    focus,
     listNavigation,
     typeahead,
   ]);

--- a/packages/react/test/visual/components/Menubar.tsx
+++ b/packages/react/test/visual/components/Menubar.tsx
@@ -1,15 +1,10 @@
 import {Composite, CompositeItem} from '@floating-ui/react';
-import {useRef} from 'react';
 
 import {Menu, MenuItem} from './Menu';
 
-export function Main() {
-  const compositeRef = useRef<HTMLDivElement>(null);
-  const compositeItemRef = useRef<HTMLDivElement>(null);
-
+export function MenuGrid() {
   return (
     <>
-      <h1 className="text-5xl font-bold mb-8">Menubar</h1>
       <div className="grid place-items-center border border-slate-400 rounded lg:w-[40rem] h-[20rem] mb-4">
         <Composite
           className="grid grid-cols-3"
@@ -27,56 +22,66 @@ export function Main() {
           ))}
         </Composite>
       </div>
-      <div className="grid place-items-center border border-slate-400 rounded lg:w-[40rem] h-[20rem] mb-4">
-        <Composite
-          className="flex"
-          ref={compositeRef}
-          role="menubar"
-          orientation="horizontal"
-        >
-          <CompositeItem role="menuitem" className="focus:bg-gray-200 p-2">
-            File
-          </CompositeItem>
-          <CompositeItem
-            role="menuitem"
-            ref={compositeItemRef}
-            className="focus:bg-gray-200 p-2 inline-block"
-            render={(props) => <div {...props} />}
-          >
-            View
-          </CompositeItem>
-          <CompositeItem
-            role="menuitem"
-            className="focus:bg-gray-200 p-2"
-            render={
-              <Menu label="Edit">
-                <MenuItem label=".jpg" />
-                <MenuItem label=".png" />
-                <MenuItem label=".gif" />
-                <Menu label="Submenu">
-                  <MenuItem label="Second level" />
-                  <Menu label="Open third level">
-                    <MenuItem label="Third level" />
-                  </Menu>
+    </>
+  );
+}
+
+export function Menubar() {
+  return (
+    <div className="grid place-items-center border border-slate-400 rounded lg:w-[40rem] h-[20rem] mb-4">
+      <Composite className="flex" role="menubar" orientation="horizontal">
+        <CompositeItem
+          role="menuitem"
+          className="focus:bg-gray-200 p-2"
+          render={
+            <Menu label="File" openOnFocus>
+              <MenuItem label="Open" />
+              <MenuItem label="Save" />
+              <MenuItem label="Close" />
+            </Menu>
+          }
+        />
+        <CompositeItem
+          role="menuitem"
+          className="focus:bg-gray-200 p-2"
+          render={
+            <Menu label="Edit" openOnFocus>
+              <MenuItem label=".jpg" />
+              <MenuItem label=".png" />
+              <MenuItem label=".gif" />
+              <Menu label="Submenu">
+                <MenuItem label="Second level" />
+                <Menu label="Open third level">
+                  <MenuItem label="Third level" />
                 </Menu>
               </Menu>
-            }
-          />
-          <CompositeItem
-            role="menuitem"
-            className="focus:bg-gray-200 p-2"
-            render={
-              <select>
-                <option>Left</option>
-                <option>Center</option>
-                <option>Right</option>
-              </select>
-            }
-          >
-            Align
-          </CompositeItem>
-        </Composite>
-      </div>
+            </Menu>
+          }
+        />
+        <CompositeItem
+          role="menuitem"
+          className="focus:bg-gray-200 p-2"
+          render={
+            <select>
+              <option>Left</option>
+              <option>Center</option>
+              <option>Right</option>
+            </select>
+          }
+        >
+          Align
+        </CompositeItem>
+      </Composite>
+    </div>
+  );
+}
+
+export function Main() {
+  return (
+    <>
+      <h1 className="text-5xl font-bold mb-8">Menubar</h1>
+      <MenuGrid />
+      <Menubar />
     </>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       use-isomorphic-layout-effect:
         specifier: ^1.1.2
         version: 1.1.2(@types/react@18.3.19)(react@18.2.0)
+      vitest-browser-react:
+        specifier: ^0.1.1
+        version: 0.1.1(@types/react-dom@18.3.1)(@types/react@18.3.19)(@vitest/browser@3.0.9(@types/node@20.10.6)(playwright@1.50.0)(typescript@5.4.2)(vite@6.2.2(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0))(vitest@3.0.9))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.10.6)(@vitest/browser@3.0.9)(jiti@1.21.0)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.10.6)(typescript@5.4.2))(terser@5.39.0))
 
   packages/react-dom:
     dependencies:
@@ -9351,6 +9354,22 @@ packages:
       yaml:
         optional: true
 
+  vitest-browser-react@0.1.1:
+    resolution: {integrity: sha512-n9l+sIAexKqqfBuEkjVGdfZ4xAn1Gn/+wc4Mo8KsUSUOVoM9evSY0rVXdMIzCQqloT/zvmFGAtziFINkqu+t7g==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      '@types/react': '>18.0.0'
+      '@types/react-dom': '>18.0.0'
+      '@vitest/browser': '>=2.1.0'
+      react: '>18.0.0'
+      react-dom: '>18.0.0'
+      vitest: '>=2.1.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   vitest@3.0.9:
     resolution: {integrity: sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -14555,6 +14574,27 @@ snapshots:
       - utf-8-validate
       - vite
 
+  '@vitest/browser@3.0.9(@types/node@20.10.6)(playwright@1.50.0)(typescript@5.4.2)(vite@6.2.2(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0))(vitest@3.0.9)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/mocker': 3.0.9(msw@2.7.3(@types/node@20.10.6)(typescript@5.4.2))(vite@6.2.2(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0))
+      '@vitest/utils': 3.0.9
+      magic-string: 0.30.17
+      msw: 2.7.3(@types/node@20.10.6)(typescript@5.4.2)
+      sirv: 3.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@20.10.6)(@vitest/browser@3.0.9)(jiti@1.21.0)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.10.6)(typescript@5.4.2))(terser@5.39.0)
+      ws: 8.18.1
+    optionalDependencies:
+      playwright: 1.50.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vite
+
   '@vitest/expect@3.0.9':
     dependencies:
       '@vitest/spy': 3.0.9
@@ -14569,6 +14609,15 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.7.3(@types/node@20.10.6)(typescript@5.2.2)
+      vite: 6.2.2(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0)
+
+  '@vitest/mocker@3.0.9(msw@2.7.3(@types/node@20.10.6)(typescript@5.4.2))(vite@6.2.2(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0))':
+    dependencies:
+      '@vitest/spy': 3.0.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      msw: 2.7.3(@types/node@20.10.6)(typescript@5.4.2)
       vite: 6.2.2(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0)
 
   '@vitest/pretty-format@3.0.9':
@@ -18347,6 +18396,31 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  msw@2.7.3(@types/node@20.10.6)(typescript@5.4.2):
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.1
+      '@bundled-es-modules/statuses': 1.0.1
+      '@bundled-es-modules/tough-cookie': 0.1.6
+      '@inquirer/confirm': 5.1.8(@types/node@20.10.6)
+      '@mswjs/interceptors': 0.37.6
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.5
+      graphql: 16.10.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.37.0
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   mute-stream@2.0.0: {}
 
   mz@2.7.0:
@@ -20678,6 +20752,16 @@ snapshots:
       jiti: 1.21.0
       terser: 5.39.0
 
+  vitest-browser-react@0.1.1(@types/react-dom@18.3.1)(@types/react@18.3.19)(@vitest/browser@3.0.9(@types/node@20.10.6)(playwright@1.50.0)(typescript@5.4.2)(vite@6.2.2(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0))(vitest@3.0.9))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.10.6)(@vitest/browser@3.0.9)(jiti@1.21.0)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.10.6)(typescript@5.4.2))(terser@5.39.0)):
+    dependencies:
+      '@vitest/browser': 3.0.9(@types/node@20.10.6)(playwright@1.50.0)(typescript@5.4.2)(vite@6.2.2(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0))(vitest@3.0.9)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@20.10.6)(@vitest/browser@3.0.9)(jiti@1.21.0)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.10.6)(typescript@5.4.2))(terser@5.39.0)
+    optionalDependencies:
+      '@types/react': 18.3.19
+      '@types/react-dom': 18.3.1
+
   vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.10.6)(@vitest/browser@3.0.9)(jiti@1.21.0)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.10.6)(typescript@5.2.2))(terser@5.39.0):
     dependencies:
       '@vitest/expect': 3.0.9
@@ -20704,6 +20788,47 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.10.6
       '@vitest/browser': 3.0.9(@types/node@20.10.6)(playwright@1.50.0)(typescript@5.2.2)(vite@6.2.2(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0))(vitest@3.0.9)
+      jsdom: 26.0.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.10.6)(@vitest/browser@3.0.9)(jiti@1.21.0)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.10.6)(typescript@5.4.2))(terser@5.39.0):
+    dependencies:
+      '@vitest/expect': 3.0.9
+      '@vitest/mocker': 3.0.9(msw@2.7.3(@types/node@20.10.6)(typescript@5.4.2))(vite@6.2.2(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0))
+      '@vitest/pretty-format': 3.0.9
+      '@vitest/runner': 3.0.9
+      '@vitest/snapshot': 3.0.9
+      '@vitest/spy': 3.0.9
+      '@vitest/utils': 3.0.9
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.0
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.8.1
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.2.2(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0)
+      vite-node: 3.0.9(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.10.6
+      '@vitest/browser': 3.0.9(@types/node@20.10.6)(playwright@1.50.0)(typescript@5.4.2)(vite@6.2.2(@types/node@20.10.6)(jiti@1.21.0)(terser@5.39.0))(vitest@3.0.9)
       jsdom: 26.0.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
`focusOnOpenRef` wasn't reset after the popup was closed. If the popup is opened the first time by pressing <kbd>Enter</kbd>, the focusOnOpen strategy set in `useListNavigation` parameters will be overridden for the subsequent open state changes (causing the highlight bug described in https://github.com/mui/base-ui/pull/1684#issuecomment-2827555892).

This PR fixes it by resetting the ref when the popup closes.