### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/release-popper.yml
+++ b/.github/workflows/release-popper.yml
@@ -11,7 +11,7 @@ jobs:
           ref: v2.x
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 20.x
       - uses: CultureHQ/actions-yarn@master
         with:
           args: install


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `20,22,24,26`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `20,22,24,26` (using `26` where a concrete pin is needed).

- `.github/workflows/release-popper.yml`
  - `node-version: 12.x` → `node-version: 20.x`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `20,22,24,26`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
