### PR TITLE
feat(useRole): deprecate `label` role

### DIFF
--- a/.changeset/deprecate-userole-label.md
+++ b/.changeset/deprecate-userole-label.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/react': minor
+---
+
+feat(useRole): deprecate `label` role

--- a/packages/react/src/hooks/useRole.ts
+++ b/packages/react/src/hooks/useRole.ts
@@ -3,6 +3,7 @@ import {getFloatingFocusElement} from '@floating-ui/react/utils';
 
 import {useFloatingParentNodeId} from '../components/FloatingTree';
 import type {ElementProps, FloatingRootContext} from '../types';
+import {warn} from '../utils/log';
 import {useId} from './useId';
 import type {ExtendedUserProps} from './useInteractions';
 
@@ -14,7 +15,13 @@ type AriaRole =
   | 'listbox'
   | 'grid'
   | 'tree';
-type ComponentRole = 'select' | 'label' | 'combobox';
+/**
+ * @deprecated `aria-labelledby` is only applied while the floating element
+ * is open, so the reference element loses its accessible name while closed.
+ * Use `aria-label` on the reference element instead.
+ */
+type DeprecatedLabelRole = 'label';
+type ComponentRole = 'select' | DeprecatedLabelRole | 'combobox';
 
 export interface UseRoleProps {
   /**
@@ -50,6 +57,16 @@ export function useRole(
 ): ElementProps {
   const {open, elements, floatingId: defaultFloatingId} = context;
   const {enabled = true, role = 'dialog'} = props;
+
+  if (__DEV__) {
+    if (role === 'label') {
+      warn(
+        'The `label` role is deprecated, as `aria-labelledby` is only',
+        'applied while the floating element is open. Apply `aria-label`',
+        'to the reference element instead.',
+      );
+    }
+  }
 
   const defaultReferenceId = useId();
   const referenceId = elements.domReference?.id || defaultReferenceId;

--- a/packages/react/test/unit/useRole.test.tsx
+++ b/packages/react/test/unit/useRole.test.tsx
@@ -1,5 +1,6 @@
 import {act, cleanup, fireEvent, render, screen} from '@testing-library/react';
 import {useState} from 'react';
+import {vi} from 'vitest';
 
 import {
   useClick,
@@ -102,6 +103,29 @@ describe('tooltip', () => {
 });
 
 describe('label', () => {
+  // These two warning tests must run before any other test in this file
+  // triggers `role: 'label'` — `warn()`'s dedup is keyed on message text for
+  // the lifetime of the test file's module instance (vitest isolates module
+  // state per file, not per test), so a "warned exactly once" assertion only
+  // holds if this is the first `role: 'label'` render in the file.
+  test('warns once that the role is deprecated', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const {rerender} = render(<App role="label" />);
+    rerender(<App role="label" />);
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+    cleanup();
+  });
+
+  test('does not warn for other roles', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<App role="dialog" />);
+    render(<App role="tooltip" />);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+    cleanup();
+  });
+
   test('sets correct aria attributes based on the open state', () => {
     const {container} = render(<App role="label" initiallyOpen />);
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();

--- a/website/pages/docs/useRole.mdx
+++ b/website/pages/docs/useRole.mdx
@@ -113,6 +113,13 @@ the floating element.
 
 #### `label{:.string}`
 
+<Notice type="warning" title="Deprecated">
+  `aria-labelledby` is only applied to the reference element
+  while the floating element is open, so the reference element
+  loses its accessible name while closed. Use `aria-label` on
+  the reference element instead.
+</Notice>
+
 This role should be used for floating elements that act as a
 label for a reference element with no text/label (e.g. an icon
 button).


### PR DESCRIPTION
Closes #3306.

The `label` role only applies `aria-labelledby` while the floating element is open, so the reference element loses its accessible name whenever it's closed — which, for a tooltip, is most of the time. Per @atomiks on the issue: *"Let's deprecate the `label` option then, and warn not to use it (and instead recommend `aria-label`)."*

So this deprecates it, non-breaking:
- The `label` role still works exactly as before — no runtime or aria change.
- Using `{role: 'label'}` now logs a dev-only warning (stripped in production) pointing to `aria-label` instead.
- It's marked `@deprecated` in the types, and the docs note it.
- Changeset added (`@floating-ui/react`: minor).

The directive is about a year old, so flagging in case the direction has changed — but implementing as asked since the issue's still open.

**Testing:** 2 new tests (warns once for `label`, never for other roles); the full `@floating-ui/react` suite passes and typecheck/lint/build are clean. The warning is dead-code-eliminated from the production bundle.
