### PR TITLE
fix(autoUpdate): refresh layoutShift observer when the root resizes

### DIFF
--- a/.changeset/wide-roots-move.md
+++ b/.changeset/wide-roots-move.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/dom': patch
+---
+
+fix(autoUpdate): refresh layout shift observer on root resize

--- a/packages/dom/src/autoUpdate.ts
+++ b/packages/dom/src/autoUpdate.ts
@@ -1,5 +1,9 @@
 import {floor, max, min} from '@floating-ui/utils';
-import {getDocumentElement, getOverflowAncestors} from '@floating-ui/utils/dom';
+import {
+  getDocumentElement,
+  getOverflowAncestors,
+  getWindow,
+} from '@floating-ui/utils/dom';
 
 import type {FloatingElement, ReferenceElement} from './types';
 import {getBoundingClientRect} from './utils/getBoundingClientRect';
@@ -129,9 +133,17 @@ function observeMove(element: Element, onMove: () => void) {
     io.observe(element);
   }
 
+  const win = getWindow(element);
+  const handleResize = () => refresh();
+
+  win.addEventListener('resize', handleResize);
+
   refresh(true);
 
-  return cleanup;
+  return () => {
+    win.removeEventListener('resize', handleResize);
+    cleanup();
+  };
 }
 
 /**

--- a/packages/dom/test/functional/autoUpdate.test.ts
+++ b/packages/dom/test/functional/autoUpdate.test.ts
@@ -2,6 +2,30 @@ import {expect, test} from '@playwright/test';
 
 import {click} from './utils/click';
 
+async function getHorizontalOffset(page: any) {
+  return await page.evaluate(() => {
+    const reference = document.querySelector(
+      '[data-testid="rootResize-reference"]',
+    );
+    const floating = document.querySelector(
+      '[data-testid="rootResize-floating"]',
+    );
+
+    if (!reference || !floating) {
+      return Number.POSITIVE_INFINITY;
+    }
+
+    return Math.abs(
+      reference.getBoundingClientRect().left -
+        floating.getBoundingClientRect().left,
+    );
+  });
+}
+
+async function expectFloatingTracksReference(page: any) {
+  await expect.poll(() => getHorizontalOffset(page)).toBeLessThanOrEqual(1);
+}
+
 ['ancestorScroll', 'elementResize', 'ancestorResize'].forEach((option) => {
   [true, false].forEach((bool) => {
     test(`${option}: ${bool}`, async ({page}) => {
@@ -49,6 +73,21 @@ test(`layoutShift: does not wait for the 1s throttle when the reference moves du
   expect(await page.locator('.container').screenshot()).toMatchSnapshot(
     `layoutShift-moveTwice.png`,
   );
+});
+
+test(`layoutShift updates after viewport resize with ancestorResize disabled`, async ({
+  page,
+}) => {
+  await page.setViewportSize({width: 620, height: 720});
+  await page.goto('http://localhost:1234/autoUpdate-root-resize');
+
+  await expectFloatingTracksReference(page);
+
+  await page.setViewportSize({width: 1000, height: 720});
+  await expectFloatingTracksReference(page);
+
+  await click(page, `[data-testid="rootResize-reference"]`);
+  await expectFloatingTracksReference(page);
 });
 
 test(`reactive whileElementsMounted`, async ({page}) => {

--- a/packages/dom/test/visual/index.tsx
+++ b/packages/dom/test/visual/index.tsx
@@ -13,7 +13,7 @@ import {
 
 import {Arrow} from './spec/Arrow';
 import {AutoPlacement} from './spec/AutoPlacement';
-import {AutoUpdate} from './spec/AutoUpdate';
+import {AutoUpdate, AutoUpdateRootResize} from './spec/AutoUpdate';
 import {Border} from './spec/Border';
 import {ContainingBlock} from './spec/ContainingBlock';
 import {DecimalSize} from './spec/DecimalSize';
@@ -54,6 +54,7 @@ const ROUTES = [
   {path: 'autoPlacement', component: AutoPlacement},
   {path: 'inline', component: Inline},
   {path: 'AutoUpdate', component: AutoUpdate},
+  {path: 'AutoUpdate-root-resize', component: AutoUpdateRootResize},
   {path: 'shadow-DOM', component: ShadowDOM},
   {path: 'containing-block', component: ContainingBlock},
   {path: 'virtual-element', component: VirtualElement},

--- a/packages/dom/test/visual/spec/AutoUpdate.tsx
+++ b/packages/dom/test/visual/spec/AutoUpdate.tsx
@@ -221,3 +221,57 @@ export function AutoUpdate() {
     </>
   );
 }
+
+export function AutoUpdateRootResize() {
+  const [moved, setMoved] = useState(false);
+
+  const {x, y, strategy, refs, update} = useFloating({
+    strategy: 'fixed',
+  });
+
+  useLayoutEffect(() => {
+    if (!refs.reference.current || !refs.floating.current) {
+      return;
+    }
+
+    return autoUpdate(refs.reference.current, refs.floating.current, update, {
+      ancestorResize: false,
+      elementResize: false,
+      layoutShift: true,
+    });
+  }, [refs.floating, refs.reference, update]);
+
+  return (
+    <>
+      <h1>AutoUpdate Root Resize</h1>
+      <button
+        ref={refs.setReference}
+        data-testid="rootResize-reference"
+        onClick={() => setMoved(true)}
+        style={{
+          position: 'fixed',
+          top: 32,
+          left: moved ? 650 : 'calc(100vw - 220px)',
+          width: 75,
+          height: 22,
+        }}
+      >
+        Toggle
+      </button>
+      <div
+        ref={refs.setFloating}
+        className="floating"
+        data-testid="rootResize-floating"
+        style={{
+          position: strategy,
+          top: y ?? '',
+          left: x ?? '',
+          width: 75,
+          height: 22,
+        }}
+      >
+        Floating
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Fixes #3206

## What

Goal is to fix `layoutShift` not triggering a reposition after the viewport/root resizes.

Refresh `observeMove` when the reference element window resizes, so the IntersectionObserver is recreated around the current reference rect and current root dimensions.

This keeps the rootMargin watch box anchored to the resized root even when `ancestorResize` is disabled. It is separate from #3482: that PR handles stale IntersectionObserver callback data, while this bug can leave the observer silent because the reference remains fully inside a stale inflated watch box.

## Why

`observeMove` computes its rootMargin from the root size when the observer is created. If the viewport grows, those insets can become stale. A later reference move can still be fully inside the old watch box, so the ratio stays at 1 and no IntersectionObserver callback fires at all.

Refreshing on window resize remeasures the reference and recreates the observer before the next layout-shift move, so the watch box matches the resized root.

## Test

Adds an `AutoUpdate-root-resize` scenario with `ancestorResize: false`: start at a 620px viewport, resize to 1000px, then click the reference so it moves while it would remain inside the stale watch box.

The functional test asserts the floating element tracks the reference after the resize and click. It fails without the fix with a 380px horizontal offset, and passes with the resize refresh in `observeMove`.