### PR TITLE
fix(utils): deduplicate `getExpandedPlacements` result for base placements

### DIFF
--- a/.changeset/fix-get-expanded-placements-base-dedupe.md
+++ b/.changeset/fix-get-expanded-placements-base-dedupe.md
@@ -1,0 +1,16 @@
+---
+"@floating-ui/utils": patch
+---
+
+fix(utils): deduplicate `getExpandedPlacements` result for base placements
+
+`getExpandedPlacements` called with a non-aligned placement (e.g. `'top'`)
+returned the original placement itself and a duplicate entry
+(`['top', 'bottom', 'bottom']`). This happens because
+`getOppositeAlignmentPlacement` is a no-op when there is no alignment suffix,
+causing both the first and third elements to equal `'top'` and `'bottom'`
+respectively.
+
+The fix filters out the input placement and removes duplicates so that
+`getExpandedPlacements('top')` now correctly returns `['bottom']`.
+Aligned placements are unaffected.

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -119,7 +119,7 @@ export function getExpandedPlacements(placement: Placement): Array<Placement> {
     getOppositeAlignmentPlacement(placement),
     oppositePlacement,
     getOppositeAlignmentPlacement(oppositePlacement),
-  ];
+  ].filter((p, i, arr) => p !== placement && arr.indexOf(p) === i);
 }
 
 export function getOppositeAlignmentPlacement<T extends string>(

--- a/packages/utils/test/getExpandedPlacements.test.ts
+++ b/packages/utils/test/getExpandedPlacements.test.ts
@@ -1,0 +1,31 @@
+import {getExpandedPlacements} from '../src';
+
+test('aligned placement: returns 3 unique alternatives excluding original', () => {
+  expect(getExpandedPlacements('top-start')).toEqual([
+    'top-end',
+    'bottom-start',
+    'bottom-end',
+  ]);
+  expect(getExpandedPlacements('bottom-end')).toEqual([
+    'bottom-start',
+    'top-end',
+    'top-start',
+  ]);
+  expect(getExpandedPlacements('left-start')).toEqual([
+    'left-end',
+    'right-start',
+    'right-end',
+  ]);
+  expect(getExpandedPlacements('right-end')).toEqual([
+    'right-start',
+    'left-end',
+    'left-start',
+  ]);
+});
+
+test('base placement: returns only the opposite placement (no original, no duplicates)', () => {
+  expect(getExpandedPlacements('top')).toEqual(['bottom']);
+  expect(getExpandedPlacements('bottom')).toEqual(['top']);
+  expect(getExpandedPlacements('left')).toEqual(['right']);
+  expect(getExpandedPlacements('right')).toEqual(['left']);
+});


### PR DESCRIPTION
## Problem

`getExpandedPlacements` called with a non-aligned (base) placement such as `'top'`, `'bottom'`, `'left'`, or `'right'` returns the **original placement itself** and a **duplicate** entry:

```ts
getExpandedPlacements('top')    // ['top', 'bottom', 'bottom']  ← original + duplicate
getExpandedPlacements('bottom') // ['bottom', 'top', 'top']
```

### Root cause

`getOppositeAlignmentPlacement` is a no-op when there is no alignment suffix because neither `'start'` nor `'end'` appears in the string. So for `'top'`:

| Expression | Result |
|---|---|
| `getOppositeAlignmentPlacement('top')` | `'top'` (unchanged) |
| `getOppositePlacement('top')` | `'bottom'` |
| `getOppositeAlignmentPlacement('bottom')` | `'bottom'` (unchanged) |

The returned array is therefore `['top', 'bottom', 'bottom']` — the input placement appears as the first element (it should never be a fallback for itself) and `'bottom'` appears twice.

### Fix

Add a `.filter` step that removes the input placement from the result and deduplicates remaining entries:

```ts
getExpandedPlacements('top')    // ['bottom']  ✓
getExpandedPlacements('bottom') // ['top']     ✓
getExpandedPlacements('left')   // ['right']   ✓
getExpandedPlacements('right')  // ['left']    ✓
```

Aligned placements are unaffected because their expanded set already contains three unique values none of which is the original placement:

```ts
getExpandedPlacements('top-start')  // ['top-end', 'bottom-start', 'bottom-end']  ✓ (no change)
```

### Impact

The `flip` middleware guards against this path via the `isBasePlacement` check and correctly never passes a base placement to `getExpandedPlacements`. However `getExpandedPlacements` is exported as a public API from `@floating-ui/utils` and consumers who call it directly (e.g. to build a custom `fallbackPlacements` list) would receive an incorrect list containing the original placement and a duplicate, causing wasted flip cycles.

> [!NOTE]
> This PR was developed with AI assistance.