### PR TITLE
feat!(next): split into sync and async versions

### DIFF
--- a/config/defineTsdownConfig.ts
+++ b/config/defineTsdownConfig.ts
@@ -1,25 +1,59 @@
 import {defineConfig} from 'tsdown';
 import {addPureAnnotations} from './addPureAnnotations';
+import {stripPlatformAwait} from './stripPlatformAwait';
 
 export interface TsdownConfigOptions {
   external?: string[];
   define?: Record<string, string>;
   entry?: string[];
+  sync?: boolean;
 }
 
 export function defineTsdownConfig(options: TsdownConfigOptions = {}) {
-  const {external = [], define, entry = ['./src']} = options;
+  const {external = [], define, entry = ['./src'], sync = false} = options;
+
+  const plugins = [addPureAnnotations()];
+  if (sync) {
+    plugins.push(stripPlatformAwait());
+  }
 
   const common = {
     entry,
     external,
     unbundle: true,
-    plugins: [addPureAnnotations()],
+    plugins,
     define: {
       __DEV__: 'process.env.NODE_ENV !== "production"',
       ...define,
     },
   };
+
+  if (sync) {
+    // Sync builds go to the default dist/ folders
+    // Async builds go to async/ subfolders
+    const asyncPlugins = [addPureAnnotations()];
+    const asyncCommon = {
+      ...common,
+      plugins: asyncPlugins,
+    };
+
+    return [
+      defineConfig({...common, format: 'cjs', outDir: 'dist/cjs'}),
+      defineConfig({
+        ...common,
+        format: 'esm',
+        outDir: 'dist/esm',
+        outExtensions: () => ({js: '.js'}),
+      }),
+      defineConfig({...asyncCommon, format: 'cjs', outDir: 'dist/async/cjs'}),
+      defineConfig({
+        ...asyncCommon,
+        format: 'esm',
+        outDir: 'dist/async/esm',
+        outExtensions: () => ({js: '.js'}),
+      }),
+    ];
+  }
 
   return [
     defineConfig({...common, format: 'cjs', outDir: 'dist/cjs'}),

--- a/config/defineViteConfig.ts
+++ b/config/defineViteConfig.ts
@@ -21,6 +21,7 @@ export function defineViteConfig(config: ViteUserConfig): ViteUserConfig {
           'packages/devtools/src',
         ),
         '@floating-ui/core': path.resolve(basePath, 'packages/core/src'),
+        '@floating-ui/core/async': path.resolve(basePath, 'packages/core/src'),
         '@floating-ui/dom': path.resolve(basePath, 'packages/dom/src'),
         '@floating-ui/react-dom': path.resolve(
           basePath,

--- a/config/prepack.mjs
+++ b/config/prepack.mjs
@@ -41,18 +41,57 @@ function createUtilsPackageJson(rootDir) {
   console.log('Created utils/package.json');
 }
 
+function createAsyncPackageJson(rootDir) {
+  const asyncDir = path.join(rootDir, 'async');
+  const asyncPackageJson = {
+    main: '../dist/async/cjs/index.js',
+    module: '../dist/async/esm/index.js',
+    types: '../dist/async/cjs/index.d.ts',
+  };
+
+  if (!fs.existsSync(asyncDir)) {
+    fs.mkdirSync(asyncDir, {recursive: true});
+  }
+
+  fs.writeFileSync(
+    path.join(asyncDir, 'package.json'),
+    JSON.stringify(asyncPackageJson, null, 2) + '\n',
+  );
+  console.log('Created async/package.json');
+}
+
+function createAsyncUtilsPackageJson(rootDir) {
+  const asyncUtilsDir = path.join(rootDir, 'async', 'utils');
+  const asyncUtilsPackageJson = {
+    main: '../../dist/async/cjs/utils/index.js',
+    module: '../../dist/async/esm/utils/index.js',
+    types: '../../dist/async/cjs/utils/index.d.ts',
+  };
+
+  if (!fs.existsSync(asyncUtilsDir)) {
+    fs.mkdirSync(asyncUtilsDir, {recursive: true});
+  }
+
+  fs.writeFileSync(
+    path.join(asyncUtilsDir, 'package.json'),
+    JSON.stringify(asyncUtilsPackageJson, null, 2) + '\n',
+  );
+  console.log('Created async/utils/package.json');
+}
+
 function main() {
   const packageName = process.argv[2];
   const options = process.argv.slice(3);
 
   if (!packageName) {
     console.error(
-      'Usage: node config/prepack.mjs <package-name> [--utils] [--react-pure]',
+      'Usage: node config/prepack.mjs <package-name> [--utils] [--react-pure] [--sync]',
     );
     process.exit(1);
   }
 
   const hasUtils = options.includes('--utils');
+  const hasSync = options.includes('--sync');
 
   const packageDir = path.join(__dirname, '..', 'packages', packageName);
   const distDir = path.join(packageDir, 'dist');
@@ -64,6 +103,21 @@ function main() {
 
   if (hasUtils) {
     createUtilsPackageJson(packageDir);
+  }
+
+  if (hasSync) {
+    // Create async build package.json files
+    const asyncCjsDir = path.join(distDir, 'async', 'cjs');
+    const asyncEsmDir = path.join(distDir, 'async', 'esm');
+
+    createPackageJson(asyncCjsDir, 'commonjs');
+    createPackageJson(asyncEsmDir, 'module');
+
+    createAsyncPackageJson(packageDir);
+
+    if (hasUtils) {
+      createAsyncUtilsPackageJson(packageDir);
+    }
   }
 }
 

--- a/config/stripPlatformAwait.ts
+++ b/config/stripPlatformAwait.ts
@@ -1,0 +1,151 @@
+import ts from 'typescript';
+
+export function stripPlatformAwait() {
+  return {
+    name: 'strip-platform-await',
+    transform(code: string, id: string) {
+      if (id.includes('node_modules')) return null;
+
+      const scriptKind =
+        id.endsWith('.tsx') || id.endsWith('.jsx')
+          ? ts.ScriptKind.TSX
+          : ts.ScriptKind.TS;
+
+      const source = ts.createSourceFile(
+        id,
+        code,
+        ts.ScriptTarget.ESNext,
+        /* setParentNodes */ true,
+        scriptKind,
+      );
+
+      let changed = false;
+
+      const transformer: ts.TransformerFactory<ts.SourceFile> = (context) => {
+        const visitor: ts.Visitor = (node) => {
+          // Remove all await expressions
+          if (ts.isAwaitExpression(node)) {
+            changed = true;
+            // Return the expression without the await
+            return ts.visitNode(node.expression, visitor);
+          }
+
+          // Remove async keyword from arrow functions in variable declarations
+          if (
+            ts.isVariableDeclaration(node) &&
+            node.initializer &&
+            ts.isArrowFunction(node.initializer)
+          ) {
+            const arrowFunc = node.initializer;
+            if (
+              arrowFunc.modifiers?.some(
+                (mod) => mod.kind === ts.SyntaxKind.AsyncKeyword,
+              )
+            ) {
+              changed = true;
+              const newModifiers = arrowFunc.modifiers.filter(
+                (mod) => mod.kind !== ts.SyntaxKind.AsyncKeyword,
+              );
+              const newArrowFunc = ts.factory.updateArrowFunction(
+                arrowFunc,
+                newModifiers.length > 0
+                  ? (newModifiers as ts.Modifier[])
+                  : undefined,
+                arrowFunc.typeParameters,
+                arrowFunc.parameters,
+                arrowFunc.type,
+                arrowFunc.equalsGreaterThanToken,
+                ts.visitNode(arrowFunc.body, visitor) as ts.ConciseBody,
+              );
+              return ts.factory.updateVariableDeclaration(
+                node,
+                node.name,
+                node.exclamationToken,
+                node.type,
+                newArrowFunc,
+              );
+            }
+          }
+
+          // Remove async keyword from function declarations
+          if (
+            ts.isFunctionDeclaration(node) &&
+            node.modifiers?.some(
+              (mod) => mod.kind === ts.SyntaxKind.AsyncKeyword,
+            )
+          ) {
+            changed = true;
+            const newModifiers = node.modifiers.filter(
+              (mod) => mod.kind !== ts.SyntaxKind.AsyncKeyword,
+            );
+            return ts.factory.updateFunctionDeclaration(
+              node,
+              newModifiers.length > 0
+                ? (newModifiers as ts.Modifier[])
+                : undefined,
+              node.asteriskToken,
+              node.name,
+              node.typeParameters,
+              node.parameters,
+              node.type,
+              node.body
+                ? (ts.visitNode(node.body, visitor) as ts.Block)
+                : undefined,
+            );
+          }
+
+          // Remove async keyword from method declarations
+          if (
+            ts.isMethodDeclaration(node) &&
+            node.modifiers?.some(
+              (mod) => mod.kind === ts.SyntaxKind.AsyncKeyword,
+            )
+          ) {
+            changed = true;
+            const newModifiers = node.modifiers.filter(
+              (mod) => mod.kind !== ts.SyntaxKind.AsyncKeyword,
+            );
+            return ts.factory.updateMethodDeclaration(
+              node,
+              newModifiers.length > 0
+                ? (newModifiers as ts.Modifier[])
+                : undefined,
+              node.asteriskToken,
+              node.name,
+              node.questionToken,
+              node.typeParameters,
+              node.parameters,
+              node.type,
+              node.body
+                ? (ts.visitNode(node.body, visitor) as ts.Block)
+                : undefined,
+            );
+          }
+
+          return ts.visitEachChild(node, visitor, context);
+        };
+
+        return (sf) => {
+          const out = ts.visitNode(sf, visitor);
+          return (out as ts.SourceFile) || sf;
+        };
+      };
+
+      const result = ts.transform(source, [transformer]);
+
+      if (!changed) {
+        return null;
+      }
+
+      const printer = ts.createPrinter({
+        newLine: ts.NewLineKind.LineFeed,
+        removeComments: false,
+      });
+
+      return {
+        code: printer.printFile(result.transformed[0]),
+        map: null,
+      };
+    },
+  };
+}

--- a/config/transform-async-dts.mjs
+++ b/config/transform-async-dts.mjs
@@ -1,0 +1,172 @@
+import fs from 'fs/promises';
+import path from 'path';
+import {glob} from 'glob';
+import ts from 'typescript';
+
+function createTransformer() {
+  return (context) => {
+    return (sourceFile) => {
+      function visit(node) {
+        // Remove StrippablePromise type alias declaration
+        if (
+          ts.isTypeAliasDeclaration(node) &&
+          node.name.text === 'StrippablePromise'
+        ) {
+          return undefined; // Remove the node
+        }
+
+        // Remove StrippablePromise from import statements
+        if (ts.isImportDeclaration(node) && node.importClause) {
+          if (
+            node.importClause.namedBindings &&
+            ts.isNamedImports(node.importClause.namedBindings)
+          ) {
+            const filteredElements =
+              node.importClause.namedBindings.elements.filter(
+                (element) => element.name.text !== 'StrippablePromise',
+              );
+
+            if (filteredElements.length === 0) {
+              return undefined; // Remove entire import if no elements left
+            }
+
+            if (
+              filteredElements.length !==
+              node.importClause.namedBindings.elements.length
+            ) {
+              return ts.factory.updateImportDeclaration(
+                node,
+                node.modifiers,
+                ts.factory.updateImportClause(
+                  node.importClause,
+                  false,
+                  node.importClause.name,
+                  ts.factory.createNamedImports(filteredElements),
+                ),
+                node.moduleSpecifier,
+                node.attributes,
+              );
+            }
+          }
+        }
+
+        // Transform StrippablePromise<T> type references to Promise<T>
+        if (
+          ts.isTypeReferenceNode(node) &&
+          ts.isIdentifier(node.typeName) &&
+          node.typeName.text === 'StrippablePromise'
+        ) {
+          // Create Promise<T> type reference
+          return ts.factory.createTypeReferenceNode(
+            ts.factory.createIdentifier('Promise'),
+            node.typeArguments,
+          );
+        }
+
+        return ts.visitEachChild(node, visit, context);
+      }
+
+      return ts.visitNode(sourceFile, visit);
+    };
+  };
+}
+
+function removeStrippablePromiseFromExports(sourceFile) {
+  return ts.transform(sourceFile, [
+    (context) => (sourceFile) => {
+      function visit(node) {
+        // Handle export declarations
+        if (
+          ts.isExportDeclaration(node) &&
+          node.exportClause &&
+          ts.isNamedExports(node.exportClause)
+        ) {
+          const filteredElements = node.exportClause.elements.filter(
+            (element) => element.name.text !== 'StrippablePromise',
+          );
+
+          if (filteredElements.length === 0) {
+            return undefined; // Remove empty export
+          }
+
+          if (filteredElements.length !== node.exportClause.elements.length) {
+            return ts.factory.updateExportDeclaration(
+              node,
+              node.modifiers,
+              false,
+              ts.factory.createNamedExports(filteredElements),
+              node.moduleSpecifier,
+              node.attributes,
+            );
+          }
+        }
+
+        return ts.visitEachChild(node, visit, context);
+      }
+
+      return ts.visitNode(sourceFile, visit);
+    },
+  ]);
+}
+
+async function transformFile(filePath) {
+  const originalContent = await fs.readFile(filePath, 'utf-8');
+
+  // Skip files that don't have StrippablePromise
+  if (!originalContent.includes('StrippablePromise')) {
+    return;
+  }
+
+  // Parse the file
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    originalContent,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  // Transform the AST
+  const result = ts.transform(sourceFile, [createTransformer()]);
+  const transformedSourceFile = result.transformed[0];
+
+  // Remove StrippablePromise from exports
+  const exportResult = removeStrippablePromiseFromExports(
+    transformedSourceFile,
+  );
+  const finalSourceFile = exportResult.transformed[0];
+
+  // Generate the new content
+  const printer = ts.createPrinter({
+    newLine: ts.NewLineKind.LineFeed,
+  });
+
+  const newContent = printer.printFile(finalSourceFile);
+
+  // Clean up
+  result.dispose();
+  exportResult.dispose();
+
+  if (originalContent !== newContent) {
+    console.log(`Transformed ${path.basename(filePath)}`);
+    await fs.writeFile(filePath, newContent, 'utf-8');
+  }
+}
+
+async function main() {
+  const packageDir = process.cwd();
+  const asyncDistDir = path.join(packageDir, 'dist', 'async');
+
+  const dtsFiles = await glob('**/*.d.ts', {
+    cwd: asyncDistDir,
+    absolute: true,
+  });
+
+  await Promise.all(dtsFiles.map(transformFile));
+
+  console.log('Finished transforming .d.ts files to async versions.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/config/transform-sync-dts.mjs
+++ b/config/transform-sync-dts.mjs
@@ -1,0 +1,174 @@
+import fs from 'fs/promises';
+import path from 'path';
+import {glob} from 'glob';
+import ts from 'typescript';
+
+function createTransformer() {
+  return (context) => {
+    return (sourceFile) => {
+      function visit(node) {
+        // Remove StrippablePromise type alias declaration
+        if (
+          ts.isTypeAliasDeclaration(node) &&
+          node.name.text === 'StrippablePromise'
+        ) {
+          return undefined; // Remove the node
+        }
+
+        // Remove StrippablePromise from import statements
+        if (ts.isImportDeclaration(node) && node.importClause) {
+          if (
+            node.importClause.namedBindings &&
+            ts.isNamedImports(node.importClause.namedBindings)
+          ) {
+            const filteredElements =
+              node.importClause.namedBindings.elements.filter(
+                (element) => element.name.text !== 'StrippablePromise',
+              );
+
+            if (filteredElements.length === 0) {
+              return undefined; // Remove entire import if no elements left
+            }
+
+            if (
+              filteredElements.length !==
+              node.importClause.namedBindings.elements.length
+            ) {
+              return ts.factory.updateImportDeclaration(
+                node,
+                node.modifiers,
+                ts.factory.updateImportClause(
+                  node.importClause,
+                  false,
+                  node.importClause.name,
+                  ts.factory.createNamedImports(filteredElements),
+                ),
+                node.moduleSpecifier,
+                node.attributes,
+              );
+            }
+          }
+        }
+
+        // Transform StrippablePromise<T> type references to T
+        if (
+          ts.isTypeReferenceNode(node) &&
+          ts.isIdentifier(node.typeName) &&
+          node.typeName.text === 'StrippablePromise'
+        ) {
+          // Return the first type argument (T)
+          if (node.typeArguments && node.typeArguments.length > 0) {
+            return node.typeArguments[0];
+          }
+          // Fallback to 'any' if no type arguments
+          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+        }
+
+        return ts.visitEachChild(node, visit, context);
+      }
+
+      return ts.visitNode(sourceFile, visit);
+    };
+  };
+}
+
+function removeStrippablePromiseFromExports(sourceFile) {
+  return ts.transform(sourceFile, [
+    (context) => (sourceFile) => {
+      function visit(node) {
+        // Handle export declarations
+        if (
+          ts.isExportDeclaration(node) &&
+          node.exportClause &&
+          ts.isNamedExports(node.exportClause)
+        ) {
+          const filteredElements = node.exportClause.elements.filter(
+            (element) => element.name.text !== 'StrippablePromise',
+          );
+
+          if (filteredElements.length === 0) {
+            return undefined; // Remove empty export
+          }
+
+          if (filteredElements.length !== node.exportClause.elements.length) {
+            return ts.factory.updateExportDeclaration(
+              node,
+              node.modifiers,
+              false,
+              ts.factory.createNamedExports(filteredElements),
+              node.moduleSpecifier,
+              node.attributes,
+            );
+          }
+        }
+
+        return ts.visitEachChild(node, visit, context);
+      }
+
+      return ts.visitNode(sourceFile, visit);
+    },
+  ]);
+}
+
+async function transformFile(filePath) {
+  const originalContent = await fs.readFile(filePath, 'utf-8');
+
+  // Skip files that don't have StrippablePromise
+  if (!originalContent.includes('StrippablePromise')) {
+    return;
+  }
+
+  // Parse the file
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    originalContent,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  // Transform the AST
+  const result = ts.transform(sourceFile, [createTransformer()]);
+  const transformedSourceFile = result.transformed[0];
+
+  // Remove StrippablePromise from exports
+  const exportResult = removeStrippablePromiseFromExports(
+    transformedSourceFile,
+  );
+  const finalSourceFile = exportResult.transformed[0];
+
+  // Generate the new content
+  const printer = ts.createPrinter({
+    newLine: ts.NewLineKind.LineFeed,
+  });
+
+  const newContent = printer.printFile(finalSourceFile);
+
+  // Clean up
+  result.dispose();
+  exportResult.dispose();
+
+  if (originalContent !== newContent) {
+    console.log(`Transformed ${path.basename(filePath)}`);
+    await fs.writeFile(filePath, newContent, 'utf-8');
+  }
+}
+
+async function main() {
+  const packageDir = process.cwd();
+  const distDir = path.join(packageDir, 'dist');
+
+  const dtsFiles = await glob('**/*.d.ts', {
+    cwd: distDir,
+    absolute: true,
+    ignore: ['**/async/**'],
+  });
+
+  await Promise.all(dtsFiles.map(transformFile));
+
+  console.log('Finished transforming .d.ts files to sync versions.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -13,6 +13,7 @@
     "baseUrl": ".",
     "paths": {
       "@floating-ui/core": ["../packages/core/src/index.ts"],
+      "@floating-ui/core/async": ["../packages/core/src/index.ts"],
       "@floating-ui/core/*": ["../packages/core/src/*"],
       "@floating-ui/dom": ["../packages/dom/src/index.ts"],
       "@floating-ui/dom/*": ["../packages/dom/src/*"],

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "globals": "^15.14.0",
+    "glob": "^11.0.2",
     "jsdom": "^26.0.0",
     "postcss": "^8.4.32",
     "prettier": "^3.1.1",

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,1 +1,2 @@
 /utils/
+/async/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
   "types": "./dist/cjs/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
+    "./async/package.json": "./dist/async/package.json",
     ".": {
       "require": {
         "types": "./dist/cjs/index.d.ts",
@@ -19,6 +20,16 @@
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
+      }
+    },
+    "./async": {
+      "require": {
+        "types": "./dist/async/cjs/index.d.ts",
+        "default": "./dist/async/cjs/index.js"
+      },
+      "import": {
+        "types": "./dist/async/esm/index.d.ts",
+        "default": "./dist/async/esm/index.js"
       }
     },
     "./utils": {
@@ -30,12 +41,23 @@
         "types": "./dist/esm/utils/index.d.ts",
         "default": "./dist/esm/utils/index.js"
       }
+    },
+    "./async/utils": {
+      "require": {
+        "types": "./dist/async/cjs/utils/index.d.ts",
+        "default": "./dist/async/cjs/utils/index.js"
+      },
+      "import": {
+        "types": "./dist/async/esm/utils/index.d.ts",
+        "default": "./dist/async/esm/utils/index.js"
+      }
     }
   },
   "sideEffects": false,
   "files": [
     "dist",
-    "utils"
+    "utils",
+    "async"
   ],
   "scripts": {
     "test": "vitest run",
@@ -44,7 +66,7 @@
     "format": "prettier --write .",
     "clean": "rimraf dist out-tsc && find . -name '*.d.ts' ! -name 'env.d.ts' -delete",
     "build": "tsdown",
-    "prepack": "node ../../config/prepack.mjs core --utils",
+    "prepack": "node ../../config/prepack.mjs core --utils --sync",
     "publint": "publint",
     "typecheck": "tsc -b"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,7 +65,7 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "clean": "rimraf dist out-tsc && find . -name '*.d.ts' ! -name 'env.d.ts' -delete",
-    "build": "tsdown",
+    "build": "tsdown && node ../../config/transform-sync-dts.mjs && node ../../config/transform-async-dts.mjs",
     "prepack": "node ../../config/prepack.mjs core --utils --sync",
     "publint": "publint",
     "typecheck": "tsc -b"

--- a/packages/core/src/detectOverflow.ts
+++ b/packages/core/src/detectOverflow.ts
@@ -12,6 +12,7 @@ import type {
   ElementContext,
   MiddlewareState,
   RootBoundary,
+  StrippablePromise,
 } from './types';
 
 export interface DetectOverflowOptions {
@@ -54,7 +55,7 @@ export interface DetectOverflowOptions {
 export async function detectOverflow(
   state: MiddlewareState,
   options: DetectOverflowOptions | Derivable<DetectOverflowOptions> = {},
-): Promise<SideObject> {
+): StrippablePromise<SideObject> {
   const {x, y, platform, rects, elements, strategy} = state;
 
   const {

--- a/packages/core/src/middleware/offset.ts
+++ b/packages/core/src/middleware/offset.ts
@@ -5,7 +5,12 @@ import {
   getSideAxis,
   type Coords,
 } from '../utils';
-import type {Derivable, Middleware, MiddlewareState} from '../types';
+import type {
+  Derivable,
+  Middleware,
+  MiddlewareState,
+  StrippablePromise,
+} from '../types';
 
 type OffsetValue =
   | number
@@ -43,7 +48,7 @@ export type OffsetOptions = OffsetValue | Derivable<OffsetValue>;
 export async function convertValueToCoords(
   state: MiddlewareState,
   options: OffsetOptions,
-): Promise<Coords> {
+): StrippablePromise<Coords> {
   const {placement, platform, elements} = state;
   const rtl = await platform.isRTL?.(elements.floating);
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,7 +10,7 @@ import type {
   Strategy,
 } from './utils';
 
-type Promisable<T> = T | Promise<T>;
+export type StrippablePromise<T> = Promise<T>;
 
 /**
  * Function option to derive middleware options from state.
@@ -27,14 +27,14 @@ export interface Platform {
     reference: ReferenceElement;
     floating: FloatingElement;
     strategy: Strategy;
-  }) => Promisable<ElementRects>;
+  }) => StrippablePromise<ElementRects>;
   getClippingRect: (args: {
     element: any;
     boundary: Boundary;
     rootBoundary: RootBoundary;
     strategy: Strategy;
-  }) => Promisable<Rect>;
-  getDimensions: (element: any) => Promisable<Dimensions>;
+  }) => StrippablePromise<Rect>;
+  getDimensions: (element: any) => StrippablePromise<Dimensions>;
 
   // Optional
   convertOffsetParentRelativeRectToViewportRelativeRect?: (args: {
@@ -42,13 +42,13 @@ export interface Platform {
     rect: Rect;
     offsetParent: any;
     strategy: Strategy;
-  }) => Promisable<Rect>;
-  getOffsetParent?: (element: any) => Promisable<any>;
-  isElement?: (value: any) => Promisable<boolean>;
-  getDocumentElement?: (element: any) => Promisable<any>;
-  getClientRects?: (element: any) => Promisable<Array<ClientRectObject>>;
-  isRTL?: (element: any) => Promisable<boolean>;
-  getScale?: (element: any) => Promisable<{x: number; y: number}>;
+  }) => StrippablePromise<Rect>;
+  getOffsetParent?: (element: any) => StrippablePromise<any>;
+  isElement?: (value: any) => StrippablePromise<boolean>;
+  getDocumentElement?: (element: any) => StrippablePromise<any>;
+  getClientRects?: (element: any) => StrippablePromise<Array<ClientRectObject>>;
+  isRTL?: (element: any) => StrippablePromise<boolean>;
+  getScale?: (element: any) => StrippablePromise<{x: number; y: number}>;
 }
 
 export interface MiddlewareData {
@@ -122,7 +122,7 @@ export type ComputePosition = (
   reference: unknown,
   floating: unknown,
   config: ComputePositionConfig,
-) => Promise<ComputePositionReturn>;
+) => StrippablePromise<ComputePositionReturn>;
 
 export interface MiddlewareReturn extends Partial<Coords> {
   data?: {
@@ -139,7 +139,7 @@ export interface MiddlewareReturn extends Partial<Coords> {
 export type Middleware = {
   name: string;
   options?: any;
-  fn: (state: MiddlewareState) => Promisable<MiddlewareReturn>;
+  fn: (state: MiddlewareState) => StrippablePromise<MiddlewareReturn>;
 };
 
 export type ReferenceElement = any;

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,3 +1,3 @@
 import {defineTsdownConfig} from '../../config';
 
-export default defineTsdownConfig();
+export default defineTsdownConfig({sync: true});

--- a/packages/dom/src/computePosition.ts
+++ b/packages/dom/src/computePosition.ts
@@ -17,7 +17,7 @@ export function computePosition(
   reference: ReferenceElement,
   floating: FloatingElement,
   options?: Partial<ComputePositionConfig>,
-): Promise<ComputePositionReturn> {
+): ComputePositionReturn {
   // This caches the expensive `getClippingElementAncestors` function so that
   // multiple lifecycle resets re-use the same result. It only lives for a
   // single call. If other functions become expensive, we can add them as well.

--- a/packages/dom/src/computePosition.ts
+++ b/packages/dom/src/computePosition.ts
@@ -1,5 +1,5 @@
 import {
-  computePosition as computePositionCore,
+  computePosition as computePositionCorePreTyped,
   type ComputePositionReturn,
 } from '@floating-ui/core';
 import {platform} from './platform';
@@ -8,6 +8,12 @@ import type {
   FloatingElement,
   ReferenceElement,
 } from './types';
+
+const computePositionCore = computePositionCorePreTyped as unknown as (
+  reference: ReferenceElement,
+  floating: FloatingElement,
+  options?: Partial<ComputePositionConfig>,
+) => ComputePositionReturn;
 
 /**
  * Computes the `x` and `y` coordinates that will place the floating element

--- a/packages/dom/src/middleware.ts
+++ b/packages/dom/src/middleware.ts
@@ -41,7 +41,7 @@ import type {
 export const detectOverflow: (
   state: MiddlewareState,
   options?: DetectOverflowOptions | Derivable<DetectOverflowOptions>,
-) => Promise<SideObject> = detectOverflowCore;
+) => SideObject = detectOverflowCore;
 
 /**
  * Modifies the placement by translating the floating element along the

--- a/packages/dom/src/middleware.ts
+++ b/packages/dom/src/middleware.ts
@@ -41,7 +41,7 @@ import type {
 export const detectOverflow: (
   state: MiddlewareState,
   options?: DetectOverflowOptions | Derivable<DetectOverflowOptions>,
-) => SideObject = detectOverflowCore;
+) => SideObject = detectOverflowCore as any;
 
 /**
  * Modifies the placement by translating the floating element along the
@@ -50,7 +50,8 @@ export const detectOverflow: (
  * object may be passed.
  * @see https://floating-ui.com/docs/offset
  */
-export const offset: (options?: OffsetOptions) => Middleware = offsetCore;
+export const offset: (options?: OffsetOptions) => Middleware =
+  offsetCore as any;
 
 /**
  * Optimizes the visibility of the floating element by choosing the placement
@@ -60,7 +61,7 @@ export const offset: (options?: OffsetOptions) => Middleware = offsetCore;
  */
 export const autoPlacement: (
   options?: AutoPlacementOptions | Derivable<AutoPlacementOptions>,
-) => Middleware = autoPlacementCore;
+) => Middleware = autoPlacementCore as any;
 
 /**
  * Optimizes the visibility of the floating element by shifting it in order to
@@ -69,7 +70,7 @@ export const autoPlacement: (
  */
 export const shift: (
   options?: ShiftOptions | Derivable<ShiftOptions>,
-) => Middleware = shiftCore;
+) => Middleware = shiftCore as any;
 
 /**
  * Optimizes the visibility of the floating element by flipping the `placement`
@@ -79,7 +80,7 @@ export const shift: (
  */
 export const flip: (
   options?: FlipOptions | Derivable<FlipOptions>,
-) => Middleware = flipCore;
+) => Middleware = flipCore as any;
 
 /**
  * Provides data that allows you to change the size of the floating element —
@@ -89,7 +90,7 @@ export const flip: (
  */
 export const size: (
   options?: SizeOptions | Derivable<SizeOptions>,
-) => Middleware = sizeCore;
+) => Middleware = sizeCore as any;
 
 /**
  * Provides data to hide the floating element in applicable situations, such as
@@ -98,7 +99,7 @@ export const size: (
  */
 export const hide: (
   options?: HideOptions | Derivable<HideOptions>,
-) => Middleware = hideCore;
+) => Middleware = hideCore as any;
 
 /**
  * Provides data to position an inner element of the floating element so that it
@@ -107,7 +108,7 @@ export const hide: (
  */
 export const arrow: (
   options: ArrowOptions | Derivable<ArrowOptions>,
-) => Middleware = arrowCore;
+) => Middleware = arrowCore as any;
 
 /**
  * Provides improved positioning for inline reference elements that can span
@@ -116,7 +117,7 @@ export const arrow: (
  */
 export const inline: (
   options?: InlineOptions | Derivable<InlineOptions>,
-) => Middleware = inlineCore;
+) => Middleware = inlineCore as any;
 
 /**
  * Built-in `limiter` that will stop `shift()` at a certain point.

--- a/packages/dom/src/platform/getElementRects.ts
+++ b/packages/dom/src/platform/getElementRects.ts
@@ -2,18 +2,18 @@ import type {Platform} from '../types';
 import {getRectRelativeToOffsetParent} from '../utils/getRectRelativeToOffsetParent';
 import {getOffsetParent} from './getOffsetParent';
 
-export const getElementRects: Platform['getElementRects'] = async function (
+export const getElementRects: Platform['getElementRects'] = function (
   this: Platform,
   data,
 ) {
   const getOffsetParentFn = this.getOffsetParent || getOffsetParent;
   const getDimensionsFn = this.getDimensions;
-  const floatingDimensions = await getDimensionsFn(data.floating);
+  const floatingDimensions = getDimensionsFn(data.floating);
 
   return {
     reference: getRectRelativeToOffsetParent(
       data.reference,
-      await getOffsetParentFn(data.floating),
+      getOffsetParentFn(data.floating),
       data.strategy,
     ),
     floating: {

--- a/packages/dom/src/types.ts
+++ b/packages/dom/src/types.ts
@@ -22,8 +22,6 @@ type Prettify<T> = {
   [K in keyof T]: T[K];
 } & {};
 
-type Promisable<T> = T | Promise<T>;
-
 export type Derivable<T> = (state: MiddlewareState) => T;
 
 export type OffsetValue =
@@ -64,14 +62,14 @@ export interface Platform {
     reference: ReferenceElement;
     floating: FloatingElement;
     strategy: Strategy;
-  }) => Promisable<ElementRects>;
+  }) => ElementRects;
   getClippingRect: (args: {
     element: Element;
     boundary: Boundary;
     rootBoundary: RootBoundary;
     strategy: Strategy;
-  }) => Promisable<Rect>;
-  getDimensions: (element: Element) => Promisable<Dimensions>;
+  }) => Rect;
+  getDimensions: (element: Element) => Dimensions;
 
   // Optional
   convertOffsetParentRelativeRectToViewportRelativeRect: (args: {
@@ -79,16 +77,16 @@ export interface Platform {
     rect: Rect;
     offsetParent: Element;
     strategy: Strategy;
-  }) => Promisable<Rect>;
+  }) => Rect;
   getOffsetParent: (
     element: Element,
     polyfill?: (element: HTMLElement) => Element | null,
-  ) => Promisable<Element | Window>;
-  isElement: (value: unknown) => Promisable<boolean>;
-  getDocumentElement: (element: Element) => Promisable<HTMLElement>;
-  getClientRects: (element: Element) => Promisable<Array<ClientRectObject>>;
-  isRTL: (element: Element) => Promisable<boolean>;
-  getScale: (element: HTMLElement) => Promisable<{x: number; y: number}>;
+  ) => Element | Window;
+  isElement: (value: unknown) => boolean;
+  getDocumentElement: (element: Element) => HTMLElement;
+  getClientRects: (element: Element) => Array<ClientRectObject>;
+  isRTL: (element: Element) => boolean;
+  getScale: (element: HTMLElement) => {x: number; y: number};
 }
 
 export interface NodeScroll {
@@ -151,7 +149,7 @@ export type MiddlewareArguments = MiddlewareState;
 
 export type Middleware = Prettify<
   Omit<CoreMiddleware, 'fn'> & {
-    fn(state: MiddlewareState): Promisable<MiddlewareReturn>;
+    fn(state: MiddlewareState): MiddlewareReturn;
   }
 >;
 
@@ -168,7 +166,7 @@ export type SizeOptions = Prettify<
           availableWidth: number;
           availableHeight: number;
         },
-      ): Promisable<void>;
+      ): void;
     }
 >;
 export type ArrowOptions = Prettify<

--- a/packages/dom/tsconfig.lib.json
+++ b/packages/dom/tsconfig.lib.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "composite": true,
     "types": [],
-    "outDir": "out-tsc"
+    "outDir": "out-tsc",
+    "paths": {
+      "@floating-ui/core": ["../core/dist/cjs/index.d.ts"],
+      "@floating-ui/core/*": ["../core/dist/cjs/*"]
+    }
   },
   "include": ["src"],
   "references": [{"path": "../core/tsconfig.lib.json"}]

--- a/packages/dom/tsconfig.lib.json
+++ b/packages/dom/tsconfig.lib.json
@@ -3,11 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "types": [],
-    "outDir": "out-tsc",
-    "paths": {
-      "@floating-ui/core": ["../core/dist/cjs/index.d.ts"],
-      "@floating-ui/core/*": ["../core/dist/cjs/*"]
-    }
+    "outDir": "out-tsc"
   },
   "include": ["src"],
   "references": [{"path": "../core/tsconfig.lib.json"}]

--- a/packages/react-dom/src/useFloating.ts
+++ b/packages/react-dom/src/useFloating.ts
@@ -1,6 +1,5 @@
 import {computePosition} from '@floating-ui/dom';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 
 import type {
   ComputePositionConfig,
@@ -92,24 +91,25 @@ export function useFloating<RT extends ReferenceType = ReferenceType>(
       config.platform = platformRef.current;
     }
 
-    computePosition(referenceRef.current, floatingRef.current, config).then(
-      (data) => {
-        const fullData = {
-          ...data,
-          // The floating element's position may be recomputed while it's closed
-          // but still mounted (such as when transitioning out). To ensure
-          // `isPositioned` will be `false` initially on the next open, avoid
-          // setting it to `true` when `open === false` (must be specified).
-          isPositioned: openRef.current !== false,
-        };
-        if (isMountedRef.current && !deepEqual(dataRef.current, fullData)) {
-          dataRef.current = fullData;
-          ReactDOM.flushSync(() => {
-            setData(fullData);
-          });
-        }
-      },
+    const data = computePosition(
+      referenceRef.current,
+      floatingRef.current,
+      config,
     );
+
+    const fullData = {
+      ...data,
+      // The floating element's position may be recomputed while it's closed
+      // but still mounted (such as when transitioning out). To ensure
+      // `isPositioned` will be `false` initially on the next open, avoid
+      // setting it to `true` when `open === false` (must be specified).
+      isPositioned: openRef.current !== false,
+    };
+
+    if (isMountedRef.current && !deepEqual(dataRef.current, fullData)) {
+      dataRef.current = fullData;
+      setData(fullData);
+    }
   }, [latestMiddleware, placement, strategy, platformRef, openRef]);
 
   useModernLayoutEffect(() => {

--- a/packages/react-native/src/arrow.ts
+++ b/packages/react-native/src/arrow.ts
@@ -1,5 +1,9 @@
-import type {Derivable, Middleware, ArrowOptions} from '@floating-ui/core';
-import {arrow as arrowCore} from '@floating-ui/core';
+import type {
+  Derivable,
+  Middleware,
+  ArrowOptions,
+} from '@floating-ui/core/async';
+import {arrow as arrowCore} from '@floating-ui/core/async';
 
 /**
  * A data provider that provides data to position an inner element of the

--- a/packages/react-native/src/arrow.ts
+++ b/packages/react-native/src/arrow.ts
@@ -22,7 +22,7 @@ export const arrow = (
   return {
     name: 'arrow',
     options,
-    fn(state) {
+    async fn(state) {
       const {element, padding} =
         typeof options === 'function' ? options(state) : options;
 

--- a/packages/react-native/src/createPlatform.ts
+++ b/packages/react-native/src/createPlatform.ts
@@ -1,4 +1,4 @@
-import type {Platform, VirtualElement} from '@floating-ui/core';
+import type {Platform, VirtualElement} from '@floating-ui/core/async';
 import {Dimensions, Platform as RNPlatform, StatusBar} from 'react-native';
 import type {View} from 'react-native';
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,6 +1,6 @@
 export type * from './types';
 export {useFloating} from './useFloating';
-export {detectOverflow} from '@floating-ui/core';
+export {detectOverflow} from '@floating-ui/core/async';
 export {
   arrow,
   autoPlacement,

--- a/packages/react-native/src/reactiveMiddleware.ts
+++ b/packages/react-native/src/reactiveMiddleware.ts
@@ -21,7 +21,7 @@ import {
   type Derivable,
   type MiddlewareState,
   type Coords,
-} from '@floating-ui/core';
+} from '@floating-ui/core/async';
 import {arrow as baseArrow} from './arrow';
 
 /**

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -2,7 +2,7 @@ import type {
   ComputePositionReturn,
   Middleware,
   Placement,
-} from '@floating-ui/core';
+} from '@floating-ui/core/async';
 import type * as React from 'react';
 
 export type {
@@ -44,7 +44,7 @@ export type {
   SizeOptions,
   Strategy,
   VirtualElement,
-} from '@floating-ui/core';
+} from '@floating-ui/core/async';
 
 export interface UseFloatingOptions {
   /**

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -1,9 +1,88 @@
 import type {
   ComputePositionReturn,
-  Middleware,
+  Middleware as CoreMiddleware,
   Placement,
-} from '@floating-ui/core/async';
+  Platform as CorePlatform,
+  MiddlewareState,
+  MiddlewareReturn,
+  ElementRects,
+  Rect,
+  Dimensions,
+  Boundary,
+  RootBoundary,
+  Strategy,
+  Elements,
+  ClientRectObject,
+} from '@floating-ui/core';
 import type * as React from 'react';
+
+// Type overrides to make core types async for React Native
+export interface Platform
+  extends Omit<
+    CorePlatform,
+    | 'getElementRects'
+    | 'getClippingRect'
+    | 'getDimensions'
+    | 'convertOffsetParentRelativeRectToViewportRelativeRect'
+    | 'getOffsetParent'
+    | 'isElement'
+    | 'getDocumentElement'
+    | 'getClientRects'
+    | 'isRTL'
+    | 'getScale'
+  > {
+  getElementRects: (args: {
+    reference: any;
+    floating: any;
+    strategy: Strategy;
+  }) => Promise<ElementRects>;
+  getClippingRect: (args: {
+    element: any;
+    boundary: Boundary;
+    rootBoundary: RootBoundary;
+    strategy: Strategy;
+  }) => Promise<Rect>;
+  getDimensions: (element: any) => Promise<Dimensions>;
+  convertOffsetParentRelativeRectToViewportRelativeRect?: (args: {
+    elements?: Elements;
+    rect: Rect;
+    offsetParent: any;
+    strategy: Strategy;
+  }) => Promise<Rect>;
+  getOffsetParent?: (element: any) => Promise<any>;
+  isElement?: (value: any) => Promise<boolean>;
+  getDocumentElement?: (element: any) => Promise<any>;
+  getClientRects?: (element: any) => ClientRectObject;
+  isRTL?: (element: any) => Promise<boolean>;
+  getScale?: (element: any) => Promise<{
+    x: number;
+    y: number;
+  }>;
+}
+
+export interface Middleware extends Omit<CoreMiddleware, 'fn'> {
+  fn: (state: MiddlewareState) => Promise<MiddlewareReturn>;
+}
+
+export interface ComputePositionConfig {
+  /**
+   * Object to interface with the current platform.
+   */
+  platform: Platform;
+  /**
+   * Where to place the floating element relative to the reference element.
+   */
+  placement?: Placement;
+  /**
+   * The strategy to use when positioning the floating element.
+   */
+  strategy?: Strategy;
+  /**
+   * Array of middleware objects to modify the positioning or provide data for
+   * rendering.
+   */
+  middleware?: Array<Middleware | null | undefined | false>;
+}
 
 export type {
   AlignedPlacement,
@@ -13,8 +92,6 @@ export type {
   Axis,
   Boundary,
   ClientRectObject,
-  ComputePositionConfig,
-  ComputePositionReturn,
   Coords,
   DetectOverflowOptions,
   Dimensions,
@@ -26,7 +103,6 @@ export type {
   HideOptions,
   InlineOptions,
   Length,
-  Middleware,
   MiddlewareArguments,
   MiddlewareData,
   MiddlewareReturn,
@@ -34,7 +110,6 @@ export type {
   OffsetOptions,
   Padding,
   Placement,
-  Platform,
   Rect,
   ReferenceElement,
   RootBoundary,
@@ -44,7 +119,7 @@ export type {
   SizeOptions,
   Strategy,
   VirtualElement,
-} from '@floating-ui/core/async';
+} from '@floating-ui/core';
 
 export interface UseFloatingOptions {
   /**

--- a/packages/react-native/src/useFloating.ts
+++ b/packages/react-native/src/useFloating.ts
@@ -1,5 +1,5 @@
-import type {ComputePositionReturn} from '@floating-ui/core';
-import {computePosition} from '@floating-ui/core';
+import type {ComputePositionReturn} from '@floating-ui/core/async';
+import {computePosition} from '@floating-ui/core/async';
 import * as React from 'react';
 
 import {createPlatform} from './createPlatform';

--- a/packages/vue/src/useFloating.ts
+++ b/packages/vue/src/useFloating.ts
@@ -93,24 +93,28 @@ export function useFloating<T extends ReferenceElement = ReferenceElement>(
 
     const open = openOption.value;
 
-    computePosition(referenceElement.value, floatingElement.value, {
-      middleware: middlewareOption.value,
-      placement: placementOption.value,
-      strategy: strategyOption.value,
-    }).then((position) => {
-      x.value = position.x;
-      y.value = position.y;
-      strategy.value = position.strategy;
-      placement.value = position.placement;
-      middlewareData.value = position.middlewareData;
-      /**
-       * The floating element's position may be recomputed while it's closed
-       * but still mounted (such as when transitioning out). To ensure
-       * `isPositioned` will be `false` initially on the next open, avoid
-       * setting it to `true` when `open === false` (must be specified).
-       */
-      isPositioned.value = open !== false;
-    });
+    const position = computePosition(
+      referenceElement.value,
+      floatingElement.value,
+      {
+        middleware: middlewareOption.value,
+        placement: placementOption.value,
+        strategy: strategyOption.value,
+      },
+    );
+
+    x.value = position.x;
+    y.value = position.y;
+    strategy.value = position.strategy;
+    placement.value = position.placement;
+    middlewareData.value = position.middlewareData;
+    /**
+     * The floating element's position may be recomputed while it's closed
+     * but still mounted (such as when transitioning out). To ensure
+     * `isPositioned` will be `false` initially on the next open, avoid
+     * setting it to `true` when `open === false` (must be specified).
+     */
+    isPositioned.value = open !== false;
   }
 
   function cleanup() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.17.0(jiti@2.4.2))
+      glob:
+        specifier: ^11.0.2
+        version: 11.0.2
       globals:
         specifier: ^15.14.0
         version: 15.14.0
@@ -3759,9 +3762,13 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  glob@10.3.10:
-    resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
+  glob@11.0.2:
+    resolution: {integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==}
+    engines: {node: 20 || >=22}
     hasBin: true
 
   glob@7.2.3:
@@ -4182,9 +4189,12 @@ packages:
     resolution: {integrity: sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==}
     engines: {node: '>= 0.4'}
 
-  jackspeak@2.3.6:
-    resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
-    engines: {node: '>=14'}
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jackspeak@4.1.1:
+    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
+    engines: {node: 20 || >=22}
 
   jest-diff@29.7.0:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
@@ -4416,6 +4426,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.1.0:
+    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+    engines: {node: 20 || >=22}
 
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
@@ -4700,6 +4714,10 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimatch@10.0.1:
+    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -4718,8 +4736,8 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@7.0.4:
-    resolution: {integrity: sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==}
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   mixme@0.5.10:
@@ -5060,6 +5078,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@1.3.0:
     resolution: {integrity: sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==}
 
@@ -5110,9 +5131,13 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.10.1:
-    resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -10914,13 +10939,23 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
-  glob@10.3.10:
+  glob@10.4.5:
     dependencies:
       foreground-child: 3.1.1
-      jackspeak: 2.3.6
+      jackspeak: 3.4.3
       minimatch: 9.0.5
-      minipass: 7.0.4
-      path-scurry: 1.10.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  glob@11.0.2:
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 4.1.1
+      minimatch: 10.0.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
 
   glob@7.2.3:
     dependencies:
@@ -11351,11 +11386,15 @@ snapshots:
       reflect.getprototypeof: 1.0.7
       set-function-name: 2.0.2
 
-  jackspeak@2.3.6:
+  jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jackspeak@4.1.1:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
 
   jest-diff@29.7.0:
     dependencies:
@@ -11451,7 +11490,7 @@ snapshots:
     dependencies:
       config-chain: 1.1.13
       editorconfig: 1.0.4
-      glob: 10.3.10
+      glob: 10.4.5
       nopt: 7.2.0
 
   js-tokens@4.0.0: {}
@@ -11636,6 +11675,8 @@ snapshots:
   loupe@3.1.3: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.1.0: {}
 
   lru-cache@4.1.5:
     dependencies:
@@ -12271,6 +12312,10 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimatch@10.0.1:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -12291,7 +12336,7 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@7.0.4: {}
+  minipass@7.1.2: {}
 
   mixme@0.5.10: {}
 
@@ -12586,6 +12631,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@1.3.0: {}
 
   parent-module@1.0.1:
@@ -12639,10 +12686,15 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.10.1:
+  path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.0.4
+      minipass: 7.1.2
+
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.1.0
+      minipass: 7.1.2
 
   path-to-regexp@6.3.0: {}
 
@@ -13190,7 +13242,7 @@ snapshots:
 
   rimraf@5.0.5:
     dependencies:
-      glob: 10.3.10
+      glob: 10.4.5
 
   rolldown-plugin-dts@0.13.8(rolldown@1.0.0-beta.11-commit.f051675)(typescript@5.2.2):
     dependencies:
@@ -13640,7 +13692,7 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
       commander: 4.1.1
-      glob: 10.3.10
+      glob: 10.4.5
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.6


### PR DESCRIPTION
There's a few ways to do this while maintaining a single source of truth.

This PR's approach is a build-time solution so we only need to write one single async version of the code, that at build time, gets split into sync and async versions. 

The sync version just strips off `async` and `await` syntax (and is now the default). The React Native package uses the `/async` subpath export.

The downside from what I can see here is 1) if you need to use both async and sync versions simultaneously, you get a duplicate cost (but I don't see why that would be needed — the DOM can stay sync at all times), and 2) the plugin approach to strip syntax could have some bugs