### PR TITLE
refactor: simplify useMergeRefs by removing redundant type assertions and tightening types

### DIFF
--- a/packages/react/src/hooks/useMergeRefs.ts
+++ b/packages/react/src/hooks/useMergeRefs.ts
@@ -1,15 +1,19 @@
 import * as React from 'react';
 
+type Ref<Instance> =
+  | Exclude<React.Ref<Instance>, React.RefObject<Instance>>
+  | React.MutableRefObject<Instance>;
+
 /**
  * Merges an array of refs into a single memoized callback ref or `null`.
  * @see https://floating-ui.com/docs/react-utils#usemergerefs
  */
 export function useMergeRefs<Instance>(
-  refs: Array<React.Ref<Instance> | undefined>,
+  refs: Array<Ref<Instance> | undefined>,
 ): null | React.RefCallback<Instance> {
-  const cleanupRef = React.useRef<void | (() => void)>(undefined);
+  const cleanupRef = React.useRef<() => void>(undefined);
 
-  const refEffect = React.useCallback((instance: Instance | null) => {
+  const refEffect = React.useCallback((instance: Instance) => {
     const cleanups = refs.map((ref) => {
       if (ref == null) {
         return;
@@ -25,9 +29,9 @@ export function useMergeRefs<Instance>(
             };
       }
 
-      (ref as React.MutableRefObject<Instance | null>).current = instance;
+      ref.current = instance;
       return () => {
-        (ref as React.MutableRefObject<Instance | null>).current = null;
+        ref.current = null;
       };
     });
 
@@ -45,13 +49,11 @@ export function useMergeRefs<Instance>(
     return (value) => {
       if (cleanupRef.current) {
         cleanupRef.current();
-        (cleanupRef as React.MutableRefObject<void | (() => void)>).current =
-          undefined;
+        cleanupRef.current = undefined;
       }
 
       if (value != null) {
-        (cleanupRef as React.MutableRefObject<void | (() => void)>).current =
-          refEffect(value);
+        cleanupRef.current = refEffect(value);
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/react/src/utils/useLiteMergeRefs.ts
+++ b/packages/react/src/utils/useLiteMergeRefs.ts
@@ -7,7 +7,7 @@ export function useLiteMergeRefs<T>(
     return (value) => {
       refs.forEach((ref) => {
         if (ref) {
-          (ref as React.MutableRefObject<T | null>).current = value;
+          ref.current = value;
         }
       });
     };


### PR DESCRIPTION
## Overview 

### useLiteMergeRefs
- Removed unnecessary type assertions.

### useMergeRefs
1. **Remove redundant type assertions**  
   - Created a `Ref<Instance>` type that excludes `React.RefObject` (readonly) and instead uses `React.MutableRefObject`, so `ref.current` can be updated directly without casting.

2. **Tightened refEffect argument type**  
   - Changed `refEffect` parameter from `instance: Instance | null` to `instance: Instance`.  
   - This aligns with the runtime guarantee that it's only invoked when `value != null`.

3. **Refined cleanupRef type**  
   - Previously `React.useRef<void | (() => void)>` allowed `void`, but in practice `refEffect` always returns `() => void`.  
   - Updated to `React.useRef<() => void>` for stronger type safety.

4. **Improved readability and maintainability**  
   - Reduced noise from type assertions.  
   - Code is more type-safe and easier to read, with fewer casts.
   
### Impact
- Removes unnecessary type assertions.  
- Improves type safety of `useMergeRefs`.  
- No runtime behavior change.  