### PR TITLE
fix(FloatingFocusManager): check if target is connected for `restoreFocus` prop

### DIFF
--- a/.changeset/olive-ears-reply.md
+++ b/.changeset/olive-ears-reply.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/react': patch
+---
+
+fix(FloatingFocusManager): check if target is connected for `restoreFocus` prop

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -414,7 +414,7 @@ export function FloatingFocusManager(
         // focus from being lost outside the floating tree.
         if (
           restoreFocus &&
-          event.currentTarget !== domReference &&
+          currentTarget !== domReference &&
           !target?.isConnected &&
           activeElement(getDocument(floatingFocusElement)) ===
             getDocument(floatingFocusElement).body

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -380,6 +380,7 @@ export function FloatingFocusManager(
     function handleFocusOutside(event: FocusEvent) {
       const relatedTarget = event.relatedTarget as HTMLElement | null;
       const currentTarget = event.currentTarget;
+      const target = getTarget(event) as HTMLElement | null;
 
       queueMicrotask(() => {
         const nodeId = getNodeId();
@@ -413,7 +414,7 @@ export function FloatingFocusManager(
         // focus from being lost outside the floating tree.
         if (
           restoreFocus &&
-          movedToUnrelatedNode &&
+          !target?.isConnected &&
           activeElement(getDocument(floatingFocusElement)) ===
             getDocument(floatingFocusElement).body
         ) {

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -414,6 +414,7 @@ export function FloatingFocusManager(
         // focus from being lost outside the floating tree.
         if (
           restoreFocus &&
+          event.currentTarget !== domReference &&
           !target?.isConnected &&
           activeElement(getDocument(floatingFocusElement)) ===
             getDocument(floatingFocusElement).body


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/issues/2013
Fixes https://github.com/mui/base-ui/issues/1997