### PR TITLE
fix(dom): observe container-type ancestors in autoUpdate

### DIFF
--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -1,14 +1,32 @@
 import {floor, max, min} from '@floating-ui/utils';
 import {
+  getComputedStyle,
   getDocumentElement,
   getOverflowAncestors,
   getWindow,
+  isHTMLElement,
+  isLastTraversableNode,
 } from '@floating-ui/utils/dom';
 
 import type {FloatingElement, ReferenceElement} from './types';
 import {getBoundingClientRect} from './utils/getBoundingClientRect';
 import {unwrapElement} from './utils/unwrapElement';
 import {rectsAreEqual} from './utils/rectsAreEqual';
+
+function getContainerTypeAncestors(element: Element): Element[] {
+  const result: Element[] = [];
+  let node: Node | null = element.parentNode;
+  while (node && !isLastTraversableNode(node)) {
+    if (isHTMLElement(node)) {
+      const {containerType} = getComputedStyle(node);
+      if (containerType === 'size' || containerType === 'inline-size') {
+        result.push(node);
+      }
+    }
+    node = node.parentNode;
+  }
+  return result;
+}
 
 export interface AutoUpdateOptions {
   /**
@@ -199,6 +217,9 @@ export function autoUpdate(
   let reobserveFrame = -1;
   let resizeObserver: ResizeObserver | null = null;
 
+  const containerAncestors =
+    elementResize && referenceEl ? getContainerTypeAncestors(referenceEl) : [];
+
   if (elementResize) {
     resizeObserver = new ResizeObserver(([firstEntry]) => {
       if (
@@ -225,6 +246,14 @@ export function autoUpdate(
     if (floating) {
       resizeObserver.observe(floating);
     }
+
+    // Ancestors with `container-type: size/inline-size` create a CSS
+    // containment context. When they resize, the reference element's position
+    // changes even if the reference itself doesn't resize, so we must observe
+    // them too. See https://github.com/floating-ui/floating-ui/issues/3206
+    containerAncestors.forEach((ancestor) => {
+      resizeObserver?.observe(ancestor);
+    });
   }
 
   let frameId: number;


### PR DESCRIPTION
## What

`autoUpdate` now observes ancestors with `container-type: size/inline-size` via the existing `ResizeObserver`.

## Why

Closes #3206.

When an ancestor has `container-type: size/inline-size`, CSS containment makes that ancestor a sizing context. Resizing it causes the reference element's viewport position to change — but the reference element itself does not resize, so neither the `elementResize` `ResizeObserver` nor the `ancestorResize` `resize` event listeners fire (those cover overflow ancestors). The floating element ends up mis-positioned until the next unrelated trigger.

## How

Walk up the ancestor tree from the reference element and collect elements whose `containerType` computed style is `"size"` or `"inline-size"`. Observe them in the same `ResizeObserver` alongside the reference and floating elements. The existing `resizeObserver.disconnect()` in the cleanup path handles unobserving them — no extra teardown needed.

The walk uses `isLastTraversableNode` / `isHTMLElement` guards already available in `@floating-ui/utils/dom` to stay consistent with the rest of the codebase and handle shadow roots correctly.