### PR TITLE
fix(react): declare function-valued type members as properties

### DIFF
--- a/.changeset/extended-refs-bivariant-setters.md
+++ b/.changeset/extended-refs-bivariant-setters.md
@@ -1,0 +1,11 @@
+---
+'@floating-ui/react': patch
+---
+
+Declare the function-valued members of the public React types as properties rather than
+methods, so reading one without calling it (`ref={refs.setReference}`) is no longer
+reported as an unbound method by type-aware linters. Covers `ExtendedRefs`,
+`FloatingEvents`, `FloatingTreeType`, `FloatingContext.onOpenChange`, and
+`FloatingRootContext['refs']`. Signatures are otherwise unchanged: `BivariantCallback`
+keeps parameter assignability bivariant, and `FloatingEvents.emit` keeps its type
+parameter.

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -136,9 +136,9 @@ export interface ExtendedRefs<RT> {
   reference: React.MutableRefObject<ReferenceType | null>;
   floating: React.MutableRefObject<HTMLElement | null>;
   domReference: React.MutableRefObject<NarrowedElement<RT> | null>;
-  setReference(node: RT | null): void;
-  setFloating(node: HTMLElement | null): void;
-  setPositionReference(node: ReferenceType | null): void;
+  setReference: BivariantCallback<(node: RT | null) => void>;
+  setFloating: BivariantCallback<(node: HTMLElement | null) => void>;
+  setPositionReference: BivariantCallback<(node: ReferenceType | null) => void>;
 }
 
 export interface ExtendedElements<RT> {
@@ -148,9 +148,9 @@ export interface ExtendedElements<RT> {
 }
 
 export interface FloatingEvents {
-  emit<T extends string>(event: T, data?: any): void;
-  on(event: string, handler: (data: any) => void): void;
-  off(event: string, handler: (data: any) => void): void;
+  emit: <T extends string>(event: T, data?: any) => void;
+  on: BivariantCallback<(event: string, handler: (data: any) => void) => void>;
+  off: BivariantCallback<(event: string, handler: (data: any) => void) => void>;
 }
 
 export interface ContextData {
@@ -177,7 +177,9 @@ export interface FloatingRootContext<RT extends ReferenceType = ReferenceType> {
   events: FloatingEvents;
   floatingId: string | undefined;
   refs: {
-    setPositionReference(node: ReferenceType | null): void;
+    setPositionReference: BivariantCallback<
+      (node: ReferenceType | null) => void
+    >;
   };
 }
 
@@ -186,7 +188,9 @@ export type FloatingContext<RT extends ReferenceType = ReferenceType> = Omit<
   'refs' | 'elements'
 > & {
   open: boolean;
-  onOpenChange(open: boolean, event?: Event, reason?: OpenChangeReason): void;
+  onOpenChange: BivariantCallback<
+    (open: boolean, event?: Event, reason?: OpenChangeReason) => void
+  >;
   events: FloatingEvents;
   dataRef: React.MutableRefObject<ContextData>;
   nodeId: string | undefined;
@@ -204,8 +208,8 @@ export interface FloatingNodeType<RT extends ReferenceType = ReferenceType> {
 export interface FloatingTreeType<RT extends ReferenceType = ReferenceType> {
   nodesRef: React.MutableRefObject<Array<FloatingNodeType<RT>>>;
   events: FloatingEvents;
-  addNode(node: FloatingNodeType): void;
-  removeNode(node: FloatingNodeType): void;
+  addNode: BivariantCallback<(node: FloatingNodeType) => void>;
+  removeNode: BivariantCallback<(node: FloatingNodeType) => void>;
 }
 
 export interface ElementProps {

--- a/packages/react/test/index.test-d.ts
+++ b/packages/react/test/index.test-d.ts
@@ -1,4 +1,13 @@
-import type {CompositeProps, UseFloatingOptions} from '../src';
+import type {
+  CompositeProps,
+  ExtendedRefs,
+  FloatingContext,
+  FloatingEvents,
+  FloatingNodeType,
+  FloatingRootContext,
+  FloatingTreeType,
+  UseFloatingOptions,
+} from '../src';
 
 // Callbacks with a narrower parameter type stay assignable, matching the
 // behavior before these optional callbacks gained an explicit `| undefined`
@@ -17,3 +26,74 @@ export const onOpenChange: UseFloatingOptions['onOpenChange'] = (
 export const onNavigate: CompositeProps['onNavigate'] = (index: 0 | 1) => {
   void index;
 };
+
+// The same guarantee for the function-valued members that are declared as
+// properties so that reading one without calling it is not treated as an
+// unbound method. Each regresses to TS2322 if it loses `BivariantCallback`.
+
+// `node` narrowed from `Element | null` to `HTMLDivElement | null`.
+export const setReference: ExtendedRefs<Element>['setReference'] = (
+  node: HTMLDivElement | null,
+) => {
+  void node;
+};
+
+// `node` narrowed from `HTMLElement | null` to `HTMLDivElement | null`.
+export const setFloating: ExtendedRefs<Element>['setFloating'] = (
+  node: HTMLDivElement | null,
+) => {
+  void node;
+};
+
+// `node` narrowed from `ReferenceType | null` to `Element | null`.
+export const setPositionReference: ExtendedRefs<Element>['setPositionReference'] =
+  (node: Element | null) => {
+    void node;
+  };
+
+export const setRootPositionReference: FloatingRootContext['refs']['setPositionReference'] =
+  (node: Element | null) => {
+    void node;
+  };
+
+// `event` narrowed from `string` to a literal union.
+export const on: FloatingEvents['on'] = (
+  event: 'open' | 'close',
+  handler: (data: any) => void,
+) => {
+  void [event, handler];
+};
+
+export const off: FloatingEvents['off'] = (
+  event: 'open' | 'close',
+  handler: (data: any) => void,
+) => {
+  void [event, handler];
+};
+
+// `node.id` narrowed from `string | undefined` to `string`.
+export const addNode: FloatingTreeType['addNode'] = (
+  node: FloatingNodeType & {id: string},
+) => {
+  void node;
+};
+
+export const removeNode: FloatingTreeType['removeNode'] = (
+  node: FloatingNodeType & {id: string},
+) => {
+  void node;
+};
+
+// `event` narrowed from `Event` to `MouseEvent`.
+export const contextOnOpenChange: FloatingContext['onOpenChange'] = (
+  open: boolean,
+  event?: MouseEvent,
+) => {
+  void [open, event];
+};
+
+// `emit` keeps its type parameter. Regresses to TS2558 if the signature is
+// ever wrapped in a helper that resolves `Parameters<T>`, which erases it.
+export function emitStaysGeneric(events: FloatingEvents) {
+  events.emit<'custom-event'>('custom-event');
+}


### PR DESCRIPTION
Reading a function-valued member of the public React types without calling it is reported as an unbound method by type-aware linters. Passing a ref setter to a `ref` prop is the common way to hit it:

```tsx
const {refs} = useFloating();
return <div ref={refs.setReference} />;
//              ^^^^^^^^^^^^^^^^^^ @typescript-eslint/unbound-method
```

> A method that is not declared with `this: void` may cause unintentional scoping of `this` when separated from its object.

`unbound-method` ships in typescript-eslint's `strict-type-checked` preset. It treats a `MethodSignature` in an interface the same as a class `MethodDeclaration`, so it can't tell that these members never touch `this`, and it flags every read that isn't a call.

Notably `@floating-ui/react-dom` already declares the same two setters as properties, so this also brings the React package in line with its sibling:

```ts
// packages/react-dom/src/types.ts
setReference: (node: RT | null) => void;
setFloating: (node: HTMLElement | null) => void;
```

## Why it started

This linted clean for years. [typescript-eslint#12448](https://github.com/typescript-eslint/typescript-eslint/pull/12448) rewrote the rule's `MemberExpression` handler to fix union-type handling. It used to call `getSymbolAtLocation` on the member expression, which didn't resolve through `ExtendedRefs<RT>`. It now reads the type of the object and calls `.getProperty(name)`, which lands on the `MethodSignature`.

The threshold is exact: 8.64.0 is clean, 8.65.0 reports. I confirmed by swapping only the rule implementation between those two versions and holding everything else fixed.

## The change

Converts the method-syntax members of the exported types in `packages/react/src/types.ts` to property syntax:

| Type | Members |
| --- | --- |
| `ExtendedRefs` | `setReference`, `setFloating`, `setPositionReference` |
| `FloatingRootContext['refs']` | `setPositionReference` |
| `FloatingEvents` | `emit`, `on`, `off` |
| `FloatingTreeType` | `addNode`, `removeNode` |
| `FloatingContext` | `onOpenChange` |

All are `useCallback`, `useEffectEvent`, or closures over local state (`createEventEmitter`), so none of them are `this`-dependent.

Plain property syntax alone would have been a breaking change. Parameters become contravariant under `strictFunctionTypes`, so a consumer assigning a narrower handler would stop compiling. This uses the `BivariantCallback` helper already defined in the file, which keeps parameters bivariant:

| | rule satisfied | `(node: HTMLDivElement \| null) => void` assignable |
| --- | --- | --- |
| method syntax (current) | no | yes |
| plain property | yes | no, `TS2322` |
| `BivariantCallback` property | yes | yes |

One exception: `FloatingEvents.emit` is declared as a plain property rather than wrapped, because `BivariantCallback` resolves `Parameters<T>` and so erases a type parameter. Wrapping `emit<T extends string>` would have silently dropped its generic (`TS2558: Expected 0 type arguments, but got 1`).

Dropping the wrapper costs nothing here. Because that signature is generic, method syntax never bought bivariance for `event` in the first place: TypeScript instantiates the type parameter before comparing, so a narrowed implementation is rejected under both shapes, identically. The two are mutually assignable.

Every converted member is bidirectionally assignable with the declaration it replaces, so none of this is breaking.

Deliberately left alone:

- The `bivariance` members inside the `BivariantCallback` helpers themselves, in `types.ts` and `Composite.tsx`. Method syntax is the mechanism there.
- `CompositeContext.onNavigate` and `FocusManagerState.onOpenChange`. Both are internal, not exported, so they can't affect consumers. Happy to convert them too if you'd rather have the whole file uniform.
- `FloatingRootContext.onOpenChange` was already property syntax and is untouched.

## Verification

- `pnpm typecheck --filter @floating-ui/react`: 5/5 tasks pass
- `pnpm test --filter @floating-ui/react`: 21 files, 286 passed, 6 skipped
- `pnpm lint --filter @floating-ui/react`: passes
- Applied the same shape to an installed `0.27.20` build in a Next.js app running typescript-eslint 8.65.0. A component using both `refs.setReference` and `refs.setFloating` lints clean with no suppressions and still type-checks.
- Confirmed the bivariance and generic-erasure claims above directly, in both directions.

## Tests

`packages/react/test/index.test-d.ts` already pins bivariance for two callbacks by assigning narrowed implementations, so I extended it in the same style. One assertion per converted member, plus one that `emit` keeps its type parameter.

I checked each assertion actually fails when the guarantee is removed, rather than assuming it would. Replacing `BivariantCallback` with plain property syntax produces `TS2322` at every bivariance assertion, and wrapping `emit` produces `TS2558`.

Two of them were vacuous on the first attempt and are now fixed, which is the reason for the case-by-case check.

`setReference` and `setFloating` are a stronger case than a test: with plain property syntax, `src` itself stops compiling, because `FloatingContext<RT>` is no longer assignable to `FloatingContext<ReferenceType>` in `useFloating.ts` and `useTransition.ts`. Bivariance on those two is load-bearing for the library's own code, not only for consumers.
