### PR TITLE
fix(useDismiss): bail out of blur to mark inside React tree if floating tree exists

### DIFF
--- a/.changeset/mighty-chairs-invite.md
+++ b/.changeset/mighty-chairs-invite.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useDismiss): bail out of blur to mark inside react tree if floating tree exists

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -523,6 +523,7 @@ export function useDismiss(
         dataRef.current.insideReactTree = true;
       },
       onBlurCapture() {
+        if (tree) return;
         clearTimeoutIfSet(blurTimeoutRef);
         dataRef.current.insideReactTree = true;
         blurTimeoutRef.current = window.setTimeout(() => {
@@ -530,7 +531,7 @@ export function useDismiss(
         });
       },
     }),
-    [closeOnEscapeKeyDown, outsidePressEvent, dataRef],
+    [closeOnEscapeKeyDown, outsidePressEvent, dataRef, tree],
   );
 
   return React.useMemo(


### PR DESCRIPTION
There are scenarios where the floating element should close if focus moved outside of it even if it's part of the same React tree. 

e.g. a Menu with submenus that don't close on mouseleave after hovering them, but do if focus is placed on the parent's menu item with the pointer. In this case, since a proper `FloatingTree` has been set up, this is being managed already and this auto blur logic should be ignored