### PR TITLE
fix(safePolygon): revert to checking if any nested child is open

### DIFF
--- a/.changeset/slow-walls-invite.md
+++ b/.changeset/slow-walls-invite.md
@@ -1,0 +1,5 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(safePolygon): revert to checking if any nested child is open

--- a/packages/react/src/safePolygon.ts
+++ b/packages/react/src/safePolygon.ts
@@ -154,23 +154,9 @@ export function safePolygon(options: SafePolygonOptions = {}) {
         return;
       }
 
-      // If the cursor is over any open nested child, abort.
-      if (tree) {
-        const openChildren = getNodeChildren(tree.nodesRef.current, nodeId);
-        const isOverOpenChild = openChildren.some((child) => {
-          const childFloating = child.context?.elements.floating;
-          return (
-            childFloating &&
-            isInside(clientPoint, childFloating.getBoundingClientRect())
-          );
-        });
-
-        if (
-          isOverOpenChild ||
-          (openChildren.length && isInside(clientPoint, rect))
-        ) {
-          return;
-        }
+      // If any nested child is open, abort.
+      if (tree && getNodeChildren(tree.nodesRef.current, nodeId).length) {
+        return;
       }
 
       // If the pointer is leaving from the opposite side, the "buffer" logic


### PR DESCRIPTION
#3332 doesn't handle gaps between elements. Using a rectangular area of the entire tree might be better, but it's still not perfect. There should be different/better solution to handle a close delay