### PR TITLE
fix(react): defer scroll to selectedIndex by one extra frame on first open

### DIFF
--- a/packages/react/src/hooks/useListNavigation.ts
+++ b/packages/react/src/hooks/useListNavigation.ts
@@ -356,12 +356,13 @@ export function useListNavigation(
 
     const initialItem = listRef.current[indexRef.current];
     const forceScrollIntoView = forceScrollIntoViewRef.current;
+    const isSyncScheduler = forceSyncFocusRef.current;
 
     if (initialItem) {
       runFocus(initialItem);
     }
 
-    const scheduler = forceSyncFocusRef.current
+    const scheduler = isSyncScheduler
       ? (v: () => void) => v()
       : requestAnimationFrame;
 
@@ -381,13 +382,23 @@ export function useListNavigation(
         (forceScrollIntoView || !isPointerModalityRef.current);
 
       if (shouldScrollIntoView) {
-        // JSDOM doesn't support `.scrollIntoView()` but it's widely supported
-        // by all browsers.
-        waitedItem.scrollIntoView?.(
-          typeof scrollIntoViewOptions === 'boolean'
-            ? {block: 'nearest', inline: 'nearest'}
-            : scrollIntoViewOptions,
-        );
+        const doScroll = () => {
+          // JSDOM doesn't support `.scrollIntoView()` but it's widely supported
+          // by all browsers.
+          waitedItem.scrollIntoView?.(
+            typeof scrollIntoViewOptions === 'boolean'
+              ? {block: 'nearest', inline: 'nearest'}
+              : scrollIntoViewOptions,
+          );
+        };
+        // When opening with a pre-selected index, the floating element's
+        // position may not yet be applied (async middleware). Defer one extra
+        // frame so the element is visible before scrolling.
+        if (forceScrollIntoView && !isSyncScheduler) {
+          requestAnimationFrame(doScroll);
+        } else {
+          doScroll();
+        }
       }
     });
   });

--- a/packages/react/test/unit/useListNavigation.test.tsx
+++ b/packages/react/test/unit/useListNavigation.test.tsx
@@ -460,8 +460,15 @@ describe('selectedIndex', () => {
     render(<App selectedIndex={0} />);
     fireEvent.click(screen.getByRole('button'));
     expect(requestAnimationFrame).toHaveBeenCalled();
-    // Run the timer
-    requestAnimationFrame.mock.calls.forEach((call) => call[0](0));
+    // First rAF pass: focuses the item and schedules the deferred scroll rAF.
+    const firstPassCount = requestAnimationFrame.mock.calls.length;
+    requestAnimationFrame.mock.calls
+      .slice(0, firstPassCount)
+      .forEach((call) => call[0](0));
+    // Second rAF pass: runs the deferred scroll scheduled for initial open.
+    requestAnimationFrame.mock.calls
+      .slice(firstPassCount)
+      .forEach((call) => call[0](0));
     expect(scrollIntoView).toHaveBeenCalled();
     cleanup();
   });


### PR DESCRIPTION
## Summary

Fixes #3378 — `useListNavigation` does not scroll to `selectedIndex` on the first open of a floating element, but works correctly on subsequent opens.

**Root cause:** When a floating element opens with a pre-selected index, `forceScrollIntoViewRef` is set to `true` and `scrollIntoView` is scheduled inside a single `requestAnimationFrame`. On the first open, floating-ui's position middleware runs asynchronously, so the floating element hasn't been positioned by the time that rAF fires. `scrollIntoView` runs on an element at its initial (unpositioned) location and has no visible effect. On subsequent opens the element already has its last-known position, so the scroll works.

**Fix:** When `forceScrollIntoView` is set (the initial-open-with-selectedIndex path) and focus is not synchronously scheduled, the `scrollIntoView` call is deferred into a second `requestAnimationFrame`. This gives floating-ui's positioning commit time to complete before the scroll runs.

## Changes

- `packages/react/src/hooks/useListNavigation.ts`: capture `isSyncScheduler` before the scheduler decision; wrap `scrollIntoView` in a nested `requestAnimationFrame` when `forceScrollIntoView && !isSyncScheduler`
- `packages/react/test/unit/useListNavigation.test.tsx`: update the `scrollIntoView on open` test to flush two rAF passes (focus pass → scroll pass)