### PR TITLE
fix(react): dismiss outside-press for inline floating element inside …

### DIFF
--- a/.changeset/modern-popover-dismiss.md
+++ b/.changeset/modern-popover-dismiss.md
@@ -1,0 +1,7 @@
+---
+"@floating-ui/react": patch
+---
+
+fix(useDismiss): avoid skipping outside-press dismissal when the target shares the same root ancestor as the floating element
+
+When a floating element is rendered inline inside a modal portal (e.g. a Popover without its own `FloatingPortal` placed inside a `FloatingFocusManager` modal), pressing a sibling element outside the floating element was misidentified as a third-party element injected after the floating element rendered. This prevented the floating element from being dismissed. The root cause is that the target's root ancestor (the portal container) contained no `data-floating-ui-inert` markers, since the markers only live on subtrees outside the modal's portal. The fix adds a check so that when the target root ancestor contains the floating element, the press is treated as a normal outside press instead of being ignored.

--- a/packages/react/src/hooks/useDismiss.ts
+++ b/packages/react/src/hooks/useDismiss.ts
@@ -262,6 +262,12 @@ export function useDismiss(
       !isRootElement(target) &&
       // Clicked on a direct ancestor (e.g. FloatingOverlay).
       !contains(target, elements.floating) &&
+      // If the target root ancestor contains the floating element, the target
+      // shares the same root tree as the floating element (e.g. both are
+      // rendered inside the same FloatingPortal container). Such a target was
+      // not injected after the floating element rendered, so it should not be
+      // treated as a third-party element.
+      !contains(targetRootAncestor, elements.floating) &&
       // If the target root element contains none of the markers, then the
       // element was injected after the floating element rendered.
       Array.from(markers).every(

--- a/packages/react/test/unit/useDismiss.test.tsx
+++ b/packages/react/test/unit/useDismiss.test.tsx
@@ -1017,3 +1017,96 @@ test('nested floating elements with different portal roots', async () => {
   expect(screen.queryByText('open 2')).toBeInTheDocument();
   expect(screen.queryByText('nested')).toBeInTheDocument();
 });
+
+describe('inline floating element inside a modal portal', () => {
+  // A modal rendered via FloatingPortal + FloatingFocusManager(modal) with its
+  // own useDismiss disabled. The modal places its floating element in a portal
+  // container under <body>, and marks every other body-level subtree with
+  // `data-floating-ui-inert`. An inline Popover (no FloatingPortal) rendered
+  // inside the Modal lives in the same portal container, so its floating
+  // element shares the same root ancestor as the Modal's other children.
+  function Modal({children}: {children: ReactNode}) {
+    const [open] = useState(true);
+    const {refs, context} = useFloating({open});
+    const {getFloatingProps} = useInteractions([
+      useDismiss(context, {enabled: false}),
+    ]);
+
+    return (
+      <FloatingPortal>
+        <FloatingFocusManager context={context} modal>
+          <div ref={refs.setFloating} role="dialog" {...getFloatingProps()}>
+            {children}
+          </div>
+        </FloatingFocusManager>
+      </FloatingPortal>
+    );
+  }
+
+  function InlinePopover() {
+    const [open, setOpen] = useState(true);
+    const {refs, context} = useFloating({
+      open,
+      onOpenChange: setOpen,
+    });
+    const {getReferenceProps, getFloatingProps} = useInteractions([
+      useDismiss(context),
+    ]);
+
+    return (
+      <>
+        <button
+          {...getReferenceProps({ref: refs.setReference})}
+          data-testid="trigger"
+        >
+          trigger
+        </button>
+        {open && (
+          <div
+            {...getFloatingProps({ref: refs.setFloating})}
+            role="tooltip"
+            data-testid="floating"
+          >
+            floating
+          </div>
+        )}
+      </>
+    );
+  }
+
+  test('outsidePress closes when pressing a sibling outside the floating element', async () => {
+    render(
+      <Modal>
+        <InlinePopover />
+        <div data-testid="other">other row</div>
+      </Modal>,
+    );
+    await act(async () => {});
+
+    expect(screen.queryByTestId('floating')).toBeInTheDocument();
+
+    // Previously this was misidentified as a third-party element injected after
+    // the floating element rendered, because the target root ancestor (the
+    // portal container) contained no markers.
+    fireEvent.pointerDown(screen.getByTestId('other'));
+    await act(async () => {});
+
+    expect(screen.queryByTestId('floating')).not.toBeInTheDocument();
+    cleanup();
+  });
+
+  test('outsidePress does not close when pressing inside the floating element', async () => {
+    render(
+      <Modal>
+        <InlinePopover />
+      </Modal>,
+    );
+    await act(async () => {});
+
+    fireEvent.pointerDown(screen.getByTestId('floating'));
+    await act(async () => {});
+
+    expect(screen.queryByTestId('floating')).toBeInTheDocument();
+    cleanup();
+  });
+});


### PR DESCRIPTION
…a modal portal

When a floating element is rendered inline (without its own FloatingPortal) inside a modal that uses FloatingPortal + FloatingFocusManager(modal), pressing a sibling element outside the floating element was misidentified as a third-party element injected after the floating element rendered.

The modal places its floating element in a portal container under <body> and marks every other body-level subtree with `data-floating-ui-inert`. The inline Popover's floating element lives in the same portal container, so when a sibling is pressed, the target's root ancestor (the portal container) contains no markers, triggering the third-party element skip.

Add a check so that when the target root ancestor contains the floating element, the press is treated as a normal outside press instead of being ignored. This doesn't affect the original third-party element detection, which only applies when the target lives in a different root tree from the floating element.