### PR TITLE
fix(react): hide portal owner from accessibility tree

### DIFF
--- a/.changeset/quiet-portal-owner.md
+++ b/.changeset/quiet-portal-owner.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/react': patch
+---
+
+Hide the non-modal FloatingPortal `aria-owns` owner from the accessibility tree.

--- a/packages/react/src/components/FloatingPortal.tsx
+++ b/packages/react/src/components/FloatingPortal.tsx
@@ -254,7 +254,11 @@ export function FloatingPortal(props: FloatingPortalProps): React.JSX.Element {
         />
       )}
       {shouldRenderGuards && portalNode && (
-        <span aria-owns={portalNode.id} style={HIDDEN_OWNER_STYLES} />
+        <span
+          aria-hidden="true"
+          aria-owns={portalNode.id}
+          style={HIDDEN_OWNER_STYLES}
+        />
       )}
       {portalNode && ReactDOM.createPortal(children, portalNode)}
       {shouldRenderGuards && portalNode && (

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -1452,6 +1452,45 @@ describe('order', () => {
 });
 
 describe('non-modal + FloatingPortal', () => {
+  test('hides the aria-owns owner from the accessibility tree', async () => {
+    function App() {
+      const [open, setOpen] = useState(false);
+      const {refs, context} = useFloating({
+        open,
+        onOpenChange: setOpen,
+      });
+
+      return (
+        <>
+          <button
+            data-testid="reference"
+            ref={refs.setReference}
+            onClick={() => setOpen(true)}
+          />
+          <FloatingPortal>
+            {open && (
+              <FloatingFocusManager context={context} modal={false}>
+                <div data-testid="floating" ref={refs.setFloating}>
+                  <span tabIndex={0} data-testid="inside" />
+                </div>
+              </FloatingFocusManager>
+            )}
+          </FloatingPortal>
+        </>
+      );
+    }
+
+    render(<App />);
+
+    await userEvent.click(screen.getByTestId('reference'));
+    await act(async () => {});
+
+    const portal = screen.getByTestId('floating').parentElement;
+    const owner = document.querySelector(`[aria-owns="${portal?.id}"]`);
+
+    expect(owner).toHaveAttribute('aria-hidden', 'true');
+  });
+
   test('focuses inside element, tabbing out focuses last document element', async () => {
     function App() {
       const [open, setOpen] = useState(false);


### PR DESCRIPTION
## Summary
- Add `aria-hidden="true"` to the non-modal FloatingPortal `aria-owns` owner span.
- Add regression coverage for the FloatingFocusManager + FloatingPortal non-modal path.
- Add a patch changeset for `@floating-ui/react`.

Fixes #3424

## Tests
- `pnpm --dir packages/react test FloatingFocusManager.test.tsx`
- `pnpm --dir packages/react test FloatingPortal.test.tsx`
- `pnpm --dir packages/react lint`
- `pnpm --dir packages/react typecheck`
- `pnpm build`