### PR TITLE
Remove unnecessary passive flag from scroll events

### DIFF
--- a/.changeset/calm-walls-listen.md
+++ b/.changeset/calm-walls-listen.md
@@ -1,0 +1,6 @@
+---
+"@floating-ui/dom": patch
+"@floating-ui/react": patch
+---
+
+fix: remove redundant passive options from scroll listeners

--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -170,8 +170,7 @@ export function autoUpdate(
       : [];
 
   ancestors.forEach((ancestor) => {
-    ancestorScroll &&
-      ancestor.addEventListener('scroll', update, {passive: true});
+    ancestorScroll && ancestor.addEventListener('scroll', update);
     ancestorResize && ancestor.addEventListener('resize', update);
   });
 

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -437,7 +437,7 @@ export function useDismiss(
     );
 
     ancestors.forEach((ancestor) => {
-      ancestor.addEventListener('scroll', onScroll, {passive: true});
+      ancestor.addEventListener('scroll', onScroll);
     });
 
     return () => {


### PR DESCRIPTION
Scroll events are uncancellable and so always passive. See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#using_passive_listeners