### PR TITLE
fix(FloatingFocusManager): check for blurring to nested elements inside the React tree without `FloatingTree`

### DIFF
--- a/.changeset/kind-rings-sing.md
+++ b/.changeset/kind-rings-sing.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/react': patch
+---
+
+fix(FloatingFocusManager): check for blurring to nested elements inside the React tree without `FloatingTree`

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -435,6 +435,12 @@ export function FloatingFocusManager(
           }
         }
 
+        // https://github.com/floating-ui/floating-ui/issues/3060
+        if (dataRef.current.insideReactTree) {
+          dataRef.current.insideReactTree = false;
+          return;
+        }
+
         // Focus did not move inside the floating tree, and there are no tabbable
         // portal guards to handle closing.
         if (
@@ -477,6 +483,7 @@ export function FloatingFocusManager(
     isUntrappedTypeableCombobox,
     getNodeId,
     orderRef,
+    dataRef,
   ]);
 
   const beforeGuardRef = React.useRef<HTMLSpanElement | null>(null);


### PR DESCRIPTION
Fixes #3060

When the nested floating element isn't nested inside the parent's portal element (changing the `root` on `FloatingPortal` to escape this behavior), it closes unexpectedly because `focusout` is triggered and the handler doesn't have knowledge of the React tree, only the DOM tree.

This PR changes this by using the same capture phase technique to let the handler know it's inside the React tree, to avoid needing to setup `FloatingTree`. This is how outside press is handled already. 

One caveat is that it requires `useDismiss` to be used in conjunction with `FloatingFocusManager` to work because `FloatingFocusManager` can't assign React props. (It seems the `closeOnFocusOut` logic in `FloatingFocusManager` could better live inside `useDismiss` instead - a possible refinement for [v1](https://github.com/floating-ui/floating-ui/issues/3260)).

Solving nested `useHover` still requires `FloatingTree` at this time, but I need to investigate how that could work.