### PR TITLE
docs: Rename "README Contributors" to "Sponsors" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,12 @@ It offers two main features:
 2. **User interactions for React**: Hooks and components for composing
    interactions to create accessible floating UI components.
 
-## README Contributors
+## Sponsors
 
 <table>
   <tr>
     <td>
       <a href="https://milfordasset.com/" target="_blank" rel="noopener noreferrer"><img width="176" height="150" src="https://github.com/floating-ui/floating-ui/blob/master/website/assets/sponsors/milford.svg" alt="Milford" /></a>
-    </td>
-    <td>
-      <a href="https://dopt.com/?utm_source=floating_ui_readme" target="_blank" rel="noopener noreferrer"><img width="200" height="150" src="https://github.com/floating-ui/floating-ui/blob/master/website/assets/sponsors/dopt.png" alt="Dopt" /></a>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
### This MR aims to:
- Rename "README Contributors" to "Sponsors". The companies mention are significant because they sponsored the project monetarily, not because they contributed to the README.
- Remove Dopt from sponsors. The company shut down and the website which was linked to is inaccessible.

### On Dopt:

> July 2024: Acquired by Airtable to bolster its AI capabilities and enhance its no-code platform offerings. The acquisition aimed to integrate Dopt’s expertise in AI-driven onboarding into Airtable’s suite of tools. Dopt’s operations and products officially wound down on August 15, 2024.

Source: https://eightception.com/dopt-startup-case-study/

>  As a part of the acquisition, we’ll shut down Dopt’s services on August 15th, which is very bittersweet.

Source: https://www.linkedin.com/posts/philipvanderbroek_some-big-news-dopt-has-been-acquired-by-activity-7224091787659730944-CtG7/