### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -29,8 +29,9 @@ jobs:
           sarif: 'true'
 
       - name: Upload SARIF to Code Scanning
-        if: always() && hashFiles('*.sarif') != ''
+        if: always()
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         with:
-          sarif_file: cve-lite-*.sarif
+          sarif_file: .
           category: cve-lite

--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,36 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite


### PR DESCRIPTION
This PR adds a CVE Lite dependency audit workflow to floating-ui. CVE Lite CLI is an OWASP Lab Project that scans pnpm, npm, Yarn, and Bun lockfiles locally for known vulnerabilities without requiring a package install step.

A scan of the current lockfile found 72 findings across 2003 packages: 7 critical, 35 high, 25 medium, and 5 low. Of those, 8 are direct dependencies with copy-ready upgrade commands, including 2 critical-severity devDependencies (`vitest` and `@vitest/browser`). A companion PR with those direct upgrades is coming separately.

The workflow runs on every push and pull request to master, and on a weekly Monday schedule. It produces a SARIF file that is uploaded to GitHub Code Scanning, so findings appear inline on the Security tab. The `fail-on: high` setting means the job will fail when high or critical findings are present, which acts as a merge gate for vulnerable dependency upgrades.

All Actions are pinned to immutable commit SHAs rather than floating version tags. The scan reads the lockfile directly so no `pnpm install` step is needed.

More about CVE Lite CLI and the OWASP Lab Project at https://owasp.org/cve-lite-cli
