### PR TITLE
fix(FloatingOverlay): add lockScroll scrollbar width CSS var

### DIFF
--- a/.changeset/early-frogs-dress.md
+++ b/.changeset/early-frogs-dress.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(FloatingOverlay): `lockScroll` detection on iPad

--- a/.changeset/strong-plants-taste.md
+++ b/.changeset/strong-plants-taste.md
@@ -1,5 +1,5 @@
 ---
-"@floating-ui/react": patch
+'@floating-ui/react': patch
 ---
 
-feat(FloatingOverlay): add `--floating-ui-scrollbar-width` property when using `lockScroll`
+feat(FloatingOverlay): add `lockScroll` scrollbar width CSS variable (`--floating-ui-scrollbar-width`)

--- a/.changeset/strong-plants-taste.md
+++ b/.changeset/strong-plants-taste.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+feat(FloatingOverlay): add `--floating-ui-scrollbar-width` property when using `lockScroll`

--- a/packages/react/src/components/FloatingOverlay.tsx
+++ b/packages/react/src/components/FloatingOverlay.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {useModernLayoutEffect, getPlatform} from '@floating-ui/react/utils';
 
 let lockCount = 0;
+const scrollbarProperty = '--floating-ui-scrollbar-width';
 
 export interface FloatingOverlayProps {
   /**
@@ -12,7 +13,11 @@ export interface FloatingOverlayProps {
 }
 
 function enableScrollLock() {
-  const isIOS = /iP(hone|ad|od)|iOS/.test(getPlatform());
+  const platform = getPlatform();
+  const isIOS =
+    /iP(hone|ad|od)|iOS/.test(platform) ||
+    // iPads can claim to be MacIntel
+    (platform === 'MacIntel' && navigator.maxTouchPoints > 1);
   const bodyStyle = document.body.style;
   // RTL <body> scrollbar
   const scrollbarX =
@@ -25,6 +30,7 @@ function enableScrollLock() {
   const scrollY = bodyStyle.top ? parseFloat(bodyStyle.top) : window.scrollY;
 
   bodyStyle.overflow = 'hidden';
+  bodyStyle.setProperty(scrollbarProperty, `${scrollbarWidth}px`);
 
   if (scrollbarWidth) {
     bodyStyle[paddingProp] = `${scrollbarWidth}px`;
@@ -50,6 +56,7 @@ function enableScrollLock() {
       overflow: '',
       [paddingProp]: '',
     });
+    bodyStyle.removeProperty(scrollbarProperty);
 
     if (isIOS) {
       Object.assign(bodyStyle, {


### PR DESCRIPTION
Fixes #3264. The Base UI technique has some issues with how `FloatingOverlay` is used, so exporting the CSS var technique for now