### PR TITLE
fix(getViewportRect): only subtract a scrollbar gutter when one is reserved

### DIFF
--- a/.changeset/viewport-gutter-false-positive.md
+++ b/.changeset/viewport-gutter-false-positive.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/dom': patch
+---
+
+fix(getViewportRect): only subtract a scrollbar gutter when one is reserved

--- a/packages/dom/src/utils/getViewportRect.ts
+++ b/packages/dom/src/utils/getViewportRect.ts
@@ -51,17 +51,28 @@ export function getViewportRect(
     }
   }
 
-  const windowScrollbarX = getWindowScrollBarX(html);
-  const scrollbarGutter = getComputedStyle(html).scrollbarGutter;
+  const htmlRect = html.getBoundingClientRect();
+  const windowScrollbarX = getWindowScrollBarX(html, htmlRect);
   // `scrollbar-gutter: stable` on the <html> reserves gutter space that shrinks
   // the visual width but isn't reflected in `html.clientWidth`. The <html>
   // border box does reflect it, so measure the reserved space from it. A
   // left-side scrollbar (`windowScrollbarX > 0`) is already handled by
-  // `getHTMLOffset`/`visualViewport.width`; skip it here.
-  if (windowScrollbarX <= 0 && scrollbarGutter && scrollbarGutter !== 'auto') {
-    const reservedWidth = html.clientWidth - html.getBoundingClientRect().width;
+  // `getHTMLOffset`/`visualViewport.width`; skip it here. `both-edges` also
+  // shifts the <html> origin by the inline-start gutter, so it fails that same
+  // check and stays uncorrected.
+  const reservedWidth = html.clientWidth - htmlRect.width;
 
-    if (reservedWidth > 0 && reservedWidth <= SCROLLBAR_MAX) {
+  if (
+    windowScrollbarX <= 0 &&
+    reservedWidth > 0 &&
+    reservedWidth <= SCROLLBAR_MAX
+  ) {
+    // Only a declared gutter reserves space; any other narrowing of the <html>
+    // box (a margin, a width, a transform) must not be treated as one. Read
+    // last so the style lookup stays off the common path.
+    const scrollbarGutter = getComputedStyle(html).scrollbarGutter;
+
+    if (scrollbarGutter && scrollbarGutter !== 'auto') {
       width -= reservedWidth;
     }
   }

--- a/packages/dom/src/utils/getViewportRect.ts
+++ b/packages/dom/src/utils/getViewportRect.ts
@@ -54,13 +54,16 @@ export function getViewportRect(
   const htmlRect = html.getBoundingClientRect();
   const windowScrollbarX = getWindowScrollBarX(html, htmlRect);
   // `scrollbar-gutter: stable` on the <html> reserves gutter space that shrinks
-  // the visual width but isn't reflected in `html.clientWidth`. The <html>
-  // border box does reflect it, so measure the reserved space from it. A
-  // left-side scrollbar (`windowScrollbarX > 0`) is already handled by
-  // `getHTMLOffset`/`visualViewport.width`; skip it here. `both-edges` also
-  // shifts the <html> origin by the inline-start gutter, so it fails that same
-  // check and stays uncorrected.
-  const reservedWidth = html.clientWidth - htmlRect.width;
+  // the visual width. In standards mode, only the border box reflects it. In
+  // quirks mode, `html.clientWidth` also shrinks, so compare it with the chosen
+  // viewport width instead. A left-side scrollbar (`windowScrollbarX > 0`) is
+  // already handled by `getHTMLOffset`/`visualViewport.width`; skip it here.
+  // `both-edges` also shifts the <html> origin by the inline-start gutter, so it
+  // fails that same check and stays uncorrected.
+  const reservedWidth =
+    win.document.compatMode === 'BackCompat'
+      ? width - html.clientWidth
+      : html.clientWidth - htmlRect.width;
 
   if (
     windowScrollbarX <= 0 &&

--- a/packages/dom/src/utils/getViewportRect.ts
+++ b/packages/dom/src/utils/getViewportRect.ts
@@ -1,5 +1,5 @@
 import type {Rect, RootBoundary, Strategy} from '@floating-ui/core';
-import {getWindow, isWebKit} from '@floating-ui/utils/dom';
+import {getComputedStyle, getWindow, isWebKit} from '@floating-ui/utils/dom';
 
 import {getDocumentElement} from '../platform/getDocumentElement';
 import {getWindowScrollBarX} from './getWindowScrollBarX';
@@ -52,32 +52,17 @@ export function getViewportRect(
   }
 
   const windowScrollbarX = getWindowScrollBarX(html);
+  const scrollbarGutter = getComputedStyle(html).scrollbarGutter;
   // `scrollbar-gutter: stable` on the <html> reserves gutter space that shrinks
-  // the visual width but isn't reflected in `html.clientWidth`, so subtract it.
-  // Only the inline-end (right) gutter can hold the scrollbar; `both-edges` also
-  // reserves an empty inline-start gutter that clips nothing, so exclude just
-  // the one scrollbar-side gutter — halve the measured (two-gutter) total. A
+  // the visual width but isn't reflected in `html.clientWidth`. The <html>
+  // border box does reflect it, so measure the reserved space from it. A
   // left-side scrollbar (`windowScrollbarX > 0`) is already handled by
   // `getHTMLOffset`/`visualViewport.width`; skip it here.
-  if (windowScrollbarX <= 0) {
-    const doc = html.ownerDocument;
-    const body = doc.body;
-    const bodyStyles = getComputedStyle(body);
-    const bodyMarginInline =
-      doc.compatMode === 'CSS1Compat'
-        ? parseFloat(bodyStyles.marginLeft) +
-            parseFloat(bodyStyles.marginRight) || 0
-        : 0;
-    const reservedWidth = Math.abs(
-      html.clientWidth - body.clientWidth - bodyMarginInline,
-    );
-    const gutter =
-      getComputedStyle(html).scrollbarGutter === 'stable both-edges'
-        ? reservedWidth / 2
-        : reservedWidth;
+  if (windowScrollbarX <= 0 && scrollbarGutter && scrollbarGutter !== 'auto') {
+    const reservedWidth = html.clientWidth - html.getBoundingClientRect().width;
 
-    if (gutter <= SCROLLBAR_MAX) {
-      width -= gutter;
+    if (reservedWidth > 0 && reservedWidth <= SCROLLBAR_MAX) {
+      width -= reservedWidth;
     }
   }
 

--- a/packages/dom/src/utils/getViewportRect.ts
+++ b/packages/dom/src/utils/getViewportRect.ts
@@ -2,6 +2,7 @@ import type {Rect, RootBoundary, Strategy} from '@floating-ui/core';
 import {getComputedStyle, getWindow, isWebKit} from '@floating-ui/utils/dom';
 
 import {getDocumentElement} from '../platform/getDocumentElement';
+import {getCurrentCSSZoom} from './getCurrentCSSZoom';
 import {getWindowScrollBarX} from './getWindowScrollBarX';
 
 // Safety check: ensure the scrollbar space is reasonable in case this
@@ -68,7 +69,8 @@ export function getViewportRect(
   if (
     windowScrollbarX <= 0 &&
     reservedWidth > 0 &&
-    reservedWidth <= SCROLLBAR_MAX
+    reservedWidth / getCurrentCSSZoom(html.ownerDocument.body || html) <=
+      SCROLLBAR_MAX
   ) {
     // Only a declared gutter reserves space; any other narrowing of the <html>
     // box (a margin, a width, a transform) must not be treated as one. Read

--- a/packages/dom/test/unit/getViewportRect.test.ts
+++ b/packages/dom/test/unit/getViewportRect.test.ts
@@ -19,7 +19,11 @@ interface Geometry {
   htmlClientHeight: number;
   htmlBCRLeft: number;
   htmlScrollLeft: number;
-  bodyClientWidth: number;
+  // The <html> border box width. Equal to `htmlClientWidth` unless a
+  // `scrollbar-gutter` reserves space, which shrinks the border box while
+  // leaving `clientWidth` at the full viewport width.
+  htmlBCRWidth?: number;
+  bodyClientWidth?: number;
   visualViewportWidth: number;
   visualViewportHeight?: number;
   visualViewportOffsetLeft?: number;
@@ -31,7 +35,8 @@ function mockViewport({
   htmlClientHeight,
   htmlBCRLeft,
   htmlScrollLeft,
-  bodyClientWidth,
+  htmlBCRWidth = htmlClientWidth,
+  bodyClientWidth = htmlClientWidth,
   visualViewportWidth,
   visualViewportHeight = htmlClientHeight,
   visualViewportOffsetLeft = 0,
@@ -43,9 +48,9 @@ function mockViewport({
   vi.spyOn(html, 'getBoundingClientRect').mockReturnValue({
     left: htmlBCRLeft,
     top: 0,
-    right: htmlBCRLeft + htmlClientWidth,
+    right: htmlBCRLeft + htmlBCRWidth,
     bottom: htmlClientHeight,
-    width: htmlClientWidth,
+    width: htmlBCRWidth,
     height: htmlClientHeight,
     x: htmlBCRLeft,
     y: 0,
@@ -54,8 +59,6 @@ function mockViewport({
   vi.spyOn(document.body, 'clientWidth', 'get').mockReturnValue(
     bodyClientWidth,
   );
-  // Neutralize the default UA body margin so the gutter math is deterministic.
-  document.body.style.margin = '0px';
   vi.stubGlobal('visualViewport', {
     width: visualViewportWidth,
     height: visualViewportHeight,
@@ -67,69 +70,89 @@ function mockViewport({
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
-  document.body.style.margin = '';
   html.style.scrollbarGutter = '';
   mocks.isWebKit = false;
 });
 
 // scrollbar-gutter: stable reserves space on the inline-end (right) edge.
-// `visualViewport.width` still includes that reserved gutter, so it must be
-// subtracted from the boundary width.
+// `html.clientWidth` and `visualViewport.width` both still include that
+// reserved gutter, so it must be subtracted from the boundary width. The
+// <html> border box is what shrinks (measured in Chrome: a 900px viewport with
+// a 15px gutter reports clientWidth 900, border box width 885).
 test('subtracts a right-side reserved gutter from the width', () => {
   mockViewport({
-    htmlClientWidth: 807,
-    htmlClientHeight: 900,
+    htmlClientWidth: 900,
+    htmlClientHeight: 600,
+    htmlBCRLeft: 0,
+    htmlBCRWidth: 885, // 15px gutter reserved on the right
+    htmlScrollLeft: 0,
+    visualViewportWidth: 900,
+  });
+  html.style.scrollbarGutter = 'stable';
+
+  const rect = getViewportRect(html, 'absolute');
+
+  expect(rect.x).toBe(0);
+  expect(rect.width).toBe(885);
+});
+
+// A body narrower than the <html> content box is ordinary CSS — a border, an
+// explicit width, or padding on the <html> — not a reserved gutter. Without a
+// `scrollbar-gutter` there is nothing to subtract.
+test('does not treat body box styles as a reserved gutter', () => {
+  mockViewport({
+    htmlClientWidth: 900,
+    htmlClientHeight: 600,
     htmlBCRLeft: 0,
     htmlScrollLeft: 0,
-    bodyClientWidth: 792, // 15px gutter reserved on the right
-    visualViewportWidth: 807,
+    bodyClientWidth: 874, // e.g. `body { border: 5px solid }`
+    visualViewportWidth: 900,
   });
 
   const rect = getViewportRect(html, 'absolute');
 
   expect(rect.x).toBe(0);
-  expect(rect.width).toBe(792);
+  expect(rect.width).toBe(900);
 });
 
-// `scrollbar-gutter: stable both-edges` reserves a gutter on BOTH inline edges,
-// but only the inline-end (right) one can hold the scrollbar. The empty
-// inline-start gutter clips nothing, so only the single scrollbar-side gutter
-// is excluded — width shrinks by one gutter and the origin stays put.
-test('subtracts only the scrollbar-side gutter for both-edges', () => {
+// Safety cap: an implausibly large measurement is more likely to be unusual
+// styles than a scrollbar gutter, so it is ignored.
+test('caps an implausibly large reserved width', () => {
   mockViewport({
     htmlClientWidth: 800,
-    htmlClientHeight: 800,
+    htmlClientHeight: 600,
     htmlBCRLeft: 0,
+    htmlBCRWidth: 760, // 40px > SCROLLBAR_MAX
     htmlScrollLeft: 0,
-    bodyClientWidth: 770, // two 15px gutters reserved
     visualViewportWidth: 800,
   });
-  html.style.scrollbarGutter = 'stable both-edges';
+  html.style.scrollbarGutter = 'stable';
 
-  const rect = getViewportRect(html, 'absolute', 'layoutViewport');
-
-  expect(rect.x).toBe(0);
-  expect(rect.width).toBe(785);
-});
-
-// The safety cap applies per edge: `both-edges` halves the measured total first,
-// so a legitimate two-gutter total isn't rejected, but an implausibly large
-// single gutter still is.
-test('caps the both-edges gutter per edge, not on the total', () => {
-  mockViewport({
-    htmlClientWidth: 800,
-    htmlClientHeight: 800,
-    htmlBCRLeft: 0,
-    htmlScrollLeft: 0,
-    bodyClientWidth: 720, // two 40px "gutters" — 40 > SCROLLBAR_MAX per edge
-    visualViewportWidth: 800,
-  });
-  html.style.scrollbarGutter = 'stable both-edges';
-
-  const rect = getViewportRect(html, 'absolute', 'layoutViewport');
+  const rect = getViewportRect(html, 'absolute');
 
   expect(rect.x).toBe(0);
   expect(rect.width).toBe(800);
+});
+
+// `scrollbar-gutter: stable both-edges` reserves a gutter on each inline edge,
+// which shifts the <html> origin right by the inline-start one (measured in
+// Chrome: a 900px viewport reports border box left 15, width 870). That shift
+// is compensated by `getHTMLOffset`, so the width is left alone here.
+test('leaves a shifted <html> origin to getHTMLOffset', () => {
+  mockViewport({
+    htmlClientWidth: 900,
+    htmlClientHeight: 600,
+    htmlBCRLeft: 15,
+    htmlBCRWidth: 870,
+    htmlScrollLeft: 0,
+    visualViewportWidth: 885,
+  });
+  html.style.scrollbarGutter = 'stable both-edges';
+
+  const rect = getViewportRect(html, 'absolute');
+
+  expect(rect.x).toBe(0);
+  expect(rect.width).toBe(885);
 });
 
 // A left-side scrollbar (e.g. Firefox `layout.scrollbar.side`) shifts the
@@ -143,7 +166,6 @@ test('does not inflate the width for a left-side scrollbar', () => {
     htmlClientHeight: 900,
     htmlBCRLeft: 15, // 15px scrollbar on the left
     htmlScrollLeft: 0,
-    bodyClientWidth: 1665,
     visualViewportWidth: 1664.5,
   });
 
@@ -223,7 +245,6 @@ test.each([
       htmlClientHeight: 600,
       htmlBCRLeft: 0,
       htmlScrollLeft: 0,
-      bodyClientWidth: 800,
       visualViewportWidth: 780,
       visualViewportHeight: 560,
       visualViewportOffsetLeft: 30,

--- a/packages/dom/test/unit/getViewportRect.test.ts
+++ b/packages/dom/test/unit/getViewportRect.test.ts
@@ -15,13 +15,14 @@ vi.mock('@floating-ui/utils/dom', async (importOriginal) => {
 const html = document.documentElement;
 
 interface Geometry {
+  compatMode?: Document['compatMode'];
   htmlClientWidth: number;
   htmlClientHeight: number;
   htmlBCRLeft: number;
   htmlScrollLeft: number;
-  // The <html> border box width. Equal to `htmlClientWidth` unless a
-  // `scrollbar-gutter` reserves space, which shrinks the border box while
-  // leaving `clientWidth` at the full viewport width.
+  // The <html> border box width. In standards mode, a reserved gutter shrinks
+  // this while leaving `clientWidth` at the full viewport width. In quirks
+  // mode, both shrink.
   htmlBCRWidth?: number;
   bodyClientWidth?: number;
   visualViewportWidth: number;
@@ -31,6 +32,7 @@ interface Geometry {
 }
 
 function mockViewport({
+  compatMode = 'CSS1Compat',
   htmlClientWidth,
   htmlClientHeight,
   htmlBCRLeft,
@@ -42,6 +44,7 @@ function mockViewport({
   visualViewportOffsetLeft = 0,
   visualViewportOffsetTop = 0,
 }: Geometry) {
+  vi.spyOn(document, 'compatMode', 'get').mockReturnValue(compatMode);
   vi.spyOn(html, 'clientWidth', 'get').mockReturnValue(htmlClientWidth);
   vi.spyOn(html, 'clientHeight', 'get').mockReturnValue(htmlClientHeight);
   vi.spyOn(html, 'scrollLeft', 'get').mockReturnValue(htmlScrollLeft);
@@ -95,6 +98,36 @@ test('subtracts a right-side reserved gutter from the width', () => {
   expect(rect.x).toBe(0);
   expect(rect.width).toBe(885);
 });
+
+// In quirks mode, the viewport `clientWidth` special case moves from <html> to
+// <body>. A stable gutter therefore shrinks both the <html> client width and
+// border box, while the body retains the full viewport width. The default
+// viewport still needs the gutter subtracted, but the layout viewport already
+// excludes it and must not be shrunk twice.
+test.each([
+  {boundary: 'viewport', rootBoundary: undefined},
+  {boundary: 'layout viewport', rootBoundary: 'layoutViewport'},
+] as const)(
+  'uses the right-side reserved gutter in quirks mode for the $boundary',
+  ({rootBoundary}) => {
+    mockViewport({
+      compatMode: 'BackCompat',
+      htmlClientWidth: 885,
+      htmlClientHeight: 600,
+      htmlBCRLeft: 0,
+      htmlBCRWidth: 885,
+      htmlScrollLeft: 0,
+      bodyClientWidth: 900,
+      visualViewportWidth: 900,
+    });
+    html.style.scrollbarGutter = 'stable';
+
+    const rect = getViewportRect(html, 'absolute', rootBoundary);
+
+    expect(rect.x).toBe(0);
+    expect(rect.width).toBe(885);
+  },
+);
 
 // A body narrower than the <html> content box is ordinary CSS — a border, an
 // explicit width, or padding on the <html> — not a reserved gutter. The <body>

--- a/packages/dom/test/unit/getViewportRect.test.ts
+++ b/packages/dom/test/unit/getViewportRect.test.ts
@@ -97,8 +97,8 @@ test('subtracts a right-side reserved gutter from the width', () => {
 });
 
 // A body narrower than the <html> content box is ordinary CSS — a border, an
-// explicit width, or padding on the <html> — not a reserved gutter. Without a
-// `scrollbar-gutter` there is nothing to subtract.
+// explicit width, or padding on the <html> — not a reserved gutter. The <body>
+// box is not read at all, so it cannot shrink the boundary.
 test('does not treat body box styles as a reserved gutter', () => {
   mockViewport({
     htmlClientWidth: 900,
@@ -108,6 +108,65 @@ test('does not treat body box styles as a reserved gutter', () => {
     bodyClientWidth: 874, // e.g. `body { border: 5px solid }`
     visualViewportWidth: 900,
   });
+
+  const rect = getViewportRect(html, 'absolute');
+
+  expect(rect.x).toBe(0);
+  expect(rect.width).toBe(900);
+});
+
+// The same body border alongside a real gutter: the gutter is still subtracted
+// in full, and the body border adds nothing to it (measured in Chrome: a 900px
+// viewport with `scrollbar-gutter: stable` and `body { border: 5px solid }`
+// reports clientWidth 900, border box 885, and clips content at 885).
+test('subtracts only the gutter when the body also has a border', () => {
+  mockViewport({
+    htmlClientWidth: 900,
+    htmlClientHeight: 600,
+    htmlBCRLeft: 0,
+    htmlBCRWidth: 885,
+    htmlScrollLeft: 0,
+    bodyClientWidth: 875,
+    visualViewportWidth: 900,
+  });
+  html.style.scrollbarGutter = 'stable';
+
+  const rect = getViewportRect(html, 'absolute');
+
+  expect(rect.x).toBe(0);
+  expect(rect.width).toBe(885);
+});
+
+// A narrower <html> border box on its own is not a gutter: `html { margin-right }`
+// produces the same measurement and reserves nothing.
+test('does not subtract a narrower <html> box without a declared gutter', () => {
+  mockViewport({
+    htmlClientWidth: 900,
+    htmlClientHeight: 600,
+    htmlBCRLeft: 0,
+    htmlBCRWidth: 890, // e.g. `html { margin-right: 10px }`
+    htmlScrollLeft: 0,
+    visualViewportWidth: 900,
+  });
+
+  const rect = getViewportRect(html, 'absolute');
+
+  expect(rect.x).toBe(0);
+  expect(rect.width).toBe(900);
+});
+
+// An <html> box wider than the viewport (`html { width }`, a scale transform)
+// measures as negative reserved space, which must never widen the boundary.
+test('ignores a negative reserved width', () => {
+  mockViewport({
+    htmlClientWidth: 900,
+    htmlClientHeight: 600,
+    htmlBCRLeft: 0,
+    htmlBCRWidth: 910,
+    htmlScrollLeft: 0,
+    visualViewportWidth: 900,
+  });
+  html.style.scrollbarGutter = 'stable';
 
   const rect = getViewportRect(html, 'absolute');
 
@@ -135,24 +194,27 @@ test('caps an implausibly large reserved width', () => {
 });
 
 // `scrollbar-gutter: stable both-edges` reserves a gutter on each inline edge,
-// which shifts the <html> origin right by the inline-start one (measured in
-// Chrome: a 900px viewport reports border box left 15, width 870). That shift
-// is compensated by `getHTMLOffset`, so the width is left alone here.
-test('leaves a shifted <html> origin to getHTMLOffset', () => {
+// which shifts the <html> origin right by the inline-start one. That shift
+// makes `windowScrollbarX` positive, so this case falls out of the gutter
+// branch and is left uncorrected. Pins the current (incorrect) result: measured
+// in Chrome, a 900px viewport with no scrollbar reports clientWidth 900,
+// visualViewport.width 900, and border box left 15 width 870, and content is
+// clipped to [15, 885] — so the correct boundary is `{x: 15, width: 870}`.
+test('leaves both-edges uncorrected (known: one gutter too wide per edge)', () => {
   mockViewport({
     htmlClientWidth: 900,
     htmlClientHeight: 600,
     htmlBCRLeft: 15,
     htmlBCRWidth: 870,
     htmlScrollLeft: 0,
-    visualViewportWidth: 885,
+    visualViewportWidth: 900,
   });
   html.style.scrollbarGutter = 'stable both-edges';
 
   const rect = getViewportRect(html, 'absolute');
 
   expect(rect.x).toBe(0);
-  expect(rect.width).toBe(885);
+  expect(rect.width).toBe(900);
 });
 
 // A left-side scrollbar (e.g. Firefox `layout.scrollbar.side`) shifts the

--- a/packages/dom/test/unit/getViewportRect.test.ts
+++ b/packages/dom/test/unit/getViewportRect.test.ts
@@ -73,6 +73,7 @@ function mockViewport({
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  delete (document.body as any).currentCSSZoom;
   html.style.scrollbarGutter = '';
   mocks.isWebKit = false;
 });
@@ -97,6 +98,29 @@ test('subtracts a right-side reserved gutter from the width', () => {
 
   expect(rect.x).toBe(0);
   expect(rect.width).toBe(885);
+});
+
+test('caps a zoomed reserved gutter in CSS pixels', () => {
+  mockViewport({
+    htmlClientWidth: 900,
+    htmlClientHeight: 600,
+    htmlBCRLeft: 0,
+    htmlBCRWidth: 870, // 15 CSS px painted at `zoom: 2`
+    htmlScrollLeft: 0,
+    visualViewportWidth: 900,
+  });
+  // The body's currentCSSZoom is cumulative, including both <html> and <body>
+  // zoom, and matches the scale Chrome applies to the root gutter.
+  Object.defineProperty(document.body, 'currentCSSZoom', {
+    configurable: true,
+    value: 2,
+  });
+  html.style.scrollbarGutter = 'stable';
+
+  const rect = getViewportRect(html, 'absolute');
+
+  expect(rect.x).toBe(0);
+  expect(rect.width).toBe(870);
 });
 
 // In quirks mode, the viewport `clientWidth` special case moves from <html> to


### PR DESCRIPTION
### The bug

`getViewportRect` infers the space reserved by `scrollbar-gutter: stable` from how much narrower `<body>`'s padding box is than `<html>`'s content box:

```js
const reservedWidth = Math.abs(html.clientWidth - body.clientWidth - bodyMarginInline);
```

An ordinary `border` or `width` on `<body>`, or `padding` on `<html>`, produces exactly the same measurement. The check that a gutter is actually declared is only used to decide whether to halve the result, so on any such page the viewport boundary silently loses up to `SCROLLBAR_MAX` (25) px off its right edge — no `scrollbar-gutter` anywhere in the page.

Measured in Chrome 148 at a 900×600 viewport, reading the boundary back through `detectOverflow({boundary: [], rootBoundary: 'viewport'})`. "truth" is the width of a `position: fixed` element with `left: 0; right: 0`:

| page CSS (no `scrollbar-gutter`) | truth | v1.8.0 | this PR |
| --- | --- | --- | --- |
| default `<body>` | 900 | 900 | 900 |
| `body { border: 5px solid }` | 900 | **890** | 900 |
| `body { border: 1px solid }` | 900 | **898** | 900 |
| `html { padding: 10px }` | 900 | **880** | 900 |
| `body { margin: 0; width: calc(100% - 20px) }` | 900 | **880** | 900 |
| `body { margin: 0; border-inline: 8px solid }` | 900 | **884** | 900 |

Everything downstream of the viewport boundary inherits the error: `shift()` stops ~10–25px early, `flip()` sees the preferred side as overflowing when it doesn't, and `size()` hands `apply` an `availableWidth` that is short by the same amount.

The same measurement is also wrong in the direction it was written for, because a body border adds to the gutter it is trying to measure:

| page CSS | truth | v1.8.0 | this PR |
| --- | --- | --- | --- |
| `html { scrollbar-gutter: stable }` | 885 | 885 | 885 |
| `html { scrollbar-gutter: stable }` + `overflow-y: hidden` (the #3386 case) | 885 | 885 | 885 |
| `html { scrollbar-gutter: stable }` + `body { margin: 0 }` | 885 | 885 | 885 |
| `html { scrollbar-gutter: stable }` + `body { border: 5px solid }` | 885 | **875** | 885 |

### The fix

A stable gutter shrinks the `<html>` **border box** while leaving `documentElement.clientWidth` at the full viewport width — that difference is the reserved space, and it is 0 for every body/html box style above. So measure it there, and only when a gutter is actually declared:

```js
if (windowScrollbarX <= 0 && scrollbarGutter && scrollbarGutter !== 'auto') {
  const reservedWidth = html.clientWidth - html.getBoundingClientRect().width;
  ...
}
```

Chrome, 900px viewport, classic scrollbars forced with `::-webkit-scrollbar`:

| `scrollbar-gutter` | `clientWidth` | border box | truth |
| --- | --- | --- | --- |
| `auto` | 900 | 900 | 900 |
| `stable` | 900 | 885 | 885 |
| `stable both-edges` | 900 | 870 (left 15) | 870 |

The `SCROLLBAR_MAX` cap is kept as a safety net, and `<body>` is no longer read at all, so the `compatMode`/margin parsing and one of the two `getComputedStyle` calls go away.

Two small things that came along with it:

- `getComputedStyle` is now the `@floating-ui/utils/dom` helper rather than the bare global, matching the rest of the codebase — it resolves through the element's own window, which matters when the document is in an iframe.
- The `stable both-edges` branch added in `ad0a73f` never ran in a browser: `both-edges` shifts the `<html>` origin right by the inline-start gutter, so `getWindowScrollBarX(html)` is `15`, not `0`, and the enclosing `windowScrollbarX <= 0` guard bails first.

  ```
  scrollbar-gutter: auto               -> getWindowScrollBarX = 0   (block runs)
  scrollbar-gutter: stable             -> getWindowScrollBarX = 0   (block runs)
  scrollbar-gutter: stable both-edges  -> getWindowScrollBarX = 15  (block skipped)
  ```

  It was only reachable from the unit test, which mocked `htmlBCRLeft: 0` together with `scrollbarGutter: 'stable both-edges'` — a geometry the browser never produces. **I have deliberately not changed `both-edges` behaviour here**: making it correct means moving the origin as well as the width (`x` should become 15 in the example above), and that interacts with the left-side-scrollbar path that `windowScrollbarX > 0` exists for, which I can't reproduce in Chromium (it keeps the root scrollbar on the right even in RTL). It is unchanged and still under-reports; happy to follow up separately if you want it fixed.

### Tests

`packages/dom/test/unit/getViewportRect.test.ts`:

- The harness mocked `html.getBoundingClientRect().width` as always equal to `html.clientWidth`, which is the one thing a reserved gutter changes, so the gutter had to be modelled through `body.clientWidth`. `htmlBCRWidth` is now a separate input and the gutter tests use the geometry measured in Chrome above.
- **`does not treat body box styles as a reserved gutter`** is the regression test: a body 26px narrower than `<html>` (`body { border: 5px solid }`) with no `scrollbar-gutter` must not shrink the boundary.
- The two `both-edges` tests are replaced by one that pins the real geometry (origin shifted, width left to `getHTMLOffset`).
- The left-side-scrollbar test and the `isWebKit × strategy × rootBoundary` matrix are unchanged.

The three rewritten/added gutter tests fail against unpatched `src` (884 vs 885, 890 vs 900, 784 vs 800) and pass with the fix.

### Verification

- `pnpm test` — 7/7 packages green (`@floating-ui/dom` 18 passed, `@floating-ui/react` 286 passed).
- `pnpm typecheck` — 9/9 green. `eslint` and `prettier --check` clean.
- Functional tests green in CI, so the committed `-linux` snapshots are unaffected. I couldn't run that suite locally (macOS), so before pushing I drove `/layout-viewport` and `/viewport-boundary` in Chromium instead and recorded the floating elements' rects across every control on those pages (`rootboundary-*`, `gutter`, `rtl`, `scroll-lock`, `strategy-*`, `boundary-*`) with and without the patch — byte-identical. Both pages use `body { margin: 0 }` with no inline box styles, where the old and new measurements coincide (the `stable + body margin 0` row above).
- The red Netlify check is unrelated: `getStaticProps` in `website/pages/index.js` fetches `https://opencollective.com/floating-ui/members/all.json`, which is currently returning 503 with an HTML body — `SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON`. `next build` fails the same way on `master`.
