### PR TITLE
fix(platform): support virtual elements without `getClientRects` in `inline()`

### DIFF
--- a/.changeset/virtual-client-rects.md
+++ b/.changeset/virtual-client-rects.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/dom': patch
+---
+
+fix(platform): don't throw in `getClientRects` when a virtual element without a `getClientRects` method is used with the `inline()` middleware

--- a/packages/dom/src/platform/getClientRects.ts
+++ b/packages/dom/src/platform/getClientRects.ts
@@ -1,3 +1,5 @@
-export function getClientRects(element: Element) {
-  return Array.from(element.getClientRects());
+import type {VirtualElement} from '../types';
+
+export function getClientRects(element: Element | VirtualElement) {
+  return element.getClientRects ? Array.from(element.getClientRects()) : [];
 }

--- a/packages/dom/test/unit/getClientRects.test.ts
+++ b/packages/dom/test/unit/getClientRects.test.ts
@@ -1,0 +1,47 @@
+import {getClientRects} from '../../src/platform/getClientRects';
+import type {VirtualElement} from '../../src/types';
+
+test('returns an empty array for a virtual element without getClientRects', () => {
+  const virtualElement: VirtualElement = {
+    getBoundingClientRect: () => ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+      width: 0,
+      height: 0,
+    }),
+  };
+
+  expect(getClientRects(virtualElement)).toEqual([]);
+});
+
+test('returns the rects of a virtual element with getClientRects', () => {
+  const rect = {
+    x: 10,
+    y: 20,
+    top: 20,
+    left: 10,
+    bottom: 30,
+    right: 40,
+    width: 30,
+    height: 10,
+  };
+  const virtualElement: VirtualElement = {
+    getBoundingClientRect: () => rect,
+    getClientRects: () => [rect],
+  };
+
+  expect(getClientRects(virtualElement)).toEqual([rect]);
+});
+
+test('returns the rects of a DOM element', () => {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+
+  expect(getClientRects(element)).toEqual(Array.from(element.getClientRects()));
+
+  element.remove();
+});


### PR DESCRIPTION
## What

`platform.getClientRects` no longer throws when the reference is a virtual element that doesn't implement the optional `getClientRects` method.

## Why

`VirtualElement.getClientRects` is optional, but the `dom` platform method called `element.getClientRects()` unconditionally. Combining a plain virtual element (e.g. a pointer-based context-menu reference implementing only `getBoundingClientRect`) with the `inline()` middleware threw `TypeError: element.getClientRects is not a function`.

## How

Optional-call with an empty-array fallback. Since #3479, `inline()` no-ops on empty client rects, so the middleware gracefully keeps the `getBoundingClientRect`-based reference rect instead of crashing. The exported `Platform` type is unchanged (widening the parameter there would break custom platform implementations under `strictFunctionTypes`); only the internal function signature accepts `VirtualElement`.