### PR TITLE
fix(react): handle IME composed input and ignore composing keydowns in useTypeahead

### DIFF
--- a/packages/react/src/hooks/useTypeahead.ts
+++ b/packages/react/src/hooks/useTypeahead.ts
@@ -157,6 +157,8 @@ export function useTypeahead(
     }
 
     if (
+      event.nativeEvent.isComposing ||
+      event.key === 'Process' ||
       listContent == null ||
       ignoreKeysRef.current.includes(event.key) ||
       // Character key.
@@ -217,21 +219,76 @@ export function useTypeahead(
     }
   });
 
+  const onCompositionEnd = useEffectEvent((event: React.CompositionEvent) => {
+    const listContent = listRef.current;
+    if (listContent == null || !event.data) {
+      return;
+    }
+
+    function getMatchingIndex(
+      list: Array<string | null>,
+      orderedList: Array<string | null>,
+      string: string,
+    ) {
+      const str = findMatchRef.current
+        ? findMatchRef.current(orderedList, string)
+        : orderedList.find(
+            (text) =>
+              text?.toLocaleLowerCase().indexOf(string.toLocaleLowerCase()) ===
+              0,
+          );
+
+      return str ? list.indexOf(str) : -1;
+    }
+
+    if (open) {
+      setTypingChange(true);
+    }
+
+    stringRef.current += event.data;
+    clearTimeoutIfSet(timeoutIdRef);
+    timeoutIdRef.current = window.setTimeout(() => {
+      stringRef.current = '';
+      prevIndexRef.current = matchIndexRef.current;
+      setTypingChange(false);
+    }, resetMs);
+
+    const prevIndex = prevIndexRef.current;
+
+    const index = getMatchingIndex(
+      listContent,
+      [
+        ...listContent.slice((prevIndex || 0) + 1),
+        ...listContent.slice(0, (prevIndex || 0) + 1),
+      ],
+      stringRef.current,
+    );
+
+    if (index !== -1) {
+      onMatch(index);
+      matchIndexRef.current = index;
+    } else {
+      stringRef.current = '';
+      setTypingChange(false);
+    }
+  });
+
   const reference: ElementProps['reference'] = React.useMemo(
-    () => ({onKeyDown}),
-    [onKeyDown],
+    () => ({onKeyDown, onCompositionEnd}),
+    [onKeyDown, onCompositionEnd],
   );
 
   const floating: ElementProps['floating'] = React.useMemo(() => {
     return {
       onKeyDown,
+      onCompositionEnd,
       onKeyUp(event) {
         if (event.key === ' ') {
           setTypingChange(false);
         }
       },
     };
-  }, [onKeyDown, setTypingChange]);
+  }, [onKeyDown, onCompositionEnd, setTypingChange]);
 
   return React.useMemo(
     () => (enabled ? {reference, floating} : {}),

--- a/packages/react/test/unit/useTypeahead.test.tsx
+++ b/packages/react/test/unit/useTypeahead.test.tsx
@@ -1,4 +1,4 @@
-import {act, cleanup, render, screen} from '@testing-library/react';
+import {act, cleanup, fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {useRef, useState} from 'react';
 import {vi} from 'vitest';
@@ -12,7 +12,7 @@ vi.useFakeTimers({shouldAdvanceTime: true});
 const useImpl = ({
   addUseClick = false,
   ...props
-}: Pick<UseTypeaheadProps, 'onMatch' | 'onTypingChange'> & {
+}: Pick<UseTypeaheadProps, 'onMatch' | 'onTypingChange' | 'findMatch'> & {
   list?: Array<string>;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -33,6 +33,7 @@ const useImpl = ({
       props.onMatch?.(index);
     },
     onTypingChange: props.onTypingChange,
+    findMatch: props.findMatch,
   });
   const click = useClick(context, {
     enabled: addUseClick,
@@ -61,7 +62,7 @@ const useImpl = ({
 };
 
 function Combobox(
-  props: Pick<UseTypeaheadProps, 'onMatch' | 'onTypingChange'> & {
+  props: Pick<UseTypeaheadProps, 'onMatch' | 'onTypingChange' | 'findMatch'> & {
     list?: Array<string>;
   },
 ) {
@@ -334,4 +335,39 @@ test('typing spaces on <div> references does not open the menu', async () => {
   await act(async () => {});
 
   expect(screen.queryByRole('listbox')).toBeInTheDocument();
+});
+
+test('handles composed input correctly via compositionend and ignores composing keydowns', async () => {
+  const spy = vi.fn();
+  const findMatchSpy = vi.fn(
+    (list: Array<string | null>, typedString: string) => {
+      return list.find((item) => item?.startsWith(typedString));
+    },
+  );
+
+  render(
+    <Combobox
+      onMatch={spy}
+      list={['apple', 'banana', '가을', '겨울']}
+      findMatch={findMatchSpy}
+    />,
+  );
+
+  const input = screen.getByRole('combobox');
+  input.focus();
+
+  // Simulating composing keystroke (isComposing: true)
+  act(() => {
+    fireEvent.keyDown(input, {key: 'r', isComposing: true});
+  });
+  expect(spy).not.toHaveBeenCalled();
+
+  // Simulating compositionend event with composed character '가'
+  act(() => {
+    fireEvent.compositionEnd(input, {data: '가'});
+  });
+  expect(spy).toHaveBeenCalledWith(2);
+  expect(findMatchSpy).toHaveBeenCalledWith(expect.any(Array), '가');
+
+  cleanup();
 });


### PR DESCRIPTION
## Problem

When typing in an IME language (such as Korean, Japanese, or Chinese), `useTypeahead` captures individual intermediate composing `keydown` events (where `event.nativeEvent.isComposing` is true). This cancels composition prematurely, splits composed syllables, and passes raw keystrokes to `findMatch` instead of the fully composed characters.

## Root Cause

- `onKeyDown` in `useTypeahead` did not check `event.nativeEvent.isComposing` or `event.key === 'Process'`, causing it to intercept composing keystrokes and call `stopEvent(event)`.
- `useTypeahead` lacked an `onCompositionEnd` event handler on reference and floating elements to process the committed composed characters from `event.data`.

## Fix

- Updated `onKeyDown` in `useTypeahead` to early-return when `event.nativeEvent.isComposing` or `event.key === 'Process'` is true.
- Added `onCompositionEnd` handler to `reference` and `floating` element props to update `stringRef` and trigger matching using `event.data`.

## Testing

- Added unit test in `packages/react/test/unit/useTypeahead.test.tsx` verifying that composing `keydown` events are ignored and `compositionend` events properly trigger matching with the composed string.
- Verified all existing typeahead tests pass cleanly.