### PR TITLE
fix(inline): use max group height as line-detection threshold in getRectsByLine

### DIFF
--- a/.changeset/fix-inline-getrectsbyl-maxgroupheight.md
+++ b/.changeset/fix-inline-getrectsbyl-maxgroupheight.md
@@ -1,0 +1,14 @@
+---
+"@floating-ui/core": patch
+---
+
+fix(inline): use max group height as line-detection threshold in `getRectsByLine`
+
+When a short rect (e.g. a superscript or small inline element) appears after a
+taller rect within the same line group, `prevRect.height` becomes very small.
+Subsequent rects that are still within the taller rect's vertical extent were
+incorrectly placed in a new group because `prevRect.height / 2` was too small
+a threshold.
+
+Track the maximum rect height seen so far in the current group
+(`maxGroupHeight`) and use that as the threshold instead of `prevRect.height`.

--- a/packages/core/src/middleware/inline.ts
+++ b/packages/core/src/middleware/inline.ts
@@ -28,12 +28,15 @@ export function getRectsByLine(rects: Array<ClientRectObject>) {
   const sortedRects = rects.slice().sort((a, b) => a.y - b.y);
   const groups = [];
   let prevRect: ClientRectObject | null = null;
+  let maxGroupHeight = 0;
   for (let i = 0; i < sortedRects.length; i++) {
     const rect = sortedRects[i];
-    if (!prevRect || rect.y - prevRect.y > prevRect.height / 2) {
+    if (!prevRect || rect.y - prevRect.y > maxGroupHeight / 2) {
       groups.push([rect]);
+      maxGroupHeight = rect.height;
     } else {
       groups[groups.length - 1].push(rect);
+      maxGroupHeight = Math.max(maxGroupHeight, rect.height);
     }
     prevRect = rect;
   }

--- a/packages/core/test/middleware/inline.test.ts
+++ b/packages/core/test/middleware/inline.test.ts
@@ -49,4 +49,21 @@ describe('getRectsByLine', () => {
       rectToClientRect({x: 20, y: 20, width: 10, height: 5}),
     ]);
   });
+
+  test('short rect in group should not truncate line-height threshold', () => {
+    // When a short rect (e.g. a small superscript/subscript) appears after a tall rect
+    // in the same group, prevRect.height becomes small. Subsequent rects that are still
+    // within the tall rect's vertical extent must NOT be split into a new group.
+    expect(
+      getRectsByLine([
+        rectToClientRect({x: 0, y: 0, width: 10, height: 20}), // tall – line 1
+        rectToClientRect({x: 10, y: 5, width: 10, height: 3}), // short inline – line 1
+        rectToClientRect({x: 20, y: 7, width: 10, height: 5}), // within tall rect – line 1
+        rectToClientRect({x: 0, y: 30, width: 30, height: 10}), // clearly line 2
+      ]),
+    ).toEqual([
+      rectToClientRect({x: 0, y: 0, width: 30, height: 20}),
+      rectToClientRect({x: 0, y: 30, width: 30, height: 10}),
+    ]);
+  });
 });


### PR DESCRIPTION
## Problem

`getRectsByLine` groups inline rects by line using the heuristic:

```ts
if (!prevRect || rect.y - prevRect.y > prevRect.height / 2) {
  // new line group
}
```

When a **short rect** (e.g. a superscript, subscript, or small inline element like `<sup>`) follows a taller rect within the same line group, `prevRect` becomes that short rect. Its `height / 2` threshold becomes too small, so the **next rect**—even if it's still within the tall rect's vertical extent—is incorrectly placed in a new group.

**Concrete example** (height=20 tall rect → height=3 short → height=5 rect that should stay on same line):

| Before fix | After fix |
|---|---|
| 3 groups: `[tall+short]`, `[medium]`, `[next-line]` | 2 groups: `[tall+short+medium]`, `[next-line]` |

This produces incorrect floating element positioning when the `inline` middleware operates on a selection that spans text with mixed font sizes (e.g. text containing a superscript or subscript).

## Fix

Track `maxGroupHeight` — the maximum height seen so far in the current group — and use it as the comparison threshold. This prevents a small intermediate rect from inadvertently lowering the threshold for subsequent rects.

```ts
if (!prevRect || rect.y - prevRect.y > maxGroupHeight / 2) {
  groups.push([rect]);
  maxGroupHeight = rect.height;
} else {
  groups[groups.length - 1].push(rect);
  maxGroupHeight = Math.max(maxGroupHeight, rect.height);
}
```

All existing unit tests continue to pass; a new test case is added to cover the regression.

> AI-assisted: this fix was identified and implemented with AI assistance.