### PR TITLE
fix(FloatingFocusManager): suppress :focus-visible on pointer-initiated close

### DIFF
--- a/.changeset/fix-focus-visible-on-return.md
+++ b/.changeset/fix-focus-visible-on-return.md
@@ -1,0 +1,7 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(FloatingFocusManager): suppress :focus-visible on pointer-initiated close
+
+When a floating element is closed via a pointer interaction (e.g. clicking a menu item), the returned focus on the reference element no longer incorrectly shows :focus-visible styling. Keyboard-initiated closes (e.g. Escape) still correctly apply :focus-visible.

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -261,6 +261,7 @@ export function FloatingFocusManager(
   const startDismissButtonRef = React.useRef<HTMLButtonElement>(null);
   const endDismissButtonRef = React.useRef<HTMLButtonElement>(null);
   const preventReturnFocusRef = React.useRef(false);
+  const isKeyboardCloseRef = React.useRef(false);
   const isPointerDownRef = React.useRef(false);
   const tabbableIndexRef = React.useRef(-1);
   const blurTimeoutRef = React.useRef(-1);
@@ -634,6 +635,11 @@ export function FloatingFocusManager(
       event: Event;
       nested: boolean;
     }) {
+      // Track whether the close was keyboard-initiated so we can
+      // conditionally suppress :focus-visible when returning focus.
+      isKeyboardCloseRef.current =
+        reason === 'escape-key' || event instanceof KeyboardEvent;
+
       if (
         ['hover', 'safe-polygon'].includes(reason) &&
         event.type === 'mouseleave'
@@ -715,7 +721,14 @@ export function FloatingFocusManager(
             ? isFocusInsideFloatingTree
             : true)
         ) {
-          tabbableReturnElement.focus({preventScroll: true});
+          tabbableReturnElement.focus({
+            preventScroll: true,
+            // Suppress :focus-visible when the floating element was closed
+            // by a pointer interaction (e.g. clicking a menu item).
+            // Only show :focus-visible for keyboard-initiated closes
+            // (e.g. pressing Escape). GH #3394
+            ...(isKeyboardCloseRef.current ? undefined : {focusVisible: false}),
+          });
         }
 
         fallbackEl.remove();


### PR DESCRIPTION
### What

Fixes #3394

### Problem

When a floating element (e.g. a dropdown menu) is closed via a **pointer interaction** (clicking a menu item, outside press), `FloatingFocusManager` returns focus to the reference element. The browser incorrectly applies the `:focus-visible` pseudo-class to the reference element, causing an unwanted focus ring.

Ideally, `:focus-visible` should only appear when the floating element was closed via **keyboard** (e.g. pressing Escape).

### Root Cause

The `tabbableReturnElement.focus({preventScroll: true})` call in the cleanup function does not specify `focusVisible`, so the browser's heuristic decides whether to apply `:focus-visible`. Due to the microtask timing of the focus call, some browsers apply `:focus-visible` even for pointer-initiated closes.

### Fix

1. Added `isKeyboardCloseRef` to track whether the close was keyboard-initiated (`reason === 'escape-key'` or `event instanceof KeyboardEvent`).
2. When returning focus after a **pointer-initiated** close, pass `focusVisible: false` to the `.focus()` call.
3. When returning focus after a **keyboard-initiated** close (Escape), omit `focusVisible` to let the browser apply its default `:focus-visible` behavior.

```diff
 tabbableReturnElement.focus({
   preventScroll: true,
+  // Suppress :focus-visible for pointer-initiated closes. GH #3394
+  ...(isKeyboardCloseRef.current
+    ? undefined
+    : {focusVisible: false}),
 });
```