### PR TITLE
fix(react): synchronously redirect modal focus guards

### DIFF
--- a/.changeset/synchronous-focus-guards.md
+++ b/.changeset/synchronous-focus-guards.md
@@ -1,0 +1,5 @@
+---
+'@floating-ui/react': patch
+---
+
+fix(FloatingFocusManager): redirect modal focus guards synchronously

--- a/packages/react/src/components/FloatingFocusManager.tsx
+++ b/packages/react/src/components/FloatingFocusManager.tsx
@@ -818,6 +818,7 @@ export function FloatingFocusManager(
               const els = getTabbableElements();
               enqueueFocus(
                 order[0] === 'reference' ? els[0] : els[els.length - 1],
+                {sync: true},
               );
             } else if (
               portalContext?.preserveTabOrder &&
@@ -847,7 +848,7 @@ export function FloatingFocusManager(
           ref={mergedAfterGuardRef}
           onFocus={(event) => {
             if (modal) {
-              enqueueFocus(getTabbableElements()[0]);
+              enqueueFocus(getTabbableElements()[0], {sync: true});
             } else if (
               portalContext?.preserveTabOrder &&
               portalContext.portalNode

--- a/packages/react/test/unit/FloatingFocusManager.test.tsx
+++ b/packages/react/test/unit/FloatingFocusManager.test.tsx
@@ -9,7 +9,7 @@ import {
   within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {test} from 'vitest';
+import {test, vi} from 'vitest';
 import {cloneElement, useRef, useState} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Context as ResponsiveContext} from 'react-responsive';
@@ -527,6 +527,30 @@ describe('guards', () => {
     await userEvent.tab();
 
     expect(document.body).not.toHaveFocus();
+  });
+
+  test('redirect focus synchronously', async () => {
+    render(<App guards={true} />);
+
+    fireEvent.click(screen.getByTestId('reference'));
+    await act(async () => {});
+
+    const guards = document.querySelectorAll<HTMLElement>(
+      '[data-floating-ui-focus-guard]',
+    );
+
+    const requestAnimationFrame = vi.mocked(window.requestAnimationFrame);
+    const implementation = requestAnimationFrame.getMockImplementation()!;
+
+    requestAnimationFrame.mockImplementation(() => 1);
+    guards[1].focus();
+    requestAnimationFrame.mockImplementation(implementation);
+    expect(screen.getByTestId('one')).toHaveFocus();
+
+    requestAnimationFrame.mockImplementation(() => 1);
+    guards[0].focus();
+    requestAnimationFrame.mockImplementation(implementation);
+    expect(screen.getByTestId('three')).toHaveFocus();
   });
 
   test.skipIf(!isJSDOM())('false', async () => {


### PR DESCRIPTION
## Summary

- redirect modal focus guards synchronously instead of waiting for `requestAnimationFrame`
- prevent fast or synthetic Tab sequences from briefly moving focus outside the modal
- add regression coverage for both focus guards

Fixes #3498.

## Testing

- `pnpm --filter @floating-ui/react exec vitest run test/unit/FloatingFocusManager.test.tsx`
- `pnpm --filter @floating-ui/react typecheck`
