### PR TITLE
perf: shrink core/dom/utils bundles with behavior-identical simplifications

### DIFF
--- a/.changeset/slim-core-middleware.md
+++ b/.changeset/slim-core-middleware.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/core': patch
+---
+
+perf(core): reduce bundle size with behavior-identical middleware simplifications

--- a/.changeset/slim-dom-platform.md
+++ b/.changeset/slim-dom-platform.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/dom': patch
+---
+
+perf(dom): reduce bundle size and skip redundant per-call work in positioning utilities

--- a/.changeset/slim-utils-helpers.md
+++ b/.changeset/slim-utils-helpers.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/utils': patch
+---
+
+perf(utils): reduce bundle size in `getNearestOverflowAncestor`

--- a/packages/core/src/computeCoordsFromPlacement.ts
+++ b/packages/core/src/computeCoordsFromPlacement.ts
@@ -40,14 +40,12 @@ export function computeCoordsFromPlacement(
       coords = {x: reference.x, y: reference.y};
   }
 
-  switch (getAlignment(placement)) {
-    case 'start':
-      coords[alignmentAxis] -= commonAlign * (rtl && isVertical ? -1 : 1);
-      break;
-    case 'end':
-      coords[alignmentAxis] += commonAlign * (rtl && isVertical ? -1 : 1);
-      break;
-    default:
+  const alignment = getAlignment(placement);
+  if (alignment) {
+    coords[alignmentAxis] +=
+      commonAlign *
+      (alignment === 'end' ? 1 : -1) *
+      (rtl && isVertical ? -1 : 1);
   }
 
   return coords;

--- a/packages/core/src/detectOverflow.ts
+++ b/packages/core/src/detectOverflow.ts
@@ -83,9 +83,8 @@ export async function detectOverflow(
       : rects.reference;
 
   const offsetParent = await platform.getOffsetParent?.(elements.floating);
-  const offsetScale = (await platform.isElement?.(offsetParent))
-    ? (await platform.getScale?.(offsetParent)) || {x: 1, y: 1}
-    : {x: 1, y: 1};
+  const offsetScale = ((await platform.isElement?.(offsetParent)) &&
+    (await platform.getScale?.(offsetParent))) || {x: 1, y: 1};
 
   const elementClientRect = rectToClientRect(
     platform.convertOffsetParentRelativeRectToViewportRelativeRect

--- a/packages/core/src/middleware/arrow.ts
+++ b/packages/core/src/middleware/arrow.ts
@@ -6,7 +6,7 @@ import {
   getAlignmentAxis,
   getAxisLength,
   getPaddingObject,
-  min as mathMin,
+  min,
 } from '@floating-ui/utils';
 
 import type {Derivable, Middleware} from '../types';
@@ -75,16 +75,15 @@ export const arrow = (
     // centered, modify the padding so that it is centered.
     const largestPossiblePadding =
       clientSize / 2 - arrowDimensions[length] / 2 - 1;
-    const minPadding = mathMin(paddingObject[minProp], largestPossiblePadding);
-    const maxPadding = mathMin(paddingObject[maxProp], largestPossiblePadding);
+    const minPadding = min(paddingObject[minProp], largestPossiblePadding);
+    const maxPadding = min(paddingObject[maxProp], largestPossiblePadding);
 
     // Make sure the arrow doesn't overflow the floating element if the center
     // point is outside the floating element's bounds.
-    const min = minPadding;
     const max = clientSize - arrowDimensions[length] - maxPadding;
     const center =
       clientSize / 2 - arrowDimensions[length] / 2 + centerToReference;
-    const offset = clamp(min, center, max);
+    const offset = clamp(minPadding, center, max);
 
     // If the reference is small enough that the arrow's padding causes it to
     // to point to nothing for an aligned placement, adjust the offset of the
@@ -95,12 +94,12 @@ export const arrow = (
       getAlignment(placement) != null &&
       center !== offset &&
       rects.reference[length] / 2 -
-        (center < min ? minPadding : maxPadding) -
+        (center < minPadding ? minPadding : maxPadding) -
         arrowDimensions[length] / 2 <
         0;
     const alignmentOffset = shouldAddOffset
-      ? center < min
-        ? center - min
+      ? center < minPadding
+        ? center - minPadding
         : center - max
       : 0;
 

--- a/packages/core/src/middleware/autoPlacement.ts
+++ b/packages/core/src/middleware/autoPlacement.ts
@@ -94,23 +94,12 @@ export const autoPlacement = (
         ? getPlacementList(alignment || null, autoAlignment, allowedPlacements)
         : allowedPlacements;
 
-    const overflow = await platform.detectOverflow(
-      state,
-      detectOverflowOptions,
-    );
-
     const currentIndex = middlewareData.autoPlacement?.index || 0;
     const currentPlacement = placements[currentIndex];
 
     if (currentPlacement == null) {
       return {};
     }
-
-    const alignmentSides = getAlignmentSides(
-      currentPlacement,
-      rects,
-      await platform.isRTL?.(elements.floating),
-    );
 
     // Make `computeCoords` start from the right place.
     if (placement !== currentPlacement) {
@@ -120,6 +109,17 @@ export const autoPlacement = (
         },
       };
     }
+
+    const overflow = await platform.detectOverflow(
+      state,
+      detectOverflowOptions,
+    );
+
+    const alignmentSides = getAlignmentSides(
+      currentPlacement,
+      rects,
+      await platform.isRTL?.(elements.floating),
+    );
 
     const currentOverflows = [
       overflow[getSide(currentPlacement)],

--- a/packages/core/src/middleware/inline.ts
+++ b/packages/core/src/middleware/inline.ts
@@ -114,19 +114,13 @@ export const inline = (
           const bottom = lastRect.bottom;
           const left = isTop ? firstRect.left : lastRect.left;
           const right = isTop ? firstRect.right : lastRect.right;
-          const width = right - left;
-          const height = bottom - top;
 
-          return {
-            top,
-            bottom,
-            left,
-            right,
-            width,
-            height,
+          return rectToClientRect({
             x: left,
             y: top,
-          };
+            width: right - left,
+            height: bottom - top,
+          });
         }
 
         const isLeftSide = getSide(placement) === 'left';
@@ -138,21 +132,13 @@ export const inline = (
 
         const top = measureRects[0].top;
         const bottom = measureRects[measureRects.length - 1].bottom;
-        const left = minLeft;
-        const right = maxRight;
-        const width = right - left;
-        const height = bottom - top;
 
-        return {
-          top,
-          bottom,
-          left,
-          right,
-          width,
-          height,
-          x: left,
+        return rectToClientRect({
+          x: minLeft,
           y: top,
-        };
+          width: maxRight - minLeft,
+          height: bottom - top,
+        });
       }
 
       return fallback;

--- a/packages/core/src/middleware/offset.ts
+++ b/packages/core/src/middleware/offset.ts
@@ -42,7 +42,7 @@ type OffsetValue =
 // Derivable.
 export type OffsetOptions = OffsetValue | Derivable<OffsetValue>;
 
-export async function convertValueToCoords(
+async function convertValueToCoords(
   state: MiddlewareState,
   options: OffsetOptions,
 ): Promise<Coords> {

--- a/packages/core/src/middleware/shift.ts
+++ b/packages/core/src/middleware/shift.ts
@@ -59,28 +59,25 @@ export const shift = (
       state,
       detectOverflowOptions,
     );
-    const crossAxis = getSideAxis(getSide(placement));
+    const crossAxis = getSideAxis(placement);
     const mainAxis = getOppositeAxis(crossAxis);
 
     let mainAxisCoord = coords[mainAxis];
     let crossAxisCoord = coords[crossAxis];
 
-    if (checkMainAxis) {
-      const minSide = mainAxis === 'y' ? 'top' : 'left';
-      const maxSide = mainAxis === 'y' ? 'bottom' : 'right';
-      const min = mainAxisCoord + overflow[minSide];
-      const max = mainAxisCoord - overflow[maxSide];
+    const clampCoord = (axis: 'x' | 'y', coord: number) =>
+      clamp(
+        coord + overflow[axis === 'y' ? 'top' : 'left'],
+        coord,
+        coord - overflow[axis === 'y' ? 'bottom' : 'right'],
+      );
 
-      mainAxisCoord = clamp(min, mainAxisCoord, max);
+    if (checkMainAxis) {
+      mainAxisCoord = clampCoord(mainAxis, mainAxisCoord);
     }
 
     if (checkCrossAxis) {
-      const minSide = crossAxis === 'y' ? 'top' : 'left';
-      const maxSide = crossAxis === 'y' ? 'bottom' : 'right';
-      const min = crossAxisCoord + overflow[minSide];
-      const max = crossAxisCoord - overflow[maxSide];
-
-      crossAxisCoord = clamp(min, crossAxisCoord, max);
+      crossAxisCoord = clampCoord(crossAxis, crossAxisCoord);
     }
 
     const limitedCoords = limiter.fn({

--- a/packages/core/src/middleware/size.ts
+++ b/packages/core/src/middleware/size.ts
@@ -79,15 +79,16 @@ export const size = (
       maximumClippingWidth,
     );
 
-    const noShift = !state.middlewareData.shift;
+    const shiftData = state.middlewareData.shift;
+    const noShift = !shiftData;
 
     let availableHeight = overflowAvailableHeight;
     let availableWidth = overflowAvailableWidth;
 
-    if (state.middlewareData.shift?.enabled.x) {
+    if (shiftData?.enabled.x) {
       availableWidth = maximumClippingWidth;
     }
-    if (state.middlewareData.shift?.enabled.y) {
+    if (shiftData?.enabled.y) {
       availableHeight = maximumClippingHeight;
     }
 

--- a/packages/dom/src/platform/convertOffsetParentRelativeRectToViewportRelativeRect.ts
+++ b/packages/dom/src/platform/convertOffsetParentRelativeRectToViewportRelativeRect.ts
@@ -37,7 +37,7 @@ export function convertOffsetParentRelativeRectToViewportRelativeRect({
   const offsets = createCoords(0);
   const isOffsetParentAnElement = isHTMLElement(offsetParent);
 
-  if (isOffsetParentAnElement || (!isOffsetParentAnElement && !isFixed)) {
+  if (isOffsetParentAnElement || !isFixed) {
     if (
       getNodeName(offsetParent) !== 'body' ||
       isOverflowElement(documentElement)

--- a/packages/dom/src/platform/getClippingRect.ts
+++ b/packages/dom/src/platform/getClippingRect.ts
@@ -6,7 +6,7 @@ import type {
   Strategy,
 } from '@floating-ui/core';
 import {rectToClientRect} from '@floating-ui/core';
-import {createCoords, max, min} from '@floating-ui/utils';
+import {max, min} from '@floating-ui/utils';
 import {
   getComputedStyle,
   getDocumentElement,
@@ -14,7 +14,6 @@ import {
   getOverflowAncestors,
   getParentNode,
   isContainingBlock,
-  isHTMLElement,
   isLastTraversableNode,
   isOverflowElement,
   isTopLayer,
@@ -40,7 +39,7 @@ function getInnerBoundingClientRect(
   const clientRect = getBoundingClientRect(element, true, strategy === 'fixed');
   const top = clientRect.top + element.clientTop;
   const left = clientRect.left + element.clientLeft;
-  const scale = isHTMLElement(element) ? getScale(element) : createCoords(1);
+  const scale = getScale(element);
   const width = element.clientWidth * scale.x;
   const height = element.clientHeight * scale.y;
   const x = left * scale.x;

--- a/packages/dom/src/utils/getBoundingClientRect.ts
+++ b/packages/dom/src/utils/getBoundingClientRect.ts
@@ -1,14 +1,17 @@
 import type {ClientRectObject} from '@floating-ui/core';
 import {rectToClientRect} from '@floating-ui/core';
 import {createCoords} from '@floating-ui/utils';
-import {getComputedStyle, getWindow} from '@floating-ui/utils/dom';
+import {
+  getComputedStyle,
+  getFrameElement,
+  getWindow,
+} from '@floating-ui/utils/dom';
 
 import {getScale} from '../platform/getScale';
 import {isElement} from '../platform/isElement';
 import {getVisualOffsets, shouldAddVisualOffsets} from './getVisualOffsets';
 import {unwrapElement} from './unwrapElement';
 import type {VirtualElement} from '../types';
-import {getFrameElement} from '@floating-ui/utils/dom';
 
 export function getBoundingClientRect(
   element: Element | VirtualElement,
@@ -43,16 +46,15 @@ export function getBoundingClientRect(
   let width = clientRect.width / scale.x;
   let height = clientRect.height / scale.y;
 
-  if (domElement) {
+  if (domElement && offsetParent) {
     const win = getWindow(domElement);
-    const offsetWin =
-      offsetParent && isElement(offsetParent)
-        ? getWindow(offsetParent)
-        : offsetParent;
+    const offsetWin = isElement(offsetParent)
+      ? getWindow(offsetParent)
+      : offsetParent;
 
     let currentWin = win;
     let currentIFrame = getFrameElement(currentWin);
-    while (currentIFrame && offsetParent && offsetWin !== currentWin) {
+    while (currentIFrame && offsetWin !== currentWin) {
       const iframeScale = getScale(currentIFrame);
       const iframeRect = currentIFrame.getBoundingClientRect();
       const css = getComputedStyle(currentIFrame);

--- a/packages/dom/src/utils/getDocumentRect.ts
+++ b/packages/dom/src/utils/getDocumentRect.ts
@@ -2,15 +2,13 @@ import type {Rect} from '@floating-ui/core';
 import {max} from '@floating-ui/utils';
 import {getComputedStyle, getNodeScroll} from '@floating-ui/utils/dom';
 
-import {getDocumentElement} from '../platform/getDocumentElement';
 import {getWindowScrollBarX} from './getWindowScrollBarX';
 
 // Gets the entire size of the scrollable document area, even extending outside
 // of the `<html>` and `<body>` rect bounds if horizontally scrollable.
-export function getDocumentRect(element: HTMLElement): Rect {
-  const html = getDocumentElement(element);
-  const scroll = getNodeScroll(element);
-  const body = element.ownerDocument.body;
+export function getDocumentRect(html: HTMLElement): Rect {
+  const scroll = getNodeScroll(html);
+  const body = html.ownerDocument.body;
 
   const width = max(
     html.scrollWidth,
@@ -25,7 +23,7 @@ export function getDocumentRect(element: HTMLElement): Rect {
     body.clientHeight,
   );
 
-  let x = -scroll.scrollLeft + getWindowScrollBarX(element);
+  let x = -scroll.scrollLeft + getWindowScrollBarX(html);
   const y = -scroll.scrollTop;
 
   if (getComputedStyle(body).direction === 'rtl') {

--- a/packages/dom/src/utils/getRectRelativeToOffsetParent.ts
+++ b/packages/dom/src/utils/getRectRelativeToOffsetParent.ts
@@ -26,13 +26,7 @@ export function getRectRelativeToOffsetParent(
   let scroll = {scrollLeft: 0, scrollTop: 0};
   const offsets = createCoords(0);
 
-  // If the <body> scrollbar appears on the left (e.g. RTL systems). Use
-  // Firefox with layout.scrollbar.side = 3 in about:config to test this.
-  function setLeftRTLScrollbarOffset() {
-    offsets.x = getWindowScrollBarX(documentElement);
-  }
-
-  if (isOffsetParentAnElement || (!isOffsetParentAnElement && !isFixed)) {
+  if (isOffsetParentAnElement || !isFixed) {
     if (
       getNodeName(offsetParent) !== 'body' ||
       isOverflowElement(documentElement)
@@ -49,13 +43,13 @@ export function getRectRelativeToOffsetParent(
       );
       offsets.x = offsetRect.x + offsetParent.clientLeft;
       offsets.y = offsetRect.y + offsetParent.clientTop;
-    } else if (documentElement) {
-      setLeftRTLScrollbarOffset();
     }
   }
 
-  if (isFixed && !isOffsetParentAnElement && documentElement) {
-    setLeftRTLScrollbarOffset();
+  // If the <body> scrollbar appears on the left (e.g. RTL systems). Use
+  // Firefox with layout.scrollbar.side = 3 in about:config to test this.
+  if (!isOffsetParentAnElement && documentElement) {
+    offsets.x = getWindowScrollBarX(documentElement);
   }
 
   const htmlOffset =

--- a/packages/dom/src/utils/getViewportRect.ts
+++ b/packages/dom/src/utils/getViewportRect.ts
@@ -23,9 +23,7 @@ export function getViewportRect(element: Element, strategy: Strategy): Rect {
     width = visualViewport.width;
     height = visualViewport.height;
 
-    const visualViewportBased = isWebKit();
-
-    if (!visualViewportBased || (visualViewportBased && strategy === 'fixed')) {
+    if (!isWebKit() || strategy === 'fixed') {
       x = visualViewport.offsetLeft;
       y = visualViewport.offsetTop;
     }

--- a/packages/dom/src/utils/getVisualOffsets.ts
+++ b/packages/dom/src/utils/getVisualOffsets.ts
@@ -22,12 +22,5 @@ export function shouldAddVisualOffsets(
   isFixed = false,
   floatingOffsetParent?: Element | Window | undefined,
 ): boolean {
-  if (
-    !floatingOffsetParent ||
-    (isFixed && floatingOffsetParent !== getWindow(element))
-  ) {
-    return false;
-  }
-
-  return isFixed;
+  return isFixed && floatingOffsetParent === getWindow(element);
 }

--- a/packages/dom/src/utils/getVisualOffsets.ts
+++ b/packages/dom/src/utils/getVisualOffsets.ts
@@ -22,5 +22,9 @@ export function shouldAddVisualOffsets(
   isFixed = false,
   floatingOffsetParent?: Element | Window | undefined,
 ): boolean {
-  return isFixed && floatingOffsetParent === getWindow(element);
+  return (
+    !!floatingOffsetParent &&
+    isFixed &&
+    floatingOffsetParent === getWindow(element)
+  );
 }

--- a/packages/dom/test/unit/getVisualOffsets.test.ts
+++ b/packages/dom/test/unit/getVisualOffsets.test.ts
@@ -1,0 +1,25 @@
+import {shouldAddVisualOffsets} from '../../src/utils/getVisualOffsets';
+
+test('does not access window when the offset parent is missing', () => {
+  const windowDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'window',
+  );
+
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    get() {
+      throw new Error('window accessed');
+    },
+  });
+
+  try {
+    expect(shouldAddVisualOffsets(undefined, true)).toBe(false);
+  } finally {
+    if (windowDescriptor) {
+      Object.defineProperty(globalThis, 'window', windowDescriptor);
+    } else {
+      delete (globalThis as {window?: Window}).window;
+    }
+  }
+});

--- a/packages/utils/src/dom.ts
+++ b/packages/utils/src/dom.ts
@@ -190,9 +190,7 @@ export function getNearestOverflowAncestor(node: Node): HTMLElement {
   const parentNode = getParentNode(node);
 
   if (isLastTraversableNode(parentNode)) {
-    return node.ownerDocument
-      ? node.ownerDocument.body
-      : (node as Document).body;
+    return (node.ownerDocument || (node as Document)).body;
   }
 
   if (isHTMLElement(parentNode) && isOverflowElement(parentNode)) {


### PR DESCRIPTION
## Summary

A pass of behavior-identical simplifications across `@floating-ui/core`, `@floating-ui/dom`, and `@floating-ui/utils`. These shrink the shipped bundle and remove some redundant per-call work in hot paths. No public API or behavior changes — every change is a straight refactor (redundant computation, duplicated logic, boolean-algebra collapses, or smaller minified forms).

> Rebased on top of #3448, which independently landed several of the originally-included changes (the `getClippingRect` accumulation loop, `isOffsetParentAnElement` reuse, `will-change`/`contain` regexes, `isWebKit` caching). This PR now contains only what remains on top of it.

## Consumer impact

Measured against a realistic popover consumer (`computePosition` + `autoUpdate` + `offset`/`flip`/`shift`/`limitShift`/`arrow`/`size`/`hide`, resolved through `dom` → `core` → `utils`, tree-shaken, minified, and gzipped as one bundle), versus current `master`:

| combined popover bundle | before | after | Δ |
|---|---|---|---|
| minified | 18,970 | 18,728 | −242 B |
| **gzipped** | **7,326** | **7,255** | **−71 B (−0.97%)** |

## Changes

### core
- **autoPlacement**: run the `currentPlacement == null` and placement-reset early returns ahead of `detectOverflow`/`isRTL`, so the reset pass skips a full clipping-rect measurement and an `isRTL` call
- **shift**: collapse the identical main/cross-axis clamp blocks into one helper; `getSideAxis(placement)` directly (the wrapper already calls `getSide`)
- **inline**: build the multi-rect result via the already-imported `rectToClientRect` instead of a hand-written literal
- **computeCoordsFromPlacement**: alignment `switch` → `if`
- **detectOverflow**: de-duplicate the `{x: 1, y: 1}` scale fallback
- **size**: hoist the repeated `middlewareData.shift` access
- **arrow**: drop the redundant `min` alias
- **offset**: un-export the internal-only `convertValueToCoords` (not part of the public API)

### dom
- **getClippingRect**: use `getScale` directly (it already returns `createCoords(1)` for non-HTML elements) — drops the ternary and two imports
- **getBoundingClientRect**: guard the iframe-composition block with `offsetParent` so the common path skips the `getWindow`/`getFrameElement` setup (this runs per frame under `animationFrame`); merge duplicate imports
- **getRectRelativeToOffsetParent** / **convertOffsetParentRelativeRectToViewportRelativeRect**: collapse `A || (!A && B)` → `A || B`, merge the two scrollbar-offset call sites
- **getViewportRect**: collapse `!v || (v && cond)` → `!v || cond`
- **getDocumentRect**: drop the redundant `getDocumentElement` call — the sole caller already passes it

### utils
- **getNearestOverflowAncestor**: `(node.ownerDocument || node).body`

## Verification

- Typecheck clean for all three packages
- Unit tests pass (core 24, utils 21, dom 1)
- Prettier clean
- Functional (Playwright) suite exercises the dom geometry paths in CI

Split into three per-package commits, each with a patch changeset.
