### PR TITLE
[useListNavigation] fix: avoid item rerenders

### DIFF
--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -549,7 +549,7 @@ export function useListNavigation(
 
   const item = React.useMemo(() => {
     function syncCurrentTarget(currentTarget: HTMLElement | null) {
-      if (!open) return;
+      if (!latestOpenRef.current) return;
       const index = listRef.current.indexOf(currentTarget);
       if (index !== -1 && indexRef.current !== index) {
         indexRef.current = index;
@@ -587,7 +587,6 @@ export function useListNavigation(
 
     return props;
   }, [
-    open,
     floatingFocusElementRef,
     focusItemOnHover,
     listRef,


### PR DESCRIPTION
The dependency on `open` in event handlers forces all items to re-render. Those event handlers should probably be stable callbacks, but I don't want to change too much here.